### PR TITLE
changes picodrive to the 32 bit version

### DIFF
--- a/packages/games/libretro/picodrive/package.mk
+++ b/packages/games/libretro/picodrive/package.mk
@@ -17,15 +17,14 @@ PKG_AUTORECONF="no"
 
 PKG_PATCH_DIRS="${PROJECT}"
 
-configure_target() {
-  :
-}
-
-make_target() {
-  cd $PKG_BUILD
-#  $PKG_BUILD/configure --platform=generic
-  make -f Makefile.libretro
-}
+if [ "${ARCH}" = "arm" ]
+then
+  make -f Makefile.libretro platform=armv6
+else
+  make_target() {
+    :
+  }
+fi
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libretro

--- a/packages/jelos/sources/scripts/runemu.sh
+++ b/packages/jelos/sources/scripts/runemu.sh
@@ -304,7 +304,7 @@ else
 
 	### Check if we need retroarch 32 bits or 64 bits
 	RABIN="retroarch"
-	if [[ "${CORE}" =~ "pcsx_rearmed" ]] || [[ "${CORE}" =~ "parallel_n64" ]]
+	if [[ "${CORE}" =~ "pcsx_rearmed" ]] || [[ "${CORE}" =~ "parallel_n64" ]] || [[ "${CORE}" =~ "picodrive" ]]
 	then
 		export LD_LIBRARY_PATH="/usr/lib32"
 		RABIN="retroarch32"

--- a/packages/jelos/sources/scripts/setsettings.sh
+++ b/packages/jelos/sources/scripts/setsettings.sh
@@ -18,7 +18,7 @@ NOREWIND=(sega32x psx zxspectrum odyssey2 mame n64 dreamcast atomiswave naomi ne
 NORUNAHEAD=(psp sega32x n64 dreamcast atomiswave naomi neogeocd saturn)
 # The following systems are listed as they don't need the Analogue D-Pad mode on RA
 NOANALOGUE=(n64 psx wonderswan wonderswancolor psp pspminis dreamcast)
-IS32BITCORE=(pcsx_rearmed parallel_n64 parallel_n64_gln64)
+IS32BITCORE=(pcsx_rearmed parallel_n64 parallel_n64_gln64 picodrive)
 
 INDEXRATIOS=(4/3 16/9 16/10 16/15 21/9 1/1 2/1 3/2 3/4 4/1 9/16 5/4 6/5 7/9 8/3 8/7 19/12 19/14 30/17 32/9 config squarepixel core full custom)
 CONF="/storage/.config/system/configs/system.cfg"

--- a/packages/virtual/arm32/package.mk
+++ b/packages/virtual/arm32/package.mk
@@ -4,6 +4,6 @@
 PKG_NAME="arm32"
 PKG_LICENSE="GPL"
 PKG_SITE="www.jelos.org"
-PKG_DEPENDS_TARGET="toolchain squashfs-tools:host dosfstools:host fakeroot:host kmod:host mtools:host populatefs:host libc gcc linux linux-drivers linux-firmware libusb unzip socat p7zip file ${OPENGLES} SDL2 SDL2_gfx SDL2_image SDL2_mixer SDL2_net SDL2_ttf libgo2 retroarch pcsx_rearmed parallel-n64_rice parallel-n64_gln64 parallel-n64_glide64"
+PKG_DEPENDS_TARGET="toolchain squashfs-tools:host dosfstools:host fakeroot:host kmod:host mtools:host populatefs:host libc gcc linux linux-drivers linux-firmware libusb unzip socat p7zip file ${OPENGLES} SDL2 SDL2_gfx SDL2_image SDL2_mixer SDL2_net SDL2_ttf libgo2 retroarch pcsx_rearmed parallel-n64_rice parallel-n64_gln64 parallel-n64_glide64 picodrive"
 PKG_SECTION="virtual"
 PKG_LONGDESC="Root package used to build and create 32-bit userland"


### PR DESCRIPTION
builds and launches picodrive as a 32 bit core.
the arm32 dynarec on this core is less buggy compared to the aarch64 version

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested Locally?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Build OS name and version:
* Docker (Y/N):
* JELOS Branch:
* Any additional information that may be useful:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
