### PR TITLE
Raze/gzdoom/lzdoom menu patches

### DIFF
--- a/packages/games/emulators/gzdoom/patches/RG503/01-fixes.patch
+++ b/packages/games/emulators/gzdoom/patches/RG503/01-fixes.patch
@@ -1,0 +1,49 @@
+diff --git a/src/common/menu/menu.cpp b/src/common/menu/menu.cpp
+index 4532dae1d..8c394dc79 100644
+--- a/src/common/menu/menu.cpp
++++ b/src/common/menu/menu.cpp
+@@ -702,7 +702,7 @@ bool M_Responder (event_t *ev)
+ 				mkey = MKEY_Back;
+ 				break;
+ 
+-			case KEY_JOY4:
++			case KEY_JOY3:
+ 			case KEY_PAD_X:
+ 				mkey = MKEY_Clear;
+ 				break;
+@@ -721,7 +721,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_UP:
+ 			case KEY_JOYAXIS2MINUS:
+ 			case KEY_JOYPOV1_UP:
+-			case KEY_JOY9:
++			case KEY_JOY14:
+ 				mkey = MKEY_Up;
+ 				break;
+ 
+@@ -729,7 +729,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_DOWN:
+ 			case KEY_JOYAXIS2PLUS:
+ 			case KEY_JOYPOV1_DOWN:
+-			case KEY_JOY10:
++			case KEY_JOY15:
+ 				mkey = MKEY_Down;
+ 				break;
+ 
+@@ -737,7 +737,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_LEFT:
+ 			case KEY_JOYAXIS1MINUS:
+ 			case KEY_JOYPOV1_LEFT:
+-			case KEY_JOY11:
++			case KEY_JOY16:
+ 				mkey = MKEY_Left;
+ 				break;
+ 
+@@ -745,7 +745,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_RIGHT:
+ 			case KEY_JOYAXIS1PLUS:
+ 			case KEY_JOYPOV1_RIGHT:
+-			case KEY_JOY12:
++			case KEY_JOY17:
+ 				mkey = MKEY_Right;
+ 				break;
+ 			}

--- a/packages/games/emulators/gzdoom/patches/RG552/01-fixes.patch
+++ b/packages/games/emulators/gzdoom/patches/RG552/01-fixes.patch
@@ -1,0 +1,49 @@
+diff --git a/src/common/menu/menu.cpp b/src/common/menu/menu.cpp
+index 4532dae1d..8c394dc79 100644
+--- a/src/common/menu/menu.cpp
++++ b/src/common/menu/menu.cpp
+@@ -702,7 +702,7 @@ bool M_Responder (event_t *ev)
+ 				mkey = MKEY_Back;
+ 				break;
+ 
+-			case KEY_JOY4:
++			case KEY_JOY3:
+ 			case KEY_PAD_X:
+ 				mkey = MKEY_Clear;
+ 				break;
+@@ -721,7 +721,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_UP:
+ 			case KEY_JOYAXIS2MINUS:
+ 			case KEY_JOYPOV1_UP:
+-			case KEY_JOY9:
++			case KEY_JOY14:
+ 				mkey = MKEY_Up;
+ 				break;
+ 
+@@ -729,7 +729,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_DOWN:
+ 			case KEY_JOYAXIS2PLUS:
+ 			case KEY_JOYPOV1_DOWN:
+-			case KEY_JOY10:
++			case KEY_JOY15:
+ 				mkey = MKEY_Down;
+ 				break;
+ 
+@@ -737,7 +737,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_LEFT:
+ 			case KEY_JOYAXIS1MINUS:
+ 			case KEY_JOYPOV1_LEFT:
+-			case KEY_JOY11:
++			case KEY_JOY16:
+ 				mkey = MKEY_Left;
+ 				break;
+ 
+@@ -745,7 +745,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_RIGHT:
+ 			case KEY_JOYAXIS1PLUS:
+ 			case KEY_JOYPOV1_RIGHT:
+-			case KEY_JOY12:
++			case KEY_JOY17:
+ 				mkey = MKEY_Right;
+ 				break;
+ 			}

