### PR TITLE
Fix WiFi connectivity issues

### DIFF
--- a/packages/jelos/sources/scripts/wifictl
+++ b/packages/jelos/sources/scripts/wifictl
@@ -27,6 +27,17 @@ fi
 
 WIFICFG="/storage/.cache/connman/wifi.config"
 
+# lists all wifi services in service=ssid format
+list_wifi() {
+  connmanctl services | cut -b 5- | awk '/\S+.+\s+wifi/ {a=$0; sub(/\s+wifi_.*$/,"", a); b=$0; sub(a, "", b); sub(/\s+/, "", b); print b "=" a}' | sort | uniq
+}
+
+# Looksup connman service name based on ssid
+# $1 - SSID to lookup
+get_wifi_service() {
+  list_wifi | awk -v ssid="${1}" '{ split($0, a, "="); if (a[2]==ssid) print a[1] }'
+}
+
 set_powersave() {
   ENABLED=$(get_setting wifi.powersave)
   if [ "${ENABLED}" = "1" ]
@@ -55,6 +66,7 @@ EOF
       connmanctl enable wifi 2>/dev/null
       set_powersave 2>/dev/null
       connmanctl scan wifi 2>/dev/null
+      connmanctl connect $(get_wifi_service ${SSID})>/dev/null
     ;;
     "disable")
       connmanctl disable wifi 2>/dev/null
@@ -62,7 +74,7 @@ EOF
       set_setting wifi.enabled 0
     ;;
     "list")
-      connmanctl services | cut -b 5- | awk '/wifi/ {sub(/\s+wifi_.*$/,"",$0);print}' | sort | uniq
+      list_wifi | awk '{sub(/\S+=/,"",$0);print}'
     ;;
     "scan")
       connmanctl scan 2>/dev/null


### PR DESCRIPTION
# Fix WiFi connectivity issues

## Description

This resolves the following issues:
* device will not connect to a different WiFi access point if it previously had connected to another WiFi point at the same physical location
* possible to connect to WiFi access point without password
* WiFi network list in Emu Station doesn't contain empty string

wifictl script reworked to use wifi network service name when calling connmanctl, instead of relying on the default configured wifi network

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Tested by making custom build and connecting to WiFi network with password and then the one without password and back.

**Test Configuration**: custom dev build
* Build OS name and version: dev
* Docker (Y/N): N
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
