### PR TITLE
Add moonlight images to Art-Book-Next

### DIFF
--- a/packages/themes/es-theme-art-book-next/package.mk
+++ b/packages/themes/es-theme-art-book-next/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2021 Fewtarius
 
 PKG_NAME="es-theme-art-book-next"
-PKG_VERSION="a4fdfbb4501fe7f7fbbd7367553eec78936f2218"
+PKG_VERSION="e35fdfda8315a88d90a8eba1fc342c0b2bedee7c"
 PKG_ARCH="any"
 PKG_LICENSE="CUSTOM"
 PKG_SITE="https://github.com/anthonycaccese/es-theme-art-book-next"


### PR DESCRIPTION
Updated art-book-next with a centered background image and logo for moonlight
