### PR TITLE
Bump ES to include moonlight changes

### DIFF
--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="emulationstation"
-PKG_VERSION="098226b"
+PKG_VERSION="fc668c1"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
# Bump ES to include moonlight changes

## Description

Include recent changes to Emulation Station from 
https://github.com/JustEnoughLinuxOS/emulationstation/pull/8
