### PR TITLE
Drop cancel-in-progress as it loften eaves the builds in a bad state …

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -11,7 +11,6 @@ on:
 
 concurrency:
   group: dev
-  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -19,7 +19,6 @@ on:
 
 concurrency:
   group: main
-  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
…requiring manual cleanup.

Note: This is a PR to main cherry picked from dev.