### PR TITLE
Flycast flyinghead Thanks @flyinghead and @Amberelec

### DIFF
--- a/packages/games/libretro/flycast_flyinghead/package.mk
+++ b/packages/games/libretro/flycast_flyinghead/package.mk
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2022-present AmberELEC (https://github.com/AmberELEC)
+
+PKG_NAME="flycast_flyinghead"
+PKG_VERSION="e46d819c465ef342f5e9ef4c683231b17f56f206"
+PKG_SITE="https://github.com/flyinghead/flycast"
+PKG_URL="$PKG_SITE.git"
+PKG_DEPENDS_TARGET="toolchain $OPENGLES libzip"
+PKG_LONGDESC="Flycast is a multi-platform Sega Dreamcast, Naomi and Atomiswave emulator"
+PKG_TOOLCHAIN="cmake"
+
+pre_configure_target() {
+  sed -i 's/"reicast"/"flycast"/g' $PKG_BUILD/shell/libretro/libretro_core_option_defines.h 
+  PKG_CMAKE_OPTS_TARGET="-Wno-dev -DLIBRETRO=ON \
+                         -DWITH_SYSTEM_ZLIB=ON \
+                         -DUSE_OPENMP=ON \
+                         -DUSE_VULKAN=OFF
+                         -DUSE_GLES=ON"
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/lib/libretro
+  cp flycast_libretro.so $INSTALL/usr/lib/libretro/flycast_flyinghead_libretro.so
+}

--- a/packages/jelos/package.mk
+++ b/packages/jelos/package.mk
@@ -37,7 +37,7 @@ LIBRETRO_CORES="2048 81 a5200 atari800 beetle-gba beetle-lynx beetle-ngp beetle-
                 picodrive pokemini potator ppsspp prboom prosystem puae px68k quasi88 quicknes race  \
                 reminiscence sameboy sameduck scummvm smsplus-gx snes9x snes9x2002 snes9x2005_plus   \
                 snes9x2010 stella stella-2014 swanstation TIC-80 tgbdual tyrquake xrick uae4arm      \
-                uzem vba-next vbam vecx vice yabasanshiro xmil"
+                uzem vba-next vbam vecx vice yabasanshiro xmil flycast_flyinghead"
 
 PKG_COMPAT="lib32"
 

--- a/packages/ui/emulationstation/config/es_features.cfg
+++ b/packages/ui/emulationstation/config/es_features.cfg
@@ -31,6 +31,7 @@
       <core name="fbneo" features="netplay, rewind, autosave, cheevos" />
       <core name="fceumm" features="netplay, rewind, autosave, cheevos" />
       <core name="flycast" features="netplay, rewind, autosave" />
+      <core name="flycast_flyinghead" features="netplay, rewind, autosave" />
       <core name="freeintv" features="netplay, rewind, autosave, cheevos" />
       <core name="fuse" features="netplay, rewind, autosave" />
       <core name="gambatte" features="decoration, colorization, netplay, rewind, autosave, cheevos" />

--- a/packages/ui/emulationstation/config/es_systems.cfg
+++ b/packages/ui/emulationstation/config/es_systems.cfg
@@ -226,6 +226,7 @@
       <emulator name="retroarch">
         <cores>
           <core default="true">flycast</core>
+          <core default="true">flycast_flyinghead</core>
         </cores>
       </emulator>
     </emulators>
@@ -488,6 +489,7 @@
       <emulator name="retroarch">
         <cores>
           <core default="true">flycast</core>
+          <core default="true">flycast_flyinghead</core>
         </cores>
       </emulator>
     </emulators>
@@ -986,6 +988,7 @@
       <emulator name="retroarch">
         <cores>
           <core default="true">flycast</core>
+          <core default="true">flycast_flyinghead</core>
         </cores>
       </emulator>
     </emulators>


### PR DESCRIPTION
Tested on 552 at dev head. Copied and modified from @AmberElec, based on work from @Flyinghead. 

This is an additional Dreamcast core and Flycast libretro is still the default core. 