### PR TITLE
Add optional Drastic Install files, Nintendo DS emulator

### DIFF
--- a/packages/games/emulators/drastic/package.mk
+++ b/packages/games/emulators/drastic/package.mk
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022-present BrooksyTech (https://github.com/brooksytech)
+
+PKG_NAME="drastic"
+PKG_VERSION=""
+PKG_ARCH="any"
+PKG_URL="https://github.com/brooksytech/JelosAddOns/raw/main/drastic.zip"
+PKG_PRIORITY="optional"
+PKG_SECTION="tools"
+PKG_SHORTDESC="Optional NDS emulator, DraStic"
+PKG_TOOLCHAIN="manual"
+
+pre_unpack() {
+  unzip sources/drastic/drastic-.zip -d ${PKG_BUILD}
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/share/
+  cp -r ${PKG_BUILD}/drastic ${INSTALL}/usr/share/
+  chmod 0755 $INSTALL/usr/share/drastic
+  chmod +x ${INSTALL}/usr/share/drastic/install.sh
+  chmod +x ${INSTALL}/usr/share/drastic/uninstall.sh
+  
+}

--- a/packages/jelos/package.mk
+++ b/packages/jelos/package.mk
@@ -24,7 +24,7 @@ PKG_EMUS="common-shaders glsl-shaders libretro-database retroarch hatarisa openb
           scummvmsa PPSSPPSDL yabasanshiroSA vicesa mupen64plussa-audio-sdl         \
           mupen64plussa-input-sdl mupen64plussa-ui-console mupen64plussa-video-rice \
           mupen64plussa-core mupen64plussa-rsp-hle mupen64plussa-video-glide64mk2   \
-          lzdoom gzdoom ecwolf amiberry raze pico-8"
+          lzdoom gzdoom ecwolf amiberry raze pico-8 drastic"
 
 LIBRETRO_CORES="2048 81 a5200 atari800 beetle-gba beetle-lynx beetle-ngp beetle-pce beetle-pcfx      \
                 beetle-supafaust beetle-supergrafx beetle-vb beetle-wswan bluemsx cannonball cap32   \

--- a/packages/jelos/sources/post-update
+++ b/packages/jelos/sources/post-update
@@ -22,6 +22,7 @@ wait < <(jobs -p)
 cp -f /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt /storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt
 cp -f /usr/config/emulationstation/es_input.cfg /storage/.config/emulationstation
 cp -f /usr/config/emulationstation/es_features.cfg /storage/.config/emulationstation
+cp -f /usr/config/modules/gamelist.xml /storage/.config/modules
 
 rsync --ignore-existing /usr/config/rsync-rules.conf /storage/.config/
 rsync --ignore-existing /usr/config/rsync.conf /storage/.config/

--- a/packages/misc/modules/sources/Drastic Install.sh
+++ b/packages/misc/modules/sources/Drastic Install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022-present Brooksytech
+
+. /etc/profile
+cd /usr/share/drastic
+./install.sh

--- a/packages/misc/modules/sources/Drastic Uninstall.sh
+++ b/packages/misc/modules/sources/Drastic Uninstall.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022-present Brooksytech
+
+. /etc/profile
+cd /usr/share/drastic
+./uninstall.sh

--- a/packages/misc/modules/sources/gamelist.xml
+++ b/packages/misc/modules/sources/gamelist.xml
@@ -39,6 +39,28 @@
                 <thumbnail>./downloaded_images/rclone-thumb.png</thumbnail>
                 <image>./downloaded_images/rclone-back.png</image>
         </game>
+	
+	<game>
+                <path>./DraStic\ Install.sh</path>
+                <name>DraStic Install</name>
+                <desc>Install optional Nintendo DS emulator DraStic.</desc>
+                <developer>JELOS</developer>
+                <publisher>JELOS</publisher>
+                <rating>1.0</rating>
+                <releasedate>2022</releasedate>
+                <genre>Script</genre>
+        </game>
+	
+	<game>
+                <path>./DraStic\ Uninstall.sh</path>
+                <name>Drastic Uninstall</name>
+                <desc>Install optional Nintendo DS emulator DraStic.</desc>
+                <developer>JELOS</developer>
+                <publisher>JELOS</publisher>
+                <rating>1.0</rating>
+                <releasedate>2022</releasedate>
+                <genre>Script</genre>
+        </game>
 
         <game>
                 <path>/storage/roms/ports/JelosAddOns.sh</path>


### PR DESCRIPTION
Adding users the options to add DraStic, a nintendo DS emulator.

This is a closed source emulator and we do not have a license to distribute. Here is a forum regarding the creators views on this. 

https://www.drastic-ds.com/viewtopic.php?t=4307#p18679

Because of this we are including it as an optional add on. 

Users can install Drastiic in emulation station from tools > install drastic
And then they can remove it from tools > uninstall drastic. 