### PR TITLE
Add Moonlight Game Streaming support #3

### DIFF
--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="emulationstation"
-PKG_VERSION="6d3fd4b"
+PKG_VERSION="aad4531"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
This is a contuniation of [Add Moonlight Game Streaming support #2](https://github.com/JustEnoughLinuxOS/distribution/pull/147).
It needs latest version of Emulation Station to have Moonlight menus visible.