### PR TITLE
Add Glide64 Parallel 64 core and set as the default. 

### DIFF
--- a/packages/games/libretro/parallel-n64_glide64/package.mk
+++ b/packages/games/libretro/parallel-n64_glide64/package.mk
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
+
+PKG_NAME="parallel-n64_glide64"
+PKG_VERSION="28c4572c9a09447b3bf5ed5fbd3594a558bc210d"
+PKG_SHA256="03ebfd3b27f8d6d2846d180c2dba6ae5dd36f1f1ebea79db8c41817525ce38d2"
+PKG_REV="2"
+PKG_LICENSE="GPLv2"
+PKG_SITE="https://github.com/libretro/parallel-n64"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain ${OPENGLES} core-info"
+PKG_SECTION="libretro"
+PKG_SHORTDESC="Optimized/rewritten Nintendo 64 emulator made specifically for Libretro. Originally based on Mupen64 Plus."
+PKG_LONGDESC="Optimized/rewritten Nintendo 64 emulator made specifically for Libretro. Originally based on Mupen64 Plus."
+PKG_TOOLCHAIN="make"
+PKG_BUILD_FLAGS="-lto"
+PKG_PATCH_DIRS+="${DEVICE}"
+
+if [ "${ARCH}" = "arm" ]
+then
+  PKG_MAKE_OPTS_TARGET=" platform=rg552"
+else
+  make_target() {
+    :
+  }
+fi
+
+pre_configure_target() {
+  sed -i 's/info->library_name = "ParaLLEl N64";/info->library_name = "ParaLLEl N64 Glide64";/g' ${PKG_BUILD}/libretro/libretro.c
+  sed -i 's/"GFX Plugin; auto|glide64|gln64|rice/"GFX Plugin; glide64|auto|gln64|rice/g' ${PKG_BUILD}/libretro/libretro.c
+  sed -i 's/"Resolution (restart); 320x240|640x480|960x720/"Resolution (restart); 640x480|320x240|960x720/g' ${PKG_BUILD}/libretro/libretro.c
+  sed -i 's/"Framerate (restart); original|fullspeed"/"Framerate (restart); fullspeed|original"/g' ${PKG_BUILD}/libretro/libretro.c
+  sed -i 's/"GFX Accuracy (restart); veryhigh|high|medium|low"/"GFX Accuracy (restart); low|veryhigh|high|medium"/g' ${PKG_BUILD}/libretro/libretro.c
+  sed -i 's/"(Glide64) Texture Filtering; automatic|N64 3-point|bilinear|nearest"/"(Glide64) Texture Filtering; nearest|automatic|N64 3-point|bilinear"/g' ${PKG_BUILD}/libretro/libretro.c
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+  if [[ "${DEVICE}" =~ RG552 ]] && [[ "${ARCH}" == "aarch64" ]]
+  then
+    cp -vP ${PKG_BUILD}/../../build.${DISTRO}-${DEVICE}.arm/parallel-n64_glide64-*/.install_pkg/usr/lib/libretro/parallel_n64_glide64_libretro.so ${INSTALL}/usr/lib/libretro/parallel_n64_glide64_libretro.so
+    cp -vP ${PKG_BUILD}/../core-info-*/parallel_n64_libretro.info ${INSTALL}/usr/lib/libretro/parallel_n64_glide64_libretro.info
+    sed -i 's/ParaLLEl N64/ParaLLEl N64 Glide64/g' ${INSTALL}/usr/lib/libretro/parallel_n64_glide64_libretro.info
+  else
+    cp parallel_n64_libretro.so ${INSTALL}/usr/lib/libretro/parallel_n64_glide64_libretro.so
+  fi
+}

--- a/packages/games/libretro/parallel-n64_glide64/patches/arm/01-gcc-10.patch
+++ b/packages/games/libretro/parallel-n64_glide64/patches/arm/01-gcc-10.patch
@@ -1,0 +1,11 @@
+diff -rupN parallel-n64.orig/mupen64plus-core/src/r4300/r4300.c parallel-n64.new/mupen64plus-core/src/r4300/r4300.c
+--- parallel-n64.orig/mupen64plus-core/src/r4300/r4300.c	2021-01-24 13:07:25.028974337 -0500
++++ parallel-n64.new/mupen64plus-core/src/r4300/r4300.c	2021-01-24 13:07:53.761102557 -0500
+@@ -50,7 +50,6 @@
+ unsigned int r4300emu = 0;
+ unsigned int count_per_op = COUNT_PER_OP_DEFAULT;
+ unsigned int llbit;
+-int stop;
+ #if NEW_DYNAREC < NEW_DYNAREC_ARM
+ int64_t reg[32], hi, lo;
+ uint32_t next_interrupt;

