### PR TITLE
Fix legacy search paths for Doom ports

### DIFF
--- a/packages/games/emulators/gzdoom/config/RG351MP/gzdoom.ini
+++ b/packages/games/emulators/gzdoom/config/RG351MP/gzdoom.ini
@@ -4,40 +4,40 @@
 [IWADSearch.Directories]
 Path=.
 Path=$DOOMWADDIR
-Path=/storage/.config/distribution/gzdoom
+Path=/storage/.config/game/gzdoom
 Path=/storage/roms/doom
 
 # These are the directories to search for wads added with the -file
 # command line parameter, if they cannot be found with the path
 # as-is. Layout is the same as for IWADSearch.Directories
 [FileSearch.Directories]
-Path=/storage/.config/distribution/gzdoom
+Path=/storage/.config/game/gzdoom
 Path=/storage/roms/doom
 Path=$DOOMWADDIR
 
 # These are the directories to search for soundfonts that let listed in the menu.
 # Layout is the same as for IWADSearch.Directories
 [SoundfontSearch.Directories]
-Path=/storage/.config/distribution/gzdoom/soundfonts
-Path=/storage/.config/distribution/gzdoom/fm_banks
+Path=/storage/.config/game/gzdoom/soundfonts
+Path=/storage/.config/game/gzdoom/fm_banks
 
 # Files to automatically execute when running the corresponding game.
 # Each file should be on its own line, preceded by Path=
 
 [Doom.AutoExec]
-Path=/storage/.config/distribution/gzdoom/autoexec.cfg
+Path=/storage/.config/game/gzdoom/autoexec.cfg
 
 [Heretic.AutoExec]
-Path=/storage/.config/distribution/gzdoom/autoexec.cfg
+Path=/storage/.config/game/gzdoom/autoexec.cfg
 
 [Hexen.AutoExec]
-Path=/storage/.config/distribution/gzdoom/autoexec.cfg
+Path=/storage/.config/game/gzdoom/autoexec.cfg
 
 [Strife.AutoExec]
-Path=/storage/.config/distribution/gzdoom/autoexec.cfg
+Path=/storage/.config/game/gzdoom/autoexec.cfg
 
 [Chex.AutoExec]
-Path=/storage/.config/distribution/gzdoom/autoexec.cfg
+Path=/storage/.config/game/gzdoom/autoexec.cfg
 
 # WAD files to always load. These are loaded after the IWAD but before
 # any files added with -file. Place each file on its own line, preceded

--- a/packages/games/emulators/gzdoom/config/RG351P/gzdoom.ini
+++ b/packages/games/emulators/gzdoom/config/RG351P/gzdoom.ini
@@ -4,40 +4,40 @@
 [IWADSearch.Directories]
 Path=.
 Path=$DOOMWADDIR
-Path=/storage/.config/distribution/gzdoom
+Path=/storage/.config/game/gzdoom
 Path=/storage/roms/doom
 
 # These are the directories to search for wads added with the -file
 # command line parameter, if they cannot be found with the path
 # as-is. Layout is the same as for IWADSearch.Directories
 [FileSearch.Directories]
-Path=/storage/.config/distribution/gzdoom
+Path=/storage/.config/game/gzdoom
 Path=/storage/roms/doom
 Path=$DOOMWADDIR
 
 # These are the directories to search for soundfonts that let listed in the menu.
 # Layout is the same as for IWADSearch.Directories
 [SoundfontSearch.Directories]
-Path=/storage/.config/distribution/gzdoom/soundfonts
-Path=/storage/.config/distribution/gzdoom/fm_banks
+Path=/storage/.config/game/gzdoom/soundfonts
+Path=/storage/.config/game/gzdoom/fm_banks
 
 # Files to automatically execute when running the corresponding game.
 # Each file should be on its own line, preceded by Path=
 
 [Doom.AutoExec]
-Path=/storage/.config/distribution/gzdoom/autoexec.cfg
+Path=/storage/.config/game/gzdoom/autoexec.cfg
 
 [Heretic.AutoExec]
-Path=/storage/.config/distribution/gzdoom/autoexec.cfg
+Path=/storage/.config/game/gzdoom/autoexec.cfg
 
 [Hexen.AutoExec]
-Path=/storage/.config/distribution/gzdoom/autoexec.cfg
+Path=/storage/.config/game/gzdoom/autoexec.cfg
 
 [Strife.AutoExec]
-Path=/storage/.config/distribution/gzdoom/autoexec.cfg
+Path=/storage/.config/game/gzdoom/autoexec.cfg
 
 [Chex.AutoExec]
-Path=/storage/.config/distribution/gzdoom/autoexec.cfg
+Path=/storage/.config/game/gzdoom/autoexec.cfg
 
 # WAD files to always load. These are loaded after the IWAD but before
 # any files added with -file. Place each file on its own line, preceded


### PR DESCRIPTION
## Description

Fixes issue where doom ports won't load on some devices because device-specific configs point to out-of-date "distribution" paths.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

I haven't tested this because I don't have a device that would have been impacted by the bad paths. But it seems low risk -- it's already broken and this fix can easily be reverted.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
