### PR TITLE
adding RK3399 optimization for the pcsx_rearmed core (32 bit NEON)

### DIFF
--- a/packages/games/libretro/pcsx_rearmed/package.mk
+++ b/packages/games/libretro/pcsx_rearmed/package.mk
@@ -17,7 +17,7 @@ PKG_PATCH_DIRS+="${DEVICE}"
 
 if [ "${ARCH}" = "arm" ]
 then
-  make -f Makefile.libretro GIT_VERSION=${PKG_VERSION} PKG_MAKE_OPTS_TARGET+=" platform=rg552"
+ make -f Makefile.libretro clean && make -f Makefile.libretro GIT_VERSION=${PKG_VERSION} PKG_MAKE_OPTS_TARGET+=" platform=rg552"
 else
   make_target() {
     :

--- a/packages/games/libretro/pcsx_rearmed/package.mk
+++ b/packages/games/libretro/pcsx_rearmed/package.mk
@@ -11,7 +11,7 @@ PKG_SITE="https://github.com/libretro/pcsx_rearmed"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SHORTDESC="ARM optimized PCSX fork"
-PKG_TOOLCHAIN="manual"
+PKG_TOOLCHAIN="make"
 PKG_BUILD_FLAGS="+speed -gold"
 PKG_PATCH_DIRS+="${DEVICE}"
 

--- a/packages/games/libretro/pcsx_rearmed/package.mk
+++ b/packages/games/libretro/pcsx_rearmed/package.mk
@@ -17,7 +17,7 @@ PKG_PATCH_DIRS+="${DEVICE}"
 
 if [ "${ARCH}" = "arm" ]
 then
-  make -f Makefile.libretro GIT_VERSION=${PKG_VERSION} platform=rg552
+  make -f Makefile.libretro GIT_VERSION=${PKG_VERSION} PKG_MAKE_OPTS_TARGET+=" platform=rg552"
 else
   make_target() {
     :

--- a/packages/games/libretro/pcsx_rearmed/package.mk
+++ b/packages/games/libretro/pcsx_rearmed/package.mk
@@ -11,7 +11,7 @@ PKG_SITE="https://github.com/libretro/pcsx_rearmed"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SHORTDESC="ARM optimized PCSX fork"
-PKG_TOOLCHAIN="make"
+PKG_TOOLCHAIN="manual"
 PKG_BUILD_FLAGS="+speed -gold"
 PKG_PATCH_DIRS+="${DEVICE}"
 

--- a/packages/games/libretro/pcsx_rearmed/package.mk
+++ b/packages/games/libretro/pcsx_rearmed/package.mk
@@ -11,16 +11,18 @@ PKG_SITE="https://github.com/libretro/pcsx_rearmed"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SHORTDESC="ARM optimized PCSX fork"
-PKG_TOOLCHAIN="manual"
+PKG_TOOLCHAIN="make"
 PKG_BUILD_FLAGS="+speed -gold"
 PKG_PATCH_DIRS+="${DEVICE}"
 
-make_target() {
-  cd ${PKG_BUILD}
-  if [ ! "${ARCH}" = "aarch64" ]; then
-    make -f Makefile.libretro GIT_VERSION=${PKG_VERSION} platform=rpi3
-  fi
-}
+if [ "${ARCH}" = "arm" ]
+then
+  PKG_MAKE_OPTS_TARGET=" platform=rg552"
+else
+  make_target() {
+    :
+  }
+fi
 
 makeinstall_target() {
   INSTALLTO="/usr/lib/libretro/"

--- a/packages/games/libretro/pcsx_rearmed/package.mk
+++ b/packages/games/libretro/pcsx_rearmed/package.mk
@@ -11,13 +11,13 @@ PKG_SITE="https://github.com/libretro/pcsx_rearmed"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SHORTDESC="ARM optimized PCSX fork"
-PKG_TOOLCHAIN="make"
+PKG_TOOLCHAIN="manual"
 PKG_BUILD_FLAGS="+speed -gold"
 PKG_PATCH_DIRS+="${DEVICE}"
 
 if [ "${ARCH}" = "arm" ]
 then
-  PKG_MAKE_OPTS_TARGET=" platform=rg552"
+  make -f Makefile.libretro GIT_VERSION=${PKG_VERSION} platform=rg552
 else
   make_target() {
     :

--- a/packages/games/libretro/pcsx_rearmed/patches/arm/pcsx_rearmed-add_platform.patch
+++ b/packages/games/libretro/pcsx_rearmed/patches/arm/pcsx_rearmed-add_platform.patch
@@ -1,0 +1,24 @@
+diff -rupN pcsx_rearmed.orig/Makefile.libretro pcsx_rearmed/Makefile.libretro
+--- pcsx_rearmed.orig/Makefile.libretro	2022-03-22 22:45:18.406511156 +0000
++++ pcsx_rearmed/Makefile.libretro	2022-03-23 00:58:28.073644000 +0000
+@@ -362,6 +362,19 @@ else ifeq ($(platform), rpi4_64)
+ 	DYNAREC = ari64
+         fpic := -fPIC
+         CFLAGS += -march=armv8-a+crc+simd -mtune=cortex-a72 -ftree-vectorize
++        
++#######################################
++# Anbernic RG552
++else ifeq ($(platform), rg552)
++   TARGET := $(TARGET_NAME)_libretro.so
++   CFLAGS += -marm -mtune=cortex-a72.cortex-a53 -mfpu=crypto-neon-fp-armv8 -mfloat-abi=hard
++   ASFLAGS += -mtune=cortex-a72.cortex-a53 -mfpu=crypto-neon-fp-armv8 -mfloat-abi=hard
++   fpic = -fPIC
++   HAVE_NEON = 1
++   ARCH = arm
++   BUILTIN_GPU = neon
++   DYNAREC = ari64
++         
+ 
+ # Classic Platforms ####################
+ # Platform affix = classic_<ISA>_<µARCH>
+


### PR DESCRIPTION
the make script from the 351elec uses optimization flags for the RPi3, so I added flags for the RK3399