--- a/packages/games/libretro/parallel-n64_glide64/patches/arm/parallel-n64-add_platform.patch
+++ b/packages/games/libretro/parallel-n64_glide64/patches/arm/parallel-n64-add_platform.patch
@@ -1,0 +1,27 @@
+diff -rupN parallel-n64.orig/Makefile parallel-n64/Makefile
+--- parallel-n64.orig/Makefile	2022-03-18 18:45:20.583802218 -0400
++++ parallel-n64/Makefile	2022-03-18 19:17:21.695069121 -0400
+@@ -273,6 +273,23 @@ ifneq (,$(findstring unix,$(platform)))
+       PLATFORM_EXT := unix
+    endif
+ 
++#######################################
++# Anbernic RG552
++else ifneq (,$(findstring rg552,$(platform)))
++   TARGET := $(TARGET_NAME)_libretro.so
++   CPUFLAGS += -marm -mtune=cortex-a73.cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard
++   ASFLAGS += -D__ARM_NEON__ -marm -mtune=cortex-a35 -mfpu=neon-fp-armv8 -mfloat-abi=hard
++   LDFLAGS += -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T
++   fpic = -fPIC
++   GLES = 1
++   GL_LIB := -lGLESv2
++   HAVE_NEON = 1
++   WITH_DYNAREC=arm
++   ifneq (,$(findstring neon,$(platform)))
++      CPUFLAGS += -D__NEON_OPT -mfpu=neon
++      HAVE_NEON = 1
++   endif
++
+ # i.MX6
+ else ifneq (,$(findstring imx6,$(platform)))
+    TARGET := $(TARGET_NAME)_libretro.so

--- a/packages/jelos/package.mk
+++ b/packages/jelos/package.mk
@@ -30,9 +30,9 @@ LIBRETRO_CORES="2048 81 a5200 atari800 beetle-gba beetle-lynx beetle-ngp beetle-
                 crocods daphne dinothawr dosbox-svn dosbox-pure duckstation easyrpg fbalpha2012      \
                 fbalpha2019 fbneo fceumm fmsx flycast freechaf freeintv freej2me fuse-libretro       \
                 gambatte gearboy gearcoleco gearsystem genesis-plus-gx genesis-plus-gx-wide gme      \
-                gpsp gw-libretro handy hatari mame2000 mame2003-plus mame2010 mame2015 mame          \
-                meowpc98 mgba mrboom mupen64plus mupen64plus-nx neocd_libretro nestopia np2kai       \
-                nxengine o2em opera parallel-n64 parallel-n64_gln64 pcsx_rearmed picodrive           \
+                gpsp gw-libretro handy hatari mame2000 mame2003-plus mame2010 mame2015 mame meowpc98 \
+                mgba mrboom mupen64plus mupen64plus-nx neocd_libretro nestopia np2kai nxengine o2em  \
+                opera parallel-n64 parallel-n64_gln64 parallel-n64_glide64 pcsx_rearmed picodrive    \
                 pokemini potator ppsspp prboom prosystem puae px68k quasi88 quicknes race            \
                 reminiscence sameboy sameduck scummvm smsplus-gx snes9x snes9x2002 snes9x2005_plus   \
                 snes9x2010 stella stella-2014 swanstation TIC-80 tgbdual tyrquake xrick uae4arm      \

--- a/packages/jelos/sources/scripts/runemu.sh
+++ b/packages/jelos/sources/scripts/runemu.sh
@@ -311,7 +311,7 @@ else
 
 	### Check if we need retroarch 32 bits or 64 bits
 	RABIN="retroarch"
-	if [[ "${CORE}" =~ "pcsx_rearmed" ]] || [[ "${CORE}" =~ "parallel_n64" ]] || [[ "${CORE}" =~ "parallel_n64_gln64" ]]
+	if [[ "${CORE}" =~ "pcsx_rearmed" ]] || [[ "${CORE}" =~ "parallel_n64" ]] || [[ "${CORE}" =~ "parallel_n64_gln64" ]] || [[ "${CORE}" =~ "parallel_n64_glide64" ]]
 	then
 		export LD_LIBRARY_PATH="/usr/lib32"
 		RABIN="retroarch32"

--- a/packages/ui/emulationstation/config/es_systems.cfg
+++ b/packages/ui/emulationstation/config/es_systems.cfg
@@ -1089,7 +1089,8 @@
     <emulators>
       <emulator name="retroarch">
         <cores>
-          <core default="true">parallel_n64</core>
+          <core default="true">parallel_n64_glide64</core>
+          <core>parallel_n64</core>
           <core>parallel_n64_gln64</core>
           <core>mupen64plus</core>
           <core>mupen64plus_next</core>

--- a/packages/virtual/arm32/package.mk
+++ b/packages/virtual/arm32/package.mk
@@ -4,6 +4,6 @@
 PKG_NAME="arm32"
 PKG_LICENSE="GPL"
 PKG_SITE="www.jelos.org"
-PKG_DEPENDS_TARGET="toolchain squashfs-tools:host dosfstools:host fakeroot:host kmod:host mtools:host populatefs:host libc gcc linux linux-drivers linux-firmware libusb unzip socat p7zip file ${OPENGLES} SDL2 SDL2_gfx SDL2_image SDL2_mixer SDL2_net SDL2_ttf retroarch pcsx_rearmed parallel-n64 parallel-n64_gln64"
+PKG_DEPENDS_TARGET="toolchain squashfs-tools:host dosfstools:host fakeroot:host kmod:host mtools:host populatefs:host libc gcc linux linux-drivers linux-firmware libusb unzip socat p7zip file ${OPENGLES} SDL2 SDL2_gfx SDL2_image SDL2_mixer SDL2_net SDL2_ttf retroarch pcsx_rearmed parallel-n64 parallel-n64_gln64 parallel-n64_glide64"
 PKG_SECTION="virtual"
 PKG_LONGDESC="Root package used to build and create 32-bit userland"


### PR DESCRIPTION
This adds a new core for Parallel 64. Uses the Glide64 Package and sets it as the default N64 core. Seems to be the best all around core. 

Test on a current build forked from the dev branch. 