### PR TITLE
Patch to rename RG552 battery in kernel driver

### DIFF
--- a/projects/Rockchip/packages/linux/patches/RG552/003-rename-battery.patch
+++ b/projects/Rockchip/packages/linux/patches/RG552/003-rename-battery.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/power/supply/cw2015_battery.c b/drivers/power/supply/cw2015_battery.c
+index 0146f1bfc29b..e742efd67f74 100644
+--- a/drivers/power/supply/cw2015_battery.c
++++ b/drivers/power/supply/cw2015_battery.c
+@@ -546,7 +546,7 @@ static enum power_supply_property cw_battery_properties[] = {
+ };
+ 
+ static const struct power_supply_desc cw2015_bat_desc = {
+-	.name		= "cw2015-battery",
++	.name		= "battery",
+ 	.type		= POWER_SUPPLY_TYPE_BATTERY,
+ 	.properties	= cw_battery_properties,
+ 	.num_properties	= ARRAY_SIZE(cw_battery_properties),


### PR DESCRIPTION
*Renames battery name in kernel driver to be inline with Jelos.

Confirmed that battery info now correctly shows in jelos info but battery icon not showing in ES