### PR TITLE
Remove new cores that break the build

### DIFF
--- a/packages/jelos/package.mk
+++ b/packages/jelos/package.mk
@@ -23,7 +23,7 @@ PKG_UI="emulationstation"
 PKG_EMUS="common-shaders glsl-shaders libretro-database retroarch hatarisa openbor  \
           scummvmsa PPSSPPSDL yabasanshiroSA vicesa mupen64plussa-audio-sdl         \
           mupen64plussa-input-sdl mupen64plussa-ui-console mupen64plussa-video-rice \
-          mupen64plussa-core mupen64plussa-rsp-hle mupen64plussa-video-glide64mk2
+          mupen64plussa-core mupen64plussa-rsp-hle mupen64plussa-video-glide64mk2   \
           lzdoom gzdoom raze ecwolf amiberry"
 
 LIBRETRO_CORES="2048 81 a5200 atari800 beetle-gba beetle-lynx beetle-ngp beetle-pce beetle-pcfx      \

--- a/packages/jelos/package.mk
+++ b/packages/jelos/package.mk
@@ -24,7 +24,7 @@ PKG_EMUS="common-shaders glsl-shaders libretro-database retroarch hatarisa openb
           scummvmsa PPSSPPSDL yabasanshiroSA vicesa mupen64plussa-audio-sdl         \
           mupen64plussa-input-sdl mupen64plussa-ui-console mupen64plussa-video-rice \
           mupen64plussa-core mupen64plussa-rsp-hle mupen64plussa-video-glide64mk2   \
-          lzdoom gzdoom raze ecwolf"
+          lzdoom gzdoom ecwolf"
 
 LIBRETRO_CORES="2048 81 a5200 atari800 beetle-gba beetle-lynx beetle-ngp beetle-pce beetle-pcfx      \
                 beetle-supafaust beetle-supergrafx beetle-vb beetle-wswan bluemsx cannonball cap32   \

--- a/packages/jelos/package.mk
+++ b/packages/jelos/package.mk
@@ -24,7 +24,7 @@ PKG_EMUS="common-shaders glsl-shaders libretro-database retroarch hatarisa openb
           scummvmsa PPSSPPSDL yabasanshiroSA vicesa mupen64plussa-audio-sdl         \
           mupen64plussa-input-sdl mupen64plussa-ui-console mupen64plussa-video-rice \
           mupen64plussa-core mupen64plussa-rsp-hle mupen64plussa-video-glide64mk2   \
-          lzdoom gzdoom raze ecwolf amiberry"
+          lzdoom gzdoom raze ecwolf"
 
 LIBRETRO_CORES="2048 81 a5200 atari800 beetle-gba beetle-lynx beetle-ngp beetle-pce beetle-pcfx      \
                 beetle-supafaust beetle-supergrafx beetle-vb beetle-wswan bluemsx cannonball cap32   \


### PR DESCRIPTION
Raze and amiberry dont currently build and break the entire build. Removing. Will need to research later. 