### PR TITLE
Hide wayland checkerboard in RA

### DIFF
--- a/packages/games/emulators/retroarch/patches/0009-hide-wayland-checkerboard.patch
+++ b/packages/games/emulators/retroarch/patches/0009-hide-wayland-checkerboard.patch
@@ -1,0 +1,13 @@
+diff --git a/gfx/common/wayland_common.c b/gfx/common/wayland_common.c
+index 03cb91ba49..15356f8002 100644
+--- a/gfx/common/wayland_common.c
++++ b/gfx/common/wayland_common.c
+@@ -442,7 +442,7 @@ static bool draw_splash_screen(gfx_ctx_wayland_data_t *wl)
+ 
+    shm_buffer_paint_checkerboard(buffer, wl->width,
+       wl->height, wl->buffer_scale,
+-      16, 0xffbcbcbc, 0xff8e8e8e);
++      16, 0xff000000, 0xff000000);
+ 
+    wl_surface_attach(wl->surface, buffer->wl_buffer, 0, 0);
+    wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);


### PR DESCRIPTION
This will hide the wayland checkerboard when launching retro arch games. Just sets both colors to black. 

Referenced here:
https://github.com/libretro/RetroArch/blob/da13fb0f48acce70b137b28597079e40e4d569a7/gfx/common/wayland_common.c#L443