### PR TITLE
Remove extra - in the cloud_backup RSYNCOPTSBACKUP options

### DIFF
--- a/packages/sysutils/rclone/sources/cloud_backup
+++ b/packages/sysutils/rclone/sources/cloud_backup
@@ -13,7 +13,7 @@ fi
 MOUNTPATH="${MOUNTPATH:=/storage/cloud}"
 SYNCPATH="${SYNCPATH:=GAMES}"
 BACKUPPATH="${BACKUPPATH:=/storage/roms}"
-RSYNCOPTSBACKUP="${RSYNCOPTSBACKUP:=--raiv --prune-empty-dirs}"
+RSYNCOPTSBACKUP="${RSYNCOPTSBACKUP:=-raiv --prune-empty-dirs}"
 
 echo -e "=> ${OS_NAME} CLOUD BACKUP UTILITY\n" >/dev/console
 


### PR DESCRIPTION
## Description
The purpose of this PR is to remove an extra - (dash) from the `cloud_backup` `RSYNCOPTSBACKUP` line.  I was testing the latest `dev` build only to find that `cloud_backup` was error'ing out.  Looking into the issue further there was an extra - on the `cloud_backup` `RSYNCOPTSBACKUP` line.  Not sure why my initial testing didn't catch this but this will fix it.

Broken:
RSYNCOPTSBACKUP="${RSYNCOPTSBACKUP:=--raiv --prune-empty-dirs}"

Fixed:
RSYNCOPTSBACKUP="${RSYNCOPTSBACKUP:=-raiv --prune-empty-dirs}"

`cloud_restore` was not impacted by this and works as expected.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested Locally?
Tested locally on my RG503.

- [x] Test A
Ran cloud_backup with `rsync.conf` in place but without `RSYNCOPTSBACKUP` specified in the `/storage/.config/rsync.conf`.  This will cause `cloud_backup` to use the defaults which has the fix in place.  `cloud_backup` ran as expected.

**Test Configuration**: JELOS-RG503.aarch64-20220708.img.gz
* Build OS name and version: 
* Docker (Y/N): Y
* JELOS Branch: cloud_backup_fix

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation