### PR TITLE
Adding back Duckstation libretro, build from source. 

### DIFF
--- a/packages/games/libretro/duckstation/package.mk
+++ b/packages/games/libretro/duckstation/package.mk
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
+# Maintenance 2022-present BrooksyTech (https://github.com/brooksytech)
+
+PKG_NAME="duckstation"
+PKG_VERSION="fa005db2e6c997afe8fc3af8de94953247232c2d"
+PKG_ARCH="aarch64"
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://github.com/brooksytech/duckstation-libretro"
+PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SECTION="libretro"
+PKG_SHORTDESC="DuckStation - PlayStation 1, aka. PSX Emulator"
+PKG_TOOLCHAIN="cmake"
+PKG_BUILD_FLAGS="-lto"
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/lib/libretro
+  cp $PKG_BUILD/.$TARGET_NAME/duckstation_libretro.so $INSTALL/usr/lib/libretro/
+}

--- a/packages/jelos/package.mk
+++ b/packages/jelos/package.mk
@@ -24,8 +24,8 @@ PKG_EMUS="common-shaders glsl-shaders libretro-database retroarch advancemame ha
           scummvmsa PPSSPPSDL"
 
 LIBRETRO_CORES="2048 81 atari800 beetle-gba beetle-lynx beetle-ngp beetle-pce beetle-pcfx            \
-                beetle-supafaust beetle-supergrafx beetle-vb beetle-wswan bluemsx                    \
-                cannonball cap32 crocods daphne dinothawr dosbox-svn dosbox-pure easyrpg fbalpha2012 \
+                beetle-supafaust beetle-supergrafx beetle-vb beetle-wswan bluemsx cannonball cap32   \
+                crocods daphne dinothawr dosbox-svn dosbox-pure duckstation easyrpg fbalpha2012      \
                 fbalpha2019 fbneo fceumm fmsx flycast freechaf freeintv freej2me fuse-libretro       \
                 gambatte gearboy gearcoleco gearsystem genesis-plus-gx genesis-plus-gx-wide gme      \
                 gpsp gw-libretro handy hatari mame2000 mame2003-plus mame2010 mame2015 mame          \

--- a/packages/ui/emulationstation/config/es_systems.cfg
+++ b/packages/ui/emulationstation/config/es_systems.cfg
@@ -1294,6 +1294,7 @@
         <cores>
           <core default="true">pcsx_rearmed</core>
           <core>swanstation</core>
+          <core>duckstation</core>
         </cores>
       </emulator>
     </emulators>


### PR DESCRIPTION
## Description

Duckstation was removed due to the libretro zip no longer being available. I forked the Duckstation repo and reset the head to the last commit before duckstation libretro was removed. 