### PR TITLE
Dev

### DIFF
--- a/packages/jelos/profile.d/02-distribution
+++ b/packages/jelos/profile.d/02-distribution
@@ -6,7 +6,6 @@
 
 export PATH="$PATH:/usr/local/bin:/usr/bin:/storage/bin"
 export SDL_GAMECONTROLLERCONFIG_FILE="/storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt"
-export SDL_AUDIODRIVER=alsa
 
 J_DIR="/storage/.config/system"
 J_CONF="${J_DIR}/configs/system.cfg"

--- a/packages/jelos/profile.d/02-distribution
+++ b/packages/jelos/profile.d/02-distribution
@@ -5,8 +5,8 @@
 . /etc/os-release
 
 export PATH="$PATH:/usr/local/bin:/usr/bin:/storage/bin"
-
 export SDL_GAMECONTROLLERCONFIG_FILE="/storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt"
+export SDL_AUDIODRIVER=alsa
 
 J_DIR="/storage/.config/system"
 J_CONF="${J_DIR}/configs/system.cfg"

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -39,6 +39,8 @@ makeinstall_target() {
 	mkdir -p ${INSTALL}/usr/config/emulationstation/resources
 	cp -rf ${PKG_BUILD}/resources/* ${INSTALL}/usr/config/emulationstation/resources/
 	rm -rf ${INSTALL}/usr/config/emulationstation/resources/logo.png
+	cp ${PKG_BUILD}/es_profile ${INSTALL}/usr/config/emulationstation
+	chmod 0755 ${INSTALL}/usr/config/emulationstation/es_profile
 
 	mkdir -p ${INSTALL}/usr/lib/${PKG_PYTHON_VERSION}
 	cp -rf ${PKG_DIR}/bluez/* ${INSTALL}/usr/lib/${PKG_PYTHON_VERSION}

--- a/packages/ui/emulationstation/sources/es_profile
+++ b/packages/ui/emulationstation/sources/es_profile
@@ -1,0 +1,3 @@
+#!/bin/sh
+. /etc/profile
+export SDL_AUDIODRIVER=alsa

--- a/packages/ui/emulationstation/system.d/emustation.service
+++ b/packages/ui/emulationstation/system.d/emustation.service
@@ -4,7 +4,7 @@ ConditionPathExists=/var/lock/start.games
 
 [Service]
 Environment=HOME=/storage
-EnvironmentFile=/etc/profile
+EnvironmentFile=/usr/config/emulationstation/es_profile
 ExecStartPre=/usr/bin/emustation-config
 ExecStart=/usr/bin/emulationstation --log-path /var/log
 KillMode=process


### PR DESCRIPTION
# Pull Request Template

## Description

An issue exists in JELOS where background music is not played when ES starts.  This issue is caused by the SDL_AUDIODRIVER environment variable not being set before ES is loaded.  Thanks to Alber in the JELOS discord for bisecting and helping trace the root cause.  This PR corrects the condition and BGM starts normally on device startup.