### PR TITLE
cleanup duckstation libretro

### DIFF
--- a/packages/games/libretro/duckstation/package.mk
+++ b/packages/games/libretro/duckstation/package.mk
@@ -3,17 +3,22 @@
 # Copyright (C) 2022-present BrooksyTech (https://github.com/brooksytech)
 
 PKG_NAME="duckstation"
-PKG_VERSION="0162b33835e09984ab9dca6f0b1295343e2dcbc3"
-PKG_SHA256="2e419f6a57d4135a548d025252b7cc293204c0c0f80af49b9d72bf1c7c9d0634"
-PKG_ARCH="aarch64"
+PKG_VERSION="24c373245ebdab946f11627520edea76e1f23b8e"
+PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
-PKG_SITE="https://github.com/brooksytech/duckstation-libretro"
+PKG_SITE="https://github.com/stenzek/duckstation"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain SDL2 nasm:host pulseaudio openssl libidn2 nghttp2 zlib curl libevdev"
 PKG_SECTION="libretro"
 PKG_SHORTDESC="DuckStation - PlayStation 1, aka. PSX Emulator"
 PKG_TOOLCHAIN="cmake"
 PKG_BUILD_FLAGS="-lto"
+
+PKG_CMAKE_OPTS_TARGET+=" -DBUILD_SDL_FRONTEND=OFF \
+                         -DBUILD_QT_FRONTEND=OFF \
+                         -DBUILD_LIBRETRO_CORE=ON \
+			 -DENABLE_DISCORD_PRESENCE=OFF \
+			 -DUSE_X11=OFF"
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libretro

--- a/packages/games/libretro/duckstation/patches/000-hide-cache-dir.patch
+++ b/packages/games/libretro/duckstation/patches/000-hide-cache-dir.patch
@@ -1,0 +1,16 @@
+diff --git a/src/duckstation-libretro/libretro_host_interface.cpp b/src/duckstation-libretro/libretro_host_interface.cpp
+index bb5f647e..35ef7f4a 100644
+--- a/src/duckstation-libretro/libretro_host_interface.cpp
++++ b/src/duckstation-libretro/libretro_host_interface.cpp
+@@ -175,9 +175,9 @@ std::string LibretroHostInterface::GetShaderCacheBasePath() const
+     }
+   }
+
+-  // Use a directory named "duckstation_cache" in the save/system directory.
++  // Use a directory named ".duckstation_cache" in the save/system directory.
+   std::string shader_cache_path = StringUtil::StdStringFromFormat(
+-    "%s" FS_OSPATH_SEPARATOR_STR "duckstation_cache" FS_OSPATH_SEPARATOR_STR, save_directory_ptr);
++    "%s" FS_OSPATH_SEPARATOR_STR ".duckstation_cache" FS_OSPATH_SEPARATOR_STR, save_directory_ptr);
+   if (!FileSystem::DirectoryExists(shader_cache_path.c_str()) &&
+       !FileSystem::CreateDirectory(shader_cache_path.c_str(), false))
+   {


### PR DESCRIPTION
remove this from my local repo and point back to the main duckstation repo.

Its pointed at the last commit before libretro was removed. 