### PR TITLE
Bump system theme to pick up Quake artwork

### DIFF
--- a/packages/themes/es-theme-art-book-next/package.mk
+++ b/packages/themes/es-theme-art-book-next/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2021 Fewtarius
 
 PKG_NAME="es-theme-art-book-next"
-PKG_VERSION="e35fdfda8315a88d90a8eba1fc342c0b2bedee7c"
+PKG_VERSION="50c82f871293c07e9feeb97c3b80bb2f290ba670"
 PKG_ARCH="any"
 PKG_LICENSE="CUSTOM"
 PKG_SITE="https://github.com/anthonycaccese/es-theme-art-book-next"


### PR DESCRIPTION
## Description

Bump system theme version to pick up Quake artwork, contributed in https://github.com/anthonycaccese/art-book-next-batocera/pull/5

## Type of change

None of the options were applicable -- this is more maintenance / ktlo.

## How Has This Been Tested Locally?

Running a docker build now to test on my device-- but this is a pretty low-risk change.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
