### PR TITLE
Add build env vars for ssh keys and wifi

### DIFF
--- a/packages/jelos/package.mk
+++ b/packages/jelos/package.mk
@@ -83,6 +83,19 @@ makeinstall_target() {
   ln -s /storage/roms ${INSTALL}/roms
   ln -sf /storage/roms/opt ${INSTALL}/opt
 
+  ### Add some quality of life customizations for hardworking devs.
+  if [ -n "${JELOS_SSH_KEYS_FILE}" ]; then
+    mkdir -p ${INSTALL}/storage/.ssh
+    cp ${JELOS_SSH_KEYS_FILE} ${INSTALL}/storage/.ssh/authorized_keys
+  fi
+
+  if [ -n "${JELOS_WIFI_SSID}" ]; then
+    sed -i "s#wifi.enabled=0#wifi.enabled=1#g" ${INSTALL}/usr/config/system/configs/system.cfg
+    cat <<EOF >> ${INSTALL}/usr/config/system/configs/system.cfg
+wifi.ssid=${JELOS_WIFI_SSID}
+wifi.key=${JELOS_WIFI_KEY}
+EOF
+  fi
 }
 
 post_install() {


### PR DESCRIPTION
# Add build env vars for ssh keys and wifi

## Description

Add those to you .bashrc to make image with ssh keys and wifi settings pre-populated
export JELOS_SSH_KEYS_FILE=~/.ssh/authorized_keys
export JELOS_WIFI_SSID=<SSID>
export JELOS_WIFI_KEY=<WIFIKEY>

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Set env variables, run build, verify that changes are part of jelos install package files
Did not make image to verify that it actually works.

**Test Configuration**:
* Build OS name and version: dev
* Docker (Y/N): N
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
