### PR TITLE
Add tailscale support

### DIFF
--- a/packages/jelos/package.mk
+++ b/packages/jelos/package.mk
@@ -50,7 +50,7 @@ PKG_MULTIMEDIA="ffmpeg mpv vlc"
 PKG_GAMESUPPORT="sixaxis jslisten evtest rg351p-js2xbox gptokeyb textviewer 351files jstest-sdl \
                  gamecontrollerdb jelosaddons libgo2 rclone sdljoytest"
 
-PKG_EXPERIMENTAL=""
+PKG_EXPERIMENTAL="tailscale"
 
 ### Project/Device specific items
 if [ "${PROJECT}" == "Rockchip" ]

--- a/packages/jelos/sources/autostart/common/097-tailscale
+++ b/packages/jelos/sources/autostart/common/097-tailscale
@@ -1,0 +1,11 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2021-present kkoshelev (https://github.com/kkoshelev)
+
+. /etc/profile
+
+if [ "$(get_setting tailscale.up)" == "1" ]
+then
+  set_setting tailscale.up 0
+  nohup tailscale down &
+fi

--- a/packages/network/tailscale/config/tailscaled.defaults
+++ b/packages/network/tailscale/config/tailscaled.defaults
@@ -1,0 +1,8 @@
+# Set the port to listen on for incoming VPN packets.
+# Remote nodes will automatically be informed about the new port number,
+# but you might want to configure this in order to set external firewall
+# settings.
+PORT="41641"
+
+# Extra flags you might want to pass to tailscaled.
+FLAGS=""

--- a/packages/network/tailscale/package.mk
+++ b/packages/network/tailscale/package.mk
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022-present kkoshelev (https://github.com/kkoshelev)
+
+PKG_NAME="tailscale"
+PKG_VERSION="1.26.1"
+PKG_ARCH="aarch64"
+PKG_SITE="https://tailscale.com/"
+PKG_URL="https://pkgs.tailscale.com/stable/tailscale_${PKG_VERSION}_arm64.tgz"
+PKG_DEPENDS_TARGET="toolchain wireguard-tools wireguard-linux-compat"
+PKG_SHORTDESC="Zero config VPN. Installs on any device in minutes, manages firewall rules for you, and works from anywhere."
+PKG_TOOLCHAIN="manual"
+
+pre_unpack() {
+  mkdir -p $PKG_BUILD
+  tar --strip-components=1 -xf $SOURCES/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tgz -C $PKG_BUILD tailscale_${PKG_VERSION}_arm64
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin/
+  cp ${PKG_BUILD}/tailscale ${INSTALL}/usr/bin/
+  cp ${PKG_BUILD}/tailscaled ${INSTALL}/usr/bin/
+
+  mkdir -p ${INSTALL}/usr/config
+    cp -R ${PKG_DIR}/config/tailscaled.defaults ${INSTALL}/usr/config
+}
+
+post_install() {
+  enable_service tailscaled.service
+}

--- a/packages/network/tailscale/system.d/tailscaled.service
+++ b/packages/network/tailscale/system.d/tailscaled.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Tailscale node agent
+Documentation=https://tailscale.com/kb/
+Wants=network-pre.target
+After=network-pre.target
+
+[Service]
+EnvironmentFile=/storage/.config/tailscaled.defaults
+ExecStartPre=/usr/bin/tailscaled --cleanup
+ExecStart=/usr/bin/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock --port $PORT $FLAGS
+ExecStopPost=/usr/bin/tailscaled --cleanup
+
+Restart=on-failure
+
+RuntimeDirectory=tailscale
+RuntimeDirectoryMode=0755
+StateDirectory=tailscale
+StateDirectoryMode=0700
+CacheDirectory=tailscale
+CacheDirectoryMode=0750
+Type=notify
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="emulationstation"
-PKG_VERSION="3c24c9b"
+PKG_VERSION="3c24c9b"  # TODO(kk): update package version after PR is merged.
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"

--- a/projects/Rockchip/devices/RG353P/linux/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RG353P/linux/linux.aarch64.conf
@@ -1823,7 +1823,7 @@ CONFIG_NET_CORE=y
 # CONFIG_GTP is not set
 # CONFIG_MACSEC is not set
 # CONFIG_NETCONSOLE is not set
-# CONFIG_TUN is not set
+CONFIG_TUN=y
 # CONFIG_TUN_VNET_CROSS_LE is not set
 # CONFIG_VETH is not set
 # CONFIG_NLMON is not set

--- a/projects/Rockchip/devices/RG503/linux/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RG503/linux/linux.aarch64.conf
@@ -1823,7 +1823,7 @@ CONFIG_NET_CORE=y
 # CONFIG_GTP is not set
 # CONFIG_MACSEC is not set
 # CONFIG_NETCONSOLE is not set
-# CONFIG_TUN is not set
+CONFIG_TUN=y
 # CONFIG_TUN_VNET_CROSS_LE is not set
 # CONFIG_VETH is not set
 # CONFIG_NLMON is not set


### PR DESCRIPTION
# Add tailscale support

## Description

This adds tailscale ui https://tailscale.com/

New "TAILSCALE VPN" toggle switch is added to network settings dialog.
Upon turning it on, it connects or disconnects from tailscale network.
If device is not authenticated, after first attempt to enable, it will display authentication url.
The user must open this url in the browser and authenticate. After auth is done the toggle switch will work.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested Locally?

Created a custom built and tested the change on RG503 only. See description.

**Test Configuration**: dev build
* Build OS name and version: dev
* Docker (Y/N): N
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
