### PR TITLE
Cleanup up NDS and setting flycast_libretro as default core. 

### DIFF
--- a/packages/jelos/sources/post-update
+++ b/packages/jelos/sources/post-update
@@ -22,6 +22,7 @@ wait < <(jobs -p)
 cp -f /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt /storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt
 cp -f /usr/config/emulationstation/es_input.cfg /storage/.config/emulationstation
 cp -f /usr/config/emulationstation/es_features.cfg /storage/.config/emulationstation
+cp -f /usr/config/emulationstation/es_sytems.cfg /storage/.config/emulationstation
 cp -f /usr/config/modules/gamelist.xml /storage/.config/modules
 
 rsync --ignore-existing /usr/config/rsync-rules.conf /storage/.config/

--- a/packages/jelos/sources/post-update
+++ b/packages/jelos/sources/post-update
@@ -22,7 +22,7 @@ wait < <(jobs -p)
 cp -f /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt /storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt
 cp -f /usr/config/emulationstation/es_input.cfg /storage/.config/emulationstation
 cp -f /usr/config/emulationstation/es_features.cfg /storage/.config/emulationstation
-cp -f /usr/config/emulationstation/es_sytems.cfg /storage/.config/emulationstation
+cp -f /usr/config/emulationstation/es_systems.cfg /storage/.config/emulationstation
 cp -f /usr/config/modules/gamelist.xml /storage/.config/modules
 
 rsync --ignore-existing /usr/config/rsync-rules.conf /storage/.config/

--- a/packages/ui/emulationstation/config/es_settings.cfg
+++ b/packages/ui/emulationstation/config/es_settings.cfg
@@ -18,6 +18,7 @@
 	<string name="FolderViewMode" value="always" />
 	<string name="GameTransitionStyle" value="instant" />
 	<string name="GamelistViewStyle" value="automatic" />
+	<string name="HiddenSystems" value="nds" />
 	<string name="INPUT P1" value="DEFAULT" />
 	<string name="INPUT P1NAME" value="DEFAULT" />
 	<string name="INPUT P2" value="DEFAULT" />

--- a/packages/ui/emulationstation/config/es_systems.cfg
+++ b/packages/ui/emulationstation/config/es_systems.cfg
@@ -1123,6 +1123,18 @@
     </emulators>
   </system>
   <system>
+    <name>nds</name>
+    <fullname>Nintendo DS</fullname>
+    <path>/storage/roms/nds</path>
+    <manufacturer>Nintendo</manufacturer>
+    <release>2005</release>
+    <hardware>portable</hardware>
+    <extension>.nds .zip .NDS .ZIP</extension>
+    <command>/storage/.config/drastic/drastic.sh %ROM%</command>
+    <platform>nds</platform>
+    <theme>nds</theme>
+  </system>
+  <system>
     <name>nes</name>
     <fullname>Nintendo Entertainment System</fullname>
     <manufacturer>Nintendo</manufacturer>

--- a/packages/ui/emulationstation/config/es_systems.cfg
+++ b/packages/ui/emulationstation/config/es_systems.cfg
@@ -225,8 +225,8 @@
     <emulators>
       <emulator name="retroarch">
         <cores>
-          <core default="true">flycast</core>
-          <core>flycast_libretro</core>
+          <core default="true">flycast_libretro</core>
+          <core>flycast</core>
         </cores>
       </emulator>
 	  <emulator name="flycastsa">
@@ -493,8 +493,8 @@
     <emulators>
       <emulator name="retroarch">
         <cores>
-          <core default="true">flycast</core>
-          <core>flycast_libretro</core>
+          <core default="true">flycast_libretro</core>
+          <core>flycast</core>
         </cores>
       </emulator>
 	  <emulator name="flycastsa">
@@ -997,8 +997,8 @@
     <emulators>
       <emulator name="retroarch">
         <cores>
-          <core default="true">flycast</core>
-          <core>flycast_libretro</core>
+          <core default="true">flycast_libretro</core>
+          <core>flycast</core>
         </cores>
       </emulator>
 	  <emulator name="flycastsa">


### PR DESCRIPTION
Also will update es_systems.cfg after each update. 

Will need to modify the NDS installer script to unhide the system. 