### PR TITLE
Sort GRP files in build game scanner

### DIFF
--- a/packages/games/emulators/raze/config/common/games/_Scan Build Engine Games.sh
+++ b/packages/games/emulators/raze/config/common/games/_Scan Build Engine Games.sh
@@ -36,6 +36,13 @@ for i in "${!SUPPORTED_GRP[@]}"; do
 	find_names+=("${SUPPORTED_GRP[$i]}")
 done
 grp_files=$(find "${BUILDENGINEPATH}" -mindepth 1 -type f \( "${find_names[@]}" \))
+# This is a hack that ensures any expansion GRP file gets written out as a
+# build file last. For example, VACATION.GRP is an expansion for DUKE3D.GRP.
+# For the expansion to work, both GRP files must be present, but the expansion
+# GRP must be passed to the Raze engine. It just so happens that all of the
+# expansion GRP files are named alphabetically later than base game GRP files,
+# meaning we can get by with a simple lexical sort before processing.
+grp_files=$(echo "${grp_files}" | sort)
 echo "Adding games..." >/dev/console
 while read -r grp_file; do
 	abs_path=$(dirname "${grp_file}")


### PR DESCRIPTION
## Description

Sort GRP files in build game scanner so expansions are passed to the Raze engine when games require multiple GRP files

Fixes issue where a properly configured Duke expansion path ends up generating a .build file that launches vanilla Duke instead of the expansion.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

I tested this with some dummy files named alphabetically similarly to the real files & ensured without the fix DUKE3D.GRP is selected, and after the fix VACATION.GRP is selected.

I also had some help from a user, (at)ravensvoice in Discord testing with real expansion files -- since I don't own those games.

**Test Configuration**:
* Build OS name and version: JELOS
* Docker (Y/N): N (Tested the change to the script alone)
* JELOS Branch: N/A
* Any additional information that may be useful:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
