### PR TITLE
Make the rsync options for cloud_backup and cloud_restore configurable via the rsync.conf

### DIFF
--- a/packages/sysutils/rclone/sources/cloud_backup
+++ b/packages/sysutils/rclone/sources/cloud_backup
@@ -11,6 +11,7 @@ else
   MOUNTPATH="/storage/cloud"
   SYNCPATH="GAMES"
   BACKUPPATH="/storage/roms"
+  RSYNCOPTSBACKUP="-raiv --prune-empty-dirs"
 fi
 
 echo -e "=> ${OS_NAME} CLOUD BACKUP UTILITY\n" >/dev/console
@@ -19,7 +20,7 @@ echo "Mounting ${MOUNTPATH}" >/dev/console 2>&1
 rclonectl mount ${MOUNTPATH} >/dev/console 2>&1
 
 echo "Backing up data from ${BACKUPPATH} to ${MOUNTPATH}/${SYNCPATH}" >/dev/console 2>&1
-rsync -raiv --include-from="${CONFIGPATH}/rsync-rules.conf" --prune-empty-dirs ${BACKUPPATH}/ ${MOUNTPATH}/${SYNCPATH}/ >/dev/console 2>&1
+rsync ${RSYNCOPTSBACKUP} --include-from="${CONFIGPATH}/rsync-rules.conf" ${BACKUPPATH}/ ${MOUNTPATH}/${SYNCPATH}/ >/dev/console 2>&1
 
 echo "Unmounting ${MOUNTPATH}" >/dev/console 2>&1
 rclonectl unmount ${MOUNTPATH} >/dev/console 2>&1

--- a/packages/sysutils/rclone/sources/cloud_restore
+++ b/packages/sysutils/rclone/sources/cloud_restore
@@ -11,6 +11,7 @@ else
   MOUNTPATH="/storage/cloud"
   SYNCPATH="GAMES"
   BACKUPPATH="/storage/roms"
+  RSYNCOPTSRESTORE="-raiv"
 fi
 
 echo -e "=> ${OS_NAME} CLOUD RESTORE UTILITY\n" >/dev/console
@@ -19,7 +20,7 @@ echo "Mounting ${MOUNTPATH}" >/dev/console 2>&1
 rclonectl mount ${MOUNTPATH} >/dev/console 2>&1
 
 echo "Restoring data from ${MOUNTPATH}/${SYNCPATH} to ${BACKUPPATH}" >/dev/console 2>&1
-rsync -raiv --include-from="${CONFIGPATH}/rsync-rules.conf" ${MOUNTPATH}/${SYNCPATH}/ ${BACKUPPATH}/ >/dev/console 2>&1
+rsync ${RSYNCOPTSRESTORE} --include-from="${CONFIGPATH}/rsync-rules.conf" ${MOUNTPATH}/${SYNCPATH}/ ${BACKUPPATH}/ >/dev/console 2>&1
 
 echo "Unmounting ${MOUNTPATH}" >/dev/console 2>&1
 rclonectl unmount ${MOUNTPATH} >/dev/console 2>&1

--- a/packages/sysutils/rclone/sources/rsync.conf
+++ b/packages/sysutils/rclone/sources/rsync.conf
@@ -6,3 +6,9 @@ SYNCPATH="GAMES"
 
 ### This is the path we are backup up from.
 BACKUPPATH="/storage/roms"
+
+### This allows changes to the rsync options for cloud_backup
+RSYNCOPTSBACKUP="-raiv --prune-empty-dirs"
+
+### This allows changes to the rsync options for cloud_restore
+RSYNCOPTSRESTORE="-raiv"


### PR DESCRIPTION
## Description
The purpose of this PR is provide some additional flexibility around rsync as it pertains to command line options that can be passed to it when using `cloud_backup` or `cloud_restore`.  Changes have been made to these scripts to allow the user to change these options via the `rsync.conf`.  By default, out of the box, the default options are the same as they are today.

The main change in both of these scripts is the addition of a variable that will be used to pass the options.

Updates to the documentation are also included.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested Locally?
The changes have been tested against a local build done for the `RG503`.

- [x] Test A
First test was done using the default command line options in the `rsync.conf`.  A backup and restore was run to confirm the scripts can continue to backup and restore game saves.

- [x] Test B
Second test was to add `--progess` to both the `RSYNCOPTSBACKUP` and `RSYNCOPTSRESTORE`.  A backup and restore was run to confirm the output matched what was expected now that `--progress` was added to the command line options.

- [x] Test C
Third test was run with a modified `rsync-rules.conf` that allowed for all files to be backed and restored on the device with `--progress` in place for both the backup and restore.

To test... setup a backup destination in rclone then, optionally, add some additional command line options in the `rsync.conf` then run a backup and restore.  Observe that the changes are reflected in the backup or restore run.

**Test Configuration**:
* Build OS name and version: JELOS-RG503.aarch64-20220705.img.gz
* Docker (Y/N): Y
* JELOS Branch: rsync_opts

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Documentation changes
```
#### rsync.conf
The rsync.conf configuration file contains parameters used by the cloud tools that provide the path for your cloud drive to be mounted, the path to sync the data from, the destination for the sync and rsync options for cloud backup and restore.  The configuration is user editable, and the defaults are as follows:
```
### This is the path where your cloud volume is mounted.
MOUNTPATH="/storage/cloud"

### This is the path to your game folder on your cloud drive.
SYNCPATH="GAMES"

### This is the path we are backup up from.
BACKUPPATH="/storage/roms"

### This allows changes to the rsync options for cloud_backup
RSYNCOPTSBACKUP="-raiv --prune-empty-dirs"

### This allows changes to the rsync options for cloud_restore
RSYNCOPTSRESTORE="-raiv"
```
