### PR TITLE
If the rsync.conf is missing variables we should set defaults

### DIFF
--- a/packages/sysutils/rclone/sources/cloud_backup
+++ b/packages/sysutils/rclone/sources/cloud_backup
@@ -7,11 +7,13 @@ CONFIGPATH="/storage/.config"
 if [ -e "${CONFIGPATH}/rsync.conf" ]
 then
   source ${CONFIGPATH}/rsync.conf
-else
-  MOUNTPATH="/storage/cloud"
-  SYNCPATH="GAMES"
-  BACKUPPATH="/storage/roms"
 fi
+
+# If rsync.conf is missing variables set defaults
+MOUNTPATH="${MOUNTPATH:=/storage/cloud}"
+SYNCPATH="${SYNCPATH:=GAMES}"
+BACKUPPATH="${BACKUPPATH:=/storage/roms}"
+RSYNCOPTSBACKUP="${RSYNCOPTSBACKUP:=--raiv --prune-empty-dirs}"
 
 echo -e "=> ${OS_NAME} CLOUD BACKUP UTILITY\n" >/dev/console
 

--- a/packages/sysutils/rclone/sources/cloud_restore
+++ b/packages/sysutils/rclone/sources/cloud_restore
@@ -7,11 +7,13 @@ CONFIGPATH="/storage/.config"
 if [ -e "${CONFIGPATH}/rsync.conf" ]
 then
   source ${CONFIGPATH}/rsync.conf
-else
-  MOUNTPATH="/storage/cloud"
-  SYNCPATH="GAMES"
-  BACKUPPATH="/storage/roms"
 fi
+
+# If rsync.conf is missing variables set defaults
+MOUNTPATH="${MOUNTPATH:=/storage/cloud}"
+SYNCPATH="${SYNCPATH:=GAMES}"
+BACKUPPATH="${BACKUPPATH:=/storage/roms}"
+RSYNCOPTSRESTORE="${RSYNCOPTSRESTORE:=-raiv}"
 
 echo -e "=> ${OS_NAME} CLOUD RESTORE UTILITY\n" >/dev/console
 


### PR DESCRIPTION
## Description
The purpose of this PR is to make sure even an `rsync.conf` with missing variables will allow `cloud_backup` and `cloud_restore` to run with defaults.  This is a followup to PR#248.

I modified the existing `if` block in `cloud_backup` and `cloud_restore` to only source the `rsync.conf` if it exists.  Then, the variables in this block were moved outside the `if` block and after the source of the `rsync.conf`.  If any of these variables aren't set in the `rsync.conf` we will provide defaults.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested Locally?
All changes were tested on a new build for an `RG503`.

- [x] Test A
First test was run with all defaults set out of the box except for `SYNCPATH` which was changed to match my webdav config.  Both `cloud_backup` and `cloud_restore` were run to ensure no errors were present.  Both scripts worked as expected.

- [x] Test B
Second test was run with `RSYNCOPTSBACKUP` and `RSYNCOPTSRESTORE` commented out of the `rsync.conf` to simulate missing variables.  Both `cloud_backup` and `cloud_restore` ran as expected.

- [x] Test C
Third test was run with all variables commented out except for `SYNCPATH` to simulate most variables missing.  Both `cloud_backup` and `cloud_restore` ran as expected.


**Test Configuration**:
* Build OS name and version: JELOS-RG503.aarch64-20220706.img.gz
* Docker (Y/N): Y
* JELOS Branch:  rsync_opts_backcompat

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation