### PR TITLE
Change to L1 and R1 to scroll through game lists.

### DIFF
--- a/packages/ui/emulationstation/config/es_input.cfg
+++ b/packages/ui/emulationstation/config/es_input.cfg
@@ -72,16 +72,16 @@
 		<input name="leftanalogright" type="axis" id="0" value="1" />
 		<input name="leftanalogup" type="axis" id="1" value="-1" />
 		<input name="leftanalogdown" type="axis" id="1" value="1" />
-		<input name="leftshoulder" type="button" id="4" value="1" />
+		<input name="leftshoulder" type="button" id="6" value="1" />
 		<input name="leftthumb" type="button" id="11" value="1" />
-		<input name="lefttrigger" type="button" id="6" value="1" />
+		<input name="lefttrigger" type="button" id="4" value="1" />
 		<input name="rightanalogleft" type="axis" id="2" value="-1" />
 		<input name="rightanalogright" type="axis" id="2" value="1" />
 		<input name="rightanalogup" type="axis" id="3" value="-1" />
 		<input name="rightanalogdown" type="axis" id="3" value="1" />
-		<input name="rightshoulder" type="button" id="5" value="1" />
+		<input name="rightshoulder" type="button" id="7" value="1" />
 		<input name="rightthumb" type="button" id="12" value="1" />
-		<input name="righttrigger" type="button" id="7" value="1" />
+		<input name="righttrigger" type="button" id="5" value="1" />
 		<input name="select" type="button" id="8" value="1" />
 		<input name="start" type="button" id="9" value="1" />
 		<input name="x" type="button" id="2" value="1" />


### PR DESCRIPTION
Currently L2 and R2 are the defaults for scrolling through game lists.

This will be more comfortable on the RG552.