--- a/packages/games/emulators/lzdoom/patches/RG503/001-fixes.patch
+++ b/packages/games/emulators/lzdoom/patches/RG503/001-fixes.patch
@@ -1,0 +1,61 @@
+diff --git a/src/menu/menu.cpp b/src/menu/menu.cpp
+index 2af6616fa0..cf6ff999d1 100644
+--- a/src/menu/menu.cpp
++++ b/src/menu/menu.cpp
+@@ -666,17 +666,17 @@ bool M_Responder (event_t *ev)
+ 			ch = ev->data1;
+ 			switch (ch)
+ 			{
+-			case KEY_JOY2:
++			case KEY_JOY1: //B button on rg552/rg503
+ 			case KEY_PAD_A:
+ 				mkey = MKEY_Back;
+ 				break;
+ 
+-			case KEY_JOY1:
++			case KEY_JOY2: //A button on rg552/rg503
+ 			case KEY_PAD_B:
+ 				mkey = MKEY_Enter;
+ 				break;
+ 
+-			case KEY_JOY4:
++			case KEY_JOY3: //X button on rg552/rg503
+ 			case KEY_PAD_X:
+ 				mkey = MKEY_Clear;
+ 				break;
+@@ -695,7 +695,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_UP:
+ 			case KEY_JOYAXIS2MINUS:
+ 			case KEY_JOYPOV1_UP:
+-			case KEY_JOY9:
++			case KEY_JOY14: //Dpad up on rg552/rg503
+ 				mkey = MKEY_Up;
+ 				break;
+ 
+@@ -703,7 +703,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_DOWN:
+ 			case KEY_JOYAXIS2PLUS:
+ 			case KEY_JOYPOV1_DOWN:
+-			case KEY_JOY10:
++			case KEY_JOY15: //Dpad down on rg552/rg503
+ 				mkey = MKEY_Down;
+ 				break;
+ 
+@@ -711,7 +711,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_LEFT:
+ 			case KEY_JOYAXIS1MINUS:
+ 			case KEY_JOYPOV1_LEFT:
+-			case KEY_JOY11:
++			case KEY_JOY16: //Dpad left on rg552/rg503
+ 				mkey = MKEY_Left;
+ 				break;
+ 
+@@ -719,7 +719,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_RIGHT:
+ 			case KEY_JOYAXIS1PLUS:
+ 			case KEY_JOYPOV1_RIGHT:
+-			case KEY_JOY12:
++			case KEY_JOY17: //Dpad right on rg552/rg503
+ 				mkey = MKEY_Right;
+ 				break;
+ 			}

--- a/packages/games/emulators/lzdoom/patches/RG552/001-fixes.patch
+++ b/packages/games/emulators/lzdoom/patches/RG552/001-fixes.patch
@@ -1,0 +1,61 @@
+diff --git a/src/menu/menu.cpp b/src/menu/menu.cpp
+index 2af6616fa0..cf6ff999d1 100644
+--- a/src/menu/menu.cpp
++++ b/src/menu/menu.cpp
+@@ -666,17 +666,17 @@ bool M_Responder (event_t *ev)
+ 			ch = ev->data1;
+ 			switch (ch)
+ 			{
+-			case KEY_JOY2:
++			case KEY_JOY1: //B button on rg552/rg503
+ 			case KEY_PAD_A:
+ 				mkey = MKEY_Back;
+ 				break;
+ 
+-			case KEY_JOY1:
++			case KEY_JOY2: //A button on rg552/rg503
+ 			case KEY_PAD_B:
+ 				mkey = MKEY_Enter;
+ 				break;
+ 
+-			case KEY_JOY4:
++			case KEY_JOY3: //X button on rg552/rg503
+ 			case KEY_PAD_X:
+ 				mkey = MKEY_Clear;
+ 				break;
+@@ -695,7 +695,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_UP:
+ 			case KEY_JOYAXIS2MINUS:
+ 			case KEY_JOYPOV1_UP:
+-			case KEY_JOY9:
++			case KEY_JOY14: //Dpad up on rg552/rg503
+ 				mkey = MKEY_Up;
+ 				break;
+ 
+@@ -703,7 +703,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_DOWN:
+ 			case KEY_JOYAXIS2PLUS:
+ 			case KEY_JOYPOV1_DOWN:
+-			case KEY_JOY10:
++			case KEY_JOY15: //Dpad down on rg552/rg503
+ 				mkey = MKEY_Down;
+ 				break;
+ 
+@@ -711,7 +711,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_LEFT:
+ 			case KEY_JOYAXIS1MINUS:
+ 			case KEY_JOYPOV1_LEFT:
+-			case KEY_JOY11:
++			case KEY_JOY16: //Dpad left on rg552/rg503
+ 				mkey = MKEY_Left;
+ 				break;
+ 
+@@ -719,7 +719,7 @@ bool M_Responder (event_t *ev)
+ 			case KEY_PAD_LTHUMB_RIGHT:
+ 			case KEY_JOYAXIS1PLUS:
+ 			case KEY_JOYPOV1_RIGHT:
+-			case KEY_JOY12:
++			case KEY_JOY17: //Dpad right on rg552/rg503
+ 				mkey = MKEY_Right;
+ 				break;
+ 			}

