### PR TITLE
Duckstation cache folder fix and other cleanup.

### DIFF
--- a/packages/games/libretro/duckstation/package.mk
+++ b/packages/games/libretro/duckstation/package.mk
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
-# Maintenance 2022-present BrooksyTech (https://github.com/brooksytech)
+# Copyright (C) 2022-present BrooksyTech (https://github.com/brooksytech)
 
 PKG_NAME="duckstation"
-PKG_VERSION="fa005db2e6c997afe8fc3af8de94953247232c2d"
+PKG_VERSION="0162b33835e09984ab9dca6f0b1295343e2dcbc3"
 PKG_ARCH="aarch64"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/brooksytech/duckstation-libretro"

--- a/packages/games/tools/portmaster/package.mk
+++ b/packages/games/tools/portmaster/package.mk
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
-# Maintenance 2022-present BrooksyTech (https://github.com/brooksytech)
+# Copyright (C) 2022-present BrooksyTech (https://github.com/brooksytech)
 
 PKG_NAME="portmaster"
 PKG_VERSION="1.0"

--- a/packages/jelos/sources/autostart/common/011-portmaster
+++ b/packages/jelos/sources/autostart/common/011-portmaster
@@ -1,7 +1,7 @@
 #!/bin/sh
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
-# Maintenance 2022-present BrooksyTech (https://github.com/brooksytech)
+# Copyright (C) 2022-present BrooksyTech (https://github.com/brooksytech)
 
 #If PortMaster does not exist copy PortMaster folder to roms/ports
 if [ ! -e "/storage/roms/ports/PortMaster" ]


### PR DESCRIPTION
Updated duckstation libretro to create cache folder as .duckstation_cache so it would not show up in emulation station menu.

Also a few cleanup items, 