### PR TITLE
add brightness hotkeys L3 + L1 and L3 + R1 for RG351P

### DIFF
--- a/projects/Rockchip/devices/RG351P/filesystem/etc/profile.d/98-jslisten
+++ b/projects/Rockchip/devices/RG351P/filesystem/etc/profile.d/98-jslisten
@@ -1,0 +1,80 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
+
+. /etc/os-release
+
+export PATH="$PATH:/usr/local/bin:/usr/bin:/storage/bin"
+
+if [ -e "/storage/.config/jslisten_hotkeys" ]
+then
+  source /storage/.config/jslisten_hotkeys
+else
+  source /usr/config/jslisten_hotkeys
+fi
+
+jslisten() {
+        JSLISTENCONF="/storage/.config/system/configs/jslisten.cfg"
+        if [ "$1" == "set" ]
+        then
+                systemctl stop jslisten
+		rm /storage/.config/system/configs/jslisten.cfg
+
+                if [ "$2" == "mpv" ]
+                then
+
+                        cat <<EOF >${JSLISTENCONF}
+[Pause]
+program="/usr/bin/manage_mpv.sh pause"
+button1=${BTN_PAUSE}
+
+[Exit]
+program="/usr/bin/manage_mpv.sh quit"
+button1=${BTN_QUIT_HOTKEY}
+button2=${BTN_QUIT_SELECT}
+
+[Skip5s]
+program="/usr/bin/manage_mpv.sh skip5s"
+button1=${BTN_SKIP5S}
+
+[Back5s]
+program="/usr/bin/manage_mpv.sh back5s"
+button1=${BTN_BACK5S}
+
+[Skip60s]
+program="/usr/bin/manage_mpv.sh skip60s"
+button1=${BTN_SKIP60S}
+
+[Back60s]
+program="/usr/bin/manage_mpv.sh back60s"
+button1=${BTN_BACK60S}
+
+EOF
+		fi
+
+                cat <<EOF >>${JSLISTENCONF}
+[KillAll]
+program="/usr/bin/killall ${2}"
+button1=${BTN_KILL_HOTKEY}
+button2=${BTN_KILL_SELECTA}
+button3=${BTN_KILL_SELECTB}
+
+[BrightnessUp]
+program="/usr/bin/brightness up"
+button1=8
+button2=5
+
+[BrightnessDown]
+program="/usr/bin/brightness down"
+button1=8
+button2=4
+EOF
+                systemctl start jslisten
+        elif [ "$1" == "stop" ]
+        then
+                systemctl stop jslisten
+        elif [ "$1" == "start" ]
+        then
+                systemctl start jslisten
+        fi
+}

--- a/projects/Rockchip/devices/RG351P/usr/lib/systemd/system/jslistenresume.service
+++ b/projects/Rockchip/devices/RG351P/usr/lib/systemd/system/jslistenresume.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Delay and restart jslisten after resume so it correctly polls the controls
+After=suspend.target
+
+[Service]
+Type=oneshot
+ExecStart=-nohup sh -c 'sleep 4; systemctl restart jslisten'
+
+[Install]
+WantedBy=suspend.target


### PR DESCRIPTION
this adds jslisten brightness hotkeys only for the RG351P.

- 98-jslisten and jslistenresume.service are placed into the RG351 projects folder in their respective filepaths so that they only are applied to the RG351P.
- jslistenresume.service is a oneshot after resuming from sleep: has a 4 second delay, then restarts the jslisten service after resuming from sleep so that jslisten hotkeys still function out of sleep.


i could not get the device.config buttons or other variables to work with jslisten, and had still to resort to using button1=8;button2=4/5 to set the hotkey buttons. i've tested these changes on my RG351P.