### PR TITLE
bump libsndfile.

### DIFF
--- a/packages/audio/libsndfile/package.mk
+++ b/packages/audio/libsndfile/package.mk
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2022-present Fewtarius
 
 PKG_NAME="libsndfile"
-PKG_VERSION="1.0.31"
-PKG_SHA256="8cdee0acb06bb0a3c1a6ca524575643df8b1f3a55a0893b4dd9f829d08263785"
+PKG_VERSION="ea3ac90e98c"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://libsndfile.github.io/libsndfile/"
 PKG_URL="https://github.com/libsndfile/libsndfile/archive/${PKG_VERSION}.tar.gz"
@@ -12,16 +12,11 @@ PKG_DEPENDS_TARGET="toolchain alsa-lib flac libogg libvorbis opus"
 PKG_LONGDESC="A C library for reading and writing sound files containing sampled audio data."
 PKG_BUILD_FLAGS="+pic"
 
-# As per notes in configure.ac:
-#  One or more of the external libraries (ie libflac, libogg, libvorbis and libopus)
-#  is either missing ... Unfortunately, for ease of maintenance, the external libs
-#  are an all or nothing affair.
-# So all of flac, libogg, libvorbis, opus are required.
-
-PKG_CMAKE_OPTS_TARGET="-DBUILD_PROGRAMS=OFF \
+PKG_CMAKE_OPTS_TARGET="-DBUILD_PROGRAMS=ON \
                        -DBUILD_EXAMPLES=OFF \
                        -DBUILD_REGTEST=OFF \
                        -DBUILD_TESTING=OFF \
-                       -DENABLE_EXTERNAL_LIBS=ON \
+                       -DENABLE_EXTERNAL_LIBS=OFF \
+		       -DBUILD_SHARED_LIBS=ON
                        -DINSTALL_MANPAGES=OFF \
                        -DINSTALL_PKGCONFIG_MODULE=ON"

--- a/packages/audio/libsndfile/patches/libsndfile-add-required-static-libaries-to-pkg-config.patch
+++ b/packages/audio/libsndfile/patches/libsndfile-add-required-static-libaries-to-pkg-config.patch
@@ -1,9 +1,0 @@
---- a/sndfile.pc	2021-01-24 23:22:23.000000000 +1100
-+++ b/sndfile.pc.in	2021-09-12 14:30:47.763655089 +1000
-@@ -8,5 +8,5 @@
- Requires:
- Requires.private: @EXTERNAL_XIPH_REQUIRE@
- Version: @VERSION@
--Libs: -L${libdir} -lsndfile
-+Libs: -L${libdir} -lsndfile -lFLAC -lvorbis -logg -lvorbisenc -lopus
- Cflags: -I${includedir}


### PR DESCRIPTION
Updates libsndfile to 1.1.0, it will still appear as 1.0.34 in the OS.