### PR TITLE
Dev .build raze.ini default bindings rg552/503

### DIFF
--- a/packages/games/emulators/raze/config/RG503/raze.ini
+++ b/packages/games/emulators/raze/config/RG503/raze.ini
@@ -412,12 +412,43 @@ vid_allowtrueultrawide=1
 [.ConsoleAliases]
 
 [.Bindings]
+Joy1=+jump
+Joy2=+open
+Joy3=+Crouch
+Joy4=toggle cl_autorun
+Joy5=+alt_fire
+Joy6=+fire
+Joy7=weapprev
+Joy8=weapnext
+Joy9=menu_main
+Joy10=pause
+Joy12=togglemap
+Joy13=centerview
+Joy14=third_person_view
+Joy15=invuse
+Joy16=invprev
+Joy17=invnext
+Axis1Plus=+strafe_right
+Axis1Minus=+strafe_left
+Axis2Plus=+move_backward
+Axis2Minus=+move_forward
+Axis3Plus=+turn_right
+Axis3Minus=+turn_left
+Axis4Plus=+look_down
+Axis4Minus=+look_up
 
 [.DoubleBindings]
 
 [.AutomapBindings]
+Joy9=+shrink_screen
+Joy10=+enlarge_Screen
+Joy13=togglefollow
+Axis2Minus=+am_panup
+Axis2Plus=+am_pandown
+Axis1Minus=+am_panleft
+Axis1Plus=+am_panright
 
-[Duke.AutoExec]
+[.AutoExec]
 Path=/storage/.config/raze/autoexec.cfg
 
 [Duke.Player]
@@ -570,20 +601,6 @@ F4=openmenu SoundOptions
 LThumb=crouch
 LTrigger=+altattack
 RTrigger=+attack
-Joy1=+open
-Joy3=turnaround
-Joy5=+run
-Joy6=+fire
-Joy7=+crouch
-Joy8=+jump
-Joy9=menu_main
-Joy10=pause
-Joy11=weapprev
-Joy12=weapnext
-Joy13=togglemap
-Joy14=menu_main
-Joy15=toggle cl_autorun
-Joy16=centerview
 
 [Duke.DoubleBindings]
 
@@ -753,17 +770,6 @@ RAlt=+Strafe
 LThumb=crouch
 LTrigger=+altattack
 RTrigger=+attack
-Joy5=+run
-Joy6=+fire
-Joy7=+crouch
-Joy8=+jump
-Joy14=menu_main
-Joy16=centerview
-Joy1=+open
-Joy3=turnaround
-Joy11=weapprev
-Joy12=weapnext
-Joy13=togglemap
 
 [ShadowWarrior.DoubleBindings]
 
@@ -774,8 +780,8 @@ Joy5=+shrink_screen
 Joy6=+enlarge_Screen
 
 [Joy:JS:0]
-Axis0deadzone=0.200001
-Axis1deadzone=0.200001
+Axis0deadzone=0.300001
+Axis1deadzone=0.300001
 Axis2deadzone=0.300001
 Axis2scale=0.7
 Axis2map=0

--- a/packages/games/emulators/raze/config/RG552/raze.ini
+++ b/packages/games/emulators/raze/config/RG552/raze.ini
@@ -408,12 +408,43 @@ vid_allowtrueultrawide=1
 [.ConsoleAliases]
 
 [.Bindings]
+Joy1=+jump
+Joy2=+open
+Joy3=+Crouch
+Joy4=toggle cl_autorun
+Joy5=+alt_fire
+Joy6=+fire
+Joy7=weapprev
+Joy8=weapnext
+Joy9=menu_main
+Joy10=pause
+Joy12=togglemap
+Joy13=centerview
+Joy14=third_person_view
+Joy15=invuse
+Joy16=invprev
+Joy17=invnext
+Axis1Plus=+strafe_right
+Axis1Minus=+strafe_left
+Axis2Plus=+move_backward
+Axis2Minus=+move_forward
+Axis3Plus=+turn_right
+Axis3Minus=+turn_left
+Axis4Plus=+look_down
+Axis4Minus=+look_up
 
 [.DoubleBindings]
 
 [.AutomapBindings]
+Joy9=+shrink_screen
+Joy10=+enlarge_Screen
+Joy13=togglefollow
+Axis2Minus=+am_panup
+Axis2Plus=+am_pandown
+Axis1Minus=+am_panleft
+Axis1Plus=+am_panright
 
-[Duke.AutoExec]
+[.AutoExec]
 Path=/storage/.config/raze/autoexec.cfg
 
 [Duke.Player]
@@ -577,7 +608,6 @@ Joy10=pause
 Joy11=weapprev
 Joy12=weapnext
 Joy13=togglemap
-Joy14=menu_main
 Joy15=toggle cl_autorun
 Joy16=centerview
 
@@ -755,7 +785,6 @@ Joy5=+run
 Joy6=+fire
 Joy7=+crouch
 Joy8=+jump
-Joy14=menu_main
 Joy16=centerview
 Joy1=+open
 Joy3=turnaround
@@ -772,8 +801,8 @@ Joy5=+shrink_screen
 Joy6=+enlarge_Screen
 
 [Joy:JS:0]
-Axis0deadzone=0.200001
-Axis1deadzone=0.200001
+Axis0deadzone=0.300001
+Axis1deadzone=0.300001
 Axis2deadzone=0.300001
 Axis2scale=0.7
 Axis2map=0


### PR DESCRIPTION
Update raze.ini default bindings for rg552/503 to fix in-game joystick controls for .build engine
