### PR TITLE
Add portmaster to Jelos tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Like any Linux distribution, this project is not the work of one person.  It is 
   * Those platforms perform best in Android on the 552, and I have no interest in them.  I recommend that you use Android instead for those.
 * Will you support my device?
   * If you send me a device and source code, I'll consider it.
+* I'm using brand-y microSD and after flashing it partitions, reboots, and hangs.
+  * When this happens the indicator is a short vibration like it's restarting normally but the power LED does not turn on.  Press reset, and it will continue normally.
 * How can I disable root password rotation?
   * SSH to the handheld and run the following commands.
     * ```set_setting rotate.root.password 0```

--- a/packages/games/tools/portmaster/package.mk
+++ b/packages/games/tools/portmaster/package.mk
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
+# Maintenance 2022-present BrooksyTech (https://github.com/brooksytech)
+
+PKG_NAME="portmaster"
+PKG_VERSION="1.0"
+PKG_ARCH="any"
+PKG_URL="https://github.com/christianhaitian/PortMaster/raw/main/PortMaster.zip"
+PKG_PRIORITY="optional"
+PKG_SECTION="tools"
+PKG_SHORTDESC="A simple tool that allows you to download various game ports that are available for Jelos"
+PKG_TOOLCHAIN="manual"
+
+pre_unpack() {
+  unzip sources/portmaster/portmaster-1.0.zip -d $PKG_BUILD
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/share/
+  cp -r $PKG_BUILD/PortMaster $INSTALL/usr/share/
+}

--- a/packages/jelos/package.mk
+++ b/packages/jelos/package.mk
@@ -41,7 +41,7 @@ PKG_COMPAT="lib32"
 PKG_MULTIMEDIA="ffmpeg mpv vlc"
 
 PKG_GAMESUPPORT="sixaxis jslisten evtest rg351p-js2xbox gptokeyb textviewer 351files jstest-sdl \
-                 gamecontrollerdb"
+                 gamecontrollerdb portmaster"
 
 PKG_EXPERIMENTAL=""
 

--- a/packages/jelos/sources/autostart/common/011-portmaster
+++ b/packages/jelos/sources/autostart/common/011-portmaster
@@ -1,0 +1,40 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
+# Maintenance 2022-present BrooksyTech (https://github.com/brooksytech)
+
+#If PortMaster does not exist copy PortMaster folder to roms/ports
+if [ ! -e "/storage/roms/ports/PortMaster" ]
+then
+	cp -r /usr/share/PortMaster /storage/roms/ports
+	chmod +x /storage/roms/ports/PortMaster -R
+	mv /storage/roms/ports/PortMaster/PortMaster.sh /storage/roms/ports/PortMaster.sh
+fi
+
+#Check if gamelist.xml exists, if not create gamelist.xml to hide portmaster by default.
+if [[ ! -e /storage/roms/ports/gamelist.xml ]];
+then
+touch /storage/roms/ports/gamelist.xml
+ cat > /storage/roms/ports/gamelist.xml <<EOF
+<?xml version="1.0"?>
+<gameList>
+	<game>
+		<path>/storage/roms/ports/PortMaster.sh</path>
+		<name>PortMaster</name>
+		<hidden>true</hidden>
+	</game>
+</gameList>
+EOF
+
+#If gamelist.xml exists and no portmaster entry exists then add portmaster entry & set to hidden.
+else
+if ! grep -R "PortMaster" "/storage/roms/ports/gamelist.xml"
+then
+sed -i 's|<gameList>|&   \
+	<game>\
+		<path>/storage/roms/ports/PortMaster.sh</path>\
+		<name>PortMaster</name>\
+		<hidden>true</hidden>\
+	</game>|' /storage/roms/ports/gamelist.xml
+	fi
+fi

--- a/packages/misc/modules/sources/PortMaster.sh
+++ b/packages/misc/modules/sources/PortMaster.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2020-present Fewtarius
+# Maintenance 2022-present BrooksyTech (https://github.com/brooksytech)
+
+/storage/roms/ports/PortMaster.sh

--- a/packages/misc/modules/sources/gamelist.xml
+++ b/packages/misc/modules/sources/gamelist.xml
@@ -78,5 +78,16 @@
 		<thumbnail>./downloaded_images/filemanager-thumb.png</thumbnail>
 		<image>./downloaded_images/filemanager.png</image>
 	</game>
+	
+	<game>
+		<path>/storage/roms/ports/PortMaster.sh</path>
+		<name>PortMaster</name>
+		<desc>Game port installer</desc>
+		<developer>christianhaitian</developer>
+		<publisher>Jelos</publisher>
+		<rating>1.0</rating>
+		<releasedate>2021</releasedate>
+		<genre>Script</genre>
+	</game>
 
 </gameList>


### PR DESCRIPTION
This adds portmaster to Jelos by default. I have configured it show in the tools category even though it is installed at /storage/roms/ports/PortMaster directory. 

The reason I chose to do it this way so that in the future if any new updates get released to portmaster the end user should be able to install the update themselves. 

This will also create the gamelist.xml in roms/ports to auto hide portmaster from showing there. If the gamelist.xml exists and no portmaster entry is there it will create that missing entry.

However if a user already has installed portmaster and the entry exists in gamelist.xml then portmaster WILL NOT BE HIDDEN in roms/ports. I thought this issue over and tried a few hacks but could not come up with a working solution that I felt comfortable with Please add your own if you have a better way. 

