### PR TITLE
Add WireGuard VPN menu item into Network Settings #2

### DIFF
--- a/packages/jelos/sources/autostart/common/098-wireguard
+++ b/packages/jelos/sources/autostart/common/098-wireguard
@@ -1,0 +1,10 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2021-present kkoshelev (https://github.com/kkoshelev)
+
+. /etc/profile
+
+if [ "$(get_setting wireguard.up)" == "1" ]
+then
+  nohup wg-quick up /storage/.config/wireguard/wg0.conf &
+fi

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -23,6 +23,48 @@ PKG_DEPENDS_TARGET="${PKG_DEPENDS_TARGET} es-theme-art-book-next"
 
 PKG_CMAKE_OPTS_TARGET=" -DENABLE_EMUELEC=1 -DGLES2=1 -DDISABLE_KODI=1 -DENABLE_FILEMANAGER=0 -DCEC=0"
 
+##########################################################################################################
+# The following allows building Emulation station from local copy by using EMULATIONSTATION_SRC.
+# The built makes symlinks to a local repository.
+#
+# One time setup:
+# ---------------
+# cd ~
+# git clone https://github.com/JustEnoughLinuxOS/emulationstation.git
+# cd emulationstation
+# git submodule update --init
+#
+# Cleanup old files:
+# ------------------
+# DEVICE=RG351V ARCH=aarch64 ./scripts/clean emulationstation
+#
+# Build from local copy:
+# ----------------------
+# EMULATIONSTATION_SRC=~/emulationstation DEVICE=RG351V ARCH=aarch64 ./scripts/build emulationstation
+#
+# Run from the device:
+# --------------------
+# Copy ./emulationstation binary found in build.JELOS-<device>.aarch64/emulationstation-*/.install_pkg/usr/bin/ 
+# Via ssh, run emulationstation with
+# systemctl stop emustation
+# chmod +x ./emulationstation
+# ./emulationstation
+##########################################################################################################
+if [ -n "$EMULATIONSTATION_SRC" ]; then
+unpack() {
+	echo cp -PRf ${EMULATIONSTATION_SRC} ${PKG_BUILD}
+  cp -PRf ${EMULATIONSTATION_SRC} ${PKG_BUILD}
+}
+# add some symbolic links to point to a code in local source folder
+post_unpack() {
+	rm -rf "${PKG_BUILD}/es-app"
+	ln -sf "${EMULATIONSTATION_SRC}/es-app" "${PKG_BUILD}"
+
+	rm -rf "${PKG_BUILD}/es-core"
+	ln -sf "${EMULATIONSTATION_SRC}/es-core" "${PKG_BUILD}"
+}
+fi
+
 pre_configure_target() {
   if [ -f ~/developer_settings.conf ]; then
     . ~/developer_settings.conf

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="emulationstation"
-PKG_VERSION="481a471"
+PKG_VERSION="6d3fd4b"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
# Add WireGuard VPN menu item into Network Settings

## Description

See also another PR with changes to emulationstation [link](https://github.com/JustEnoughLinuxOS/emulationstation/pull/4).

1. Enables WireGuard VPN if setting "wireguard.up=1".
2. Added a simpler way, with instructions, to build emulationstation package to simplify development workflow.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Tested by making a custom build and uploading it ro RG351V.

- [x] Test A: Boot device, upload WG config, enable VPN in settings, see another PR.
Verify VPN connection is active (wg show).
Reboot device.
Verify VPN connection is active (wg show).

**Test Configuration**: RG351V
* Build OS name and version: custom dev build
* Docker (Y/N): N
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
