### PR TITLE
Tweak our overclock capability to potentially improve boot stability.

### DIFF
--- a/projects/Rockchip/devices/RG351MP/device.init
+++ b/projects/Rockchip/devices/RG351MP/device.init
@@ -1,6 +1,3 @@
-# Inform init that this is a rotated display
-DISPLAY_ROTATED=true
-
 # Apply the default clocks early.
 echo 1296000 >/sys/devices/system/cpu/cpufreq/policy0
 echo 480000000 >/sys/devices/platform/ff400000.gpu/devfreq/ff400000.gpu

--- a/projects/Rockchip/devices/RG351V/device.init
+++ b/projects/Rockchip/devices/RG351V/device.init
@@ -1,6 +1,3 @@
-# Inform init that this is a rotated display
-DISPLAY_ROTATED=true
-
 # Apply the default clocks early.
 echo 1296000 >/sys/devices/system/cpu/cpufreq/policy0
 echo 480000000 >/sys/devices/platform/ff400000.gpu/devfreq/ff400000.gpu

--- a/projects/Rockchip/devices/RG552/device.init
+++ b/projects/Rockchip/devices/RG552/device.init
@@ -3,3 +3,10 @@ DISPLAY_ROTATED=true
 
 # Rotate the display on the 552.
 fbset -g 1152 1920 1152 1920 32 2>/dev/null
+
+# Apply the default clocks early.
+echo 1416000 >/sys/devices/system/cpu/cpufreq/policy0
+echo 1800000 >/sys/devices/system/cpu/cpufreq/policy4
+echo 800000000 >/sys/devices/platform/ff9a0000.gpu/devfreq/ff9a0000.gpu
+echo 856000000 >/sys/devices/platform/dmc/devfreq/dmc
+

--- a/projects/Rockchip/packages/linux/package.mk
+++ b/projects/Rockchip/packages/linux/package.mk
@@ -6,7 +6,7 @@
 
 PKG_NAME="linux"
 PKG_URL="https://github.com/JustEnoughLinuxOS/rockchip-kernel.git"
-PKG_VERSION="b259f0437"
+PKG_VERSION="1a8d74081"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kernel.org"

--- a/projects/Rockchip/packages/system-utils/sources/devices/RG552/overclock
+++ b/projects/Rockchip/packages/system-utils/sources/devices/RG552/overclock
@@ -85,17 +85,6 @@ case ${PROFILE} in
     DRAM="933000000"
     cooling_profile aggressive
   ;;
-  probably-fire)
-    # Can only enable this one over ssh..
-    # DO NOT USE!
-    # You are responsible if you break it.
-    # If your device catches on fire, well you were warned.
-    LITTLE_CORES="1704000"
-    BIG_CORES="2208000"
-    GPU="1100000000"
-    DRAM="1056000000"
-    cooling_profile aggressive
-  ;;
 esac
 
 freqset


### PR DESCRIPTION
* Eliminate the top overclocks as we're not using them anyway.
* Apply the default clocks in init to reduce risk of instability during boot.