### PR TITLE
Doom scan integrate

### DIFF
--- a/packages/games/tools/doomscan/package.mk
+++ b/packages/games/tools/doomscan/package.mk
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2022-present travis134
+
+PKG_NAME="doomscan"
+PKG_VERSION="3bba0abe4dd13c7c77f6d5e355a8e70ee650720a"
+PKG_ARCH="any"
+PKG_SITE="https://github.com/travis134/doomscan"
+PKG_URL="${PKG_SITE}.git"
+PKG_PRIORITY="optional"
+PKG_SECTION="tools"
+PKG_SHORTDESC="Creates .doom files based on user selection of WAD and PK3 files."
+PKG_TOOLCHAIN="manual"
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/share
+  cp -r ${PKG_BUILD}/doomscan ${INSTALL}/usr/share
+  cp "${PKG_BUILD}/_Scan Doom Games.sh" ${INSTALL}/usr/share/doomscan
+  chmod 0755 ${INSTALL}/usr/share/doomscan "${INSTALL}/usr/share/doomscan/_Scan Doom Games.sh"
+
+  mkdir -p ${INSTALL}/usr/lib/autostart/common
+  cp ${PKG_DIR}/sources/autostart/common/* ${INSTALL}/usr/lib/autostart/common
+}

--- a/packages/games/tools/doomscan/sources/autostart/common/011-doomscan
+++ b/packages/games/tools/doomscan/sources/autostart/common/011-doomscan
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2022-present travis134
+
+#If doomscan does not exist copy doomscan folder to roms/doom
+if [ ! -e "/storage/roms/doom/doomscan" ]; then
+	cp -r /usr/share/doomscan /storage/roms/doom
+	chmod +x /storage/roms/doom/doomscan -R
+	mv "/storage/roms/doom/doomscan/_Scan Doom Games.sh" "/storage/roms/doom/_Scan Doom Games.sh"
+fi

--- a/packages/themes/thememaster/sources/autostart/common/011-thememaster
+++ b/packages/themes/thememaster/sources/autostart/common/011-thememaster
@@ -11,7 +11,7 @@ then
 	mv /storage/roms/ports/ThemeMaster/ThemeMaster.sh /storage/roms/ports/ThemeMaster.sh
 fi
 
-#Check if gamelist.xml exists, if not create gamelist.xml to hide portmaster by default.
+#Check if gamelist.xml exists, if not create gamelist.xml to hide ThemeMaster by default.
 if [[ ! -e /storage/roms/ports/gamelist.xml ]];
 then
 touch /storage/roms/ports/gamelist.xml
@@ -26,7 +26,7 @@ touch /storage/roms/ports/gamelist.xml
 </gameList>
 EOF
 
-#If gamelist.xml exists and no portmaster entry exists then add portmaster entry & set to hidden.
+#If gamelist.xml exists and no ThemeMaster entry exists then add ThemeMaster entry & set to hidden.
 else
 if ! grep -R "ThemeMaster" "/storage/roms/ports/gamelist.xml"
 then

--- a/packages/ui/emulationstation/config/common/es_systems.cfg
+++ b/packages/ui/emulationstation/config/common/es_systems.cfg
@@ -2212,7 +2212,7 @@
     <release>1993</release>
     <hardware>game engine</hardware>
     <path>/storage/roms/doom</path>
-    <extension>.doom</extension>
+    <extension>.sh .SH .doom</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>pc</platform>
     <theme>doom</theme>

--- a/packages/virtual/gamesupport/package.mk
+++ b/packages/virtual/gamesupport/package.mk
@@ -7,7 +7,7 @@ PKG_SITE="www.jelos.org"
 PKG_SECTION="virtual"
 PKG_LONGDESC="Game support software metapackage."
 
-PKG_GAMESUPPORT="sixaxis rg351p-js2xbox gptokeyb jstest-sdl gamecontrollerdb jelosaddons sdljoytest"
+PKG_GAMESUPPORT="sixaxis rg351p-js2xbox gptokeyb jstest-sdl gamecontrollerdb jelosaddons sdljoytest doomscan"
 
 PKG_DEPENDS_TARGET="${PKG_GAMESUPPORT}"
 


### PR DESCRIPTION
# Pull Request Template

## Description

Add new package for doomscan -- a script that makes it easier for users to set up .doom files which specify the wads and mod (pk3) files to be used by whichever doom engine (lzdoom/gzdoom) the user prefers.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Used docker to build and create an image, loaded on my device, and ensured that the scan script appears under the Doom top-level menu, and it functions correctly. I'll add a video in a follow up comment.

**Test Configuration**:
* Build OS name and version: JELOS
* Docker (Y/N): Y
* JELOS Branch: dev / this branch

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
