### PR TITLE
Roll back PPSSPPSDL.

### DIFF
--- a/config/blocklist
+++ b/config/blocklist
@@ -1,2 +1,3 @@
 np2kai # Last major commit before hiatus is broken
 vicesa # Doesn't support updating with the script.
+PPSSPPSDL # non-buffered rendering is still broken.

--- a/packages/games/emulators/PPSSPPSDL/package.mk
+++ b/packages/games/emulators/PPSSPPSDL/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
 # Copyright (C) 2022-present Fewtarius
 PKG_NAME="PPSSPPSDL"
-PKG_VERSION="83f3539f32bc138b0a48f7d61bb34e19c609d6bc"
+PKG_VERSION="cf9c3e8c76f1df5c2b028141fff9d4e9fd029e13"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"


### PR DESCRIPTION
PPSSPPSDL is broken in the last few commits, roll it back so it works as expected.