--- a/packages/games/emulators/raze/patches/02-fixes.patch
+++ b/packages/games/emulators/raze/patches/02-fixes.patch
@@ -1,0 +1,61 @@
+diff --git a/source/common/menu/menu.cpp b/source/common/menu/menu.cpp
+index 89017d67b..8c84c0679 100644
+--- a/source/common/menu/menu.cpp
++++ b/source/common/menu/menu.cpp
+@@ -692,20 +692,20 @@ bool M_Responder (event_t *ev)
+ 			ch = ev->data1;
+ 			switch (ch)
+ 			{
+-			case KEY_JOY1:
+-			case KEY_JOY3:
++			case KEY_JOY2:
++			case KEY_JOY4:
+ 			case KEY_JOY15:
+ 			case KEY_PAD_A:
+ 				mkey = MKEY_Enter;
+ 				break;
+ 
+-			case KEY_JOY2:
++			case KEY_JOY1:
+ 			case KEY_JOY14:
+ 			case KEY_PAD_B:
+ 				mkey = MKEY_Back;
+ 				break;
+ 
+-			case KEY_JOY4:
++			case KEY_JOY3:
+ 			case KEY_PAD_X:
+ 				mkey = MKEY_Clear;
+ 				break;
+@@ -720,6 +720,7 @@ bool M_Responder (event_t *ev)
+ 				mkey = MKEY_PageDown;
+ 				break;
+ 
++			case KEY_JOY14:
+ 			case KEY_PAD_DPAD_UP:
+ 			case KEY_PAD_LTHUMB_UP:
+ 			case KEY_JOYAXIS2MINUS:
+@@ -727,6 +728,7 @@ bool M_Responder (event_t *ev)
+ 				mkey = MKEY_Up;
+ 				break;
+ 
++			case KEY_JOY15:
+ 			case KEY_PAD_DPAD_DOWN:
+ 			case KEY_PAD_LTHUMB_DOWN:
+ 			case KEY_JOYAXIS2PLUS:
+@@ -734,6 +736,7 @@ bool M_Responder (event_t *ev)
+ 				mkey = MKEY_Down;
+ 				break;
+ 
++			case KEY_JOY16:
+ 			case KEY_PAD_DPAD_LEFT:
+ 			case KEY_PAD_LTHUMB_LEFT:
+ 			case KEY_JOYAXIS1MINUS:
+@@ -741,6 +744,7 @@ bool M_Responder (event_t *ev)
+ 				mkey = MKEY_Left;
+ 				break;
+ 
++			case KEY_JOY17:
+ 			case KEY_PAD_DPAD_RIGHT:
+ 			case KEY_PAD_LTHUMB_RIGHT:
+ 			case KEY_JOYAXIS1PLUS:


### PR DESCRIPTION
Create patch files for raze/gzdoom/lzdoom to

Swap A/B buttons for confirm/cancel (gzdoom is already correct)
Set X button for clear (instead of Y button)
Assign dpad for menu control (suitable for rg552/rg503)