### PR TITLE
Adding jq as a misc package so it gets built and emplacing it in /usr/bin as part of install

### DIFF
--- a/packages/sysutils/jq/package.mk
+++ b/packages/sysutils/jq/package.mk
@@ -17,5 +17,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
                            --disable-valgrind"
 
 makeinstall_target() {
-  :
+  mkdir -p $INSTALL/usr/bin
+  cp jq $INSTALL/usr/bin/
 }
+

--- a/packages/virtual/misc-packages/package.mk
+++ b/packages/virtual/misc-packages/package.mk
@@ -7,7 +7,7 @@ PKG_VERSION=""
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain Python3 ${ADDITIONAL_PACKAGES}"
+PKG_DEPENDS_TARGET="toolchain Python3 jq ${ADDITIONAL_PACKAGES}"
 PKG_SECTION="virtual"
 PKG_LONGDESC="misc-packages: Metapackage for miscellaneous packages"
 


### PR DESCRIPTION
## Description

Adding jq as a misc package so it gets built and emplacing it in /usr/bin as part of install.

I am working on an addon for JELOS which uses jq -- and we already have a jq package defined for JELOS, it's just not depended on by anything so it never gets built or installed.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?
I built an image with this for my RG353P device and ensured that jq does get installed to /usr/bin correctly -- and my project which depends on jq being installed works as intended!

**Test Configuration**:
* Build OS name and version: JELOS RG353P aarch64
* Docker (Y/N): Y
* JELOS Branch: dev

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

