### PR TITLE
post-game cloud backup, and rclone fix on x86_64

### DIFF
--- a/packages/games/emulators/drastic/scripts/start_drastic.sh
+++ b/packages/games/emulators/drastic/scripts/start_drastic.sh
@@ -9,7 +9,7 @@ if [ ! -d "/storage/.config/drastic/aarch64/drastic" ]; then
   echo -e "=> ${OS_NAME} DRASTIC INSTALLATION"
   echo -e "\nChecking for internet connection..."
 
-  INETUP=$(ping -c1 -w1 www.google.com >/dev/null 2>&1)
+  INETUP=$(/usr/bin/amionline >/dev/null 2>&1)
   if [ $? == 0 ]
   then
     mkdir -p "/storage/.config/drastic/aarch64"

--- a/packages/jelos/config/system/configs/system.cfg
+++ b/packages/jelos/config/system/configs/system.cfg
@@ -44,6 +44,7 @@ c16.integerscale=1
 c16.rgascale=0
 c64.integerscale=1
 c64.rgascale=0
+cloud.backup=0
 colecovision.integerscale=1
 colecovision.ratio=4/3
 colecovision.rgascale=0

--- a/packages/jelos/sources/scripts/amionline
+++ b/packages/jelos/sources/scripts/amionline
@@ -1,0 +1,20 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2020-present Fewtarius
+
+ip route | awk '/default/ {print $3}' >/dev/null 2>&1
+if [ ! $? = 0 ]
+then
+  echo false
+  exit 1
+else
+  ping www.google.com -c1 -w1 >/dev/null 2>&1
+  if [ ! $? = 0 ]
+  then
+    echo false
+    exit 1
+  else
+    echo true
+    exit 0
+  fi
+fi

--- a/packages/jelos/sources/scripts/runemu.sh
+++ b/packages/jelos/sources/scripts/runemu.sh
@@ -477,6 +477,18 @@ then
 	fi
 fi
 
+### Backup save games
+CLOUD_BACKUP=$(get_setting "cloud.backup")
+if [ "${CLOUD_BACKUP}" = "1" ]
+then
+  INETUP=$(/usr/bin/amionline >/dev/null 2>&1)
+  if [ $? == 0 ]
+  then
+    log "backup saves to the cloud."
+    run /usr/bin/cloud_backup
+  fi
+fi
+
 $VERBOSE && log "Checking errors: ${ret_error} "
 if [ "${ret_error}" == "0" ]
 then

--- a/packages/sysutils/rclone/package.mk
+++ b/packages/sysutils/rclone/package.mk
@@ -3,16 +3,39 @@
 # Copyright (C) 2022-present Fewtarius
 
 PKG_NAME="rclone"
-PKG_VERSION="1.58.0"
-PKG_URL="https://downloads.rclone.org/v${PKG_VERSION}/rclone-v${PKG_VERSION}-linux-arm64.zip"
+PKG_VERSION="1.60.0"
 PKG_DEPENDS_TARGET="toolchain fuse rsync"
 PKG_SECTION="tools"
 PKG_SHORTDESC="rsync for cloud storage"
 PKG_TOOLCHAIN="manual"
 
+case ${ARCH} in
+    aarch64)
+      RCLONE_ARCH="arm64"
+    ;;
+    *)
+      RCLONE_ARCH="amd64"
+    ;;
+esac
+
+PKG_URL="https://downloads.rclone.org/v${PKG_VERSION}/rclone-v${PKG_VERSION}-linux-${RCLONE_ARCH}.zip"
+PKG_RCLONE="rclone-v${PKG_VERSION}-linux-${RCLONE_ARCH}/rclone"
+
 pre_unpack() {
-  unzip sources/rclone/rclone-${PKG_VERSION}.zip -d ${PKG_BUILD}/
+  # Will need to figure out why unpack isn't handling this correctly.
+  cd sources/rclone
+  if [ ! -e "rclone-${PKG_VERSION}-${RCLONE_ARCH}.zip" ]
+  then
+    mv rclone-${PKG_VERSION}.zip rclone-${PKG_VERSION}-${RCLONE_ARCH}.zip
+  fi
 }
+
+unpack() {
+  unzip rclone-${PKG_VERSION}-${RCLONE_ARCH}.zip -d ${PKG_BUILD}/
+  rm -f rclone-${PKG_VERSION}.*
+  cd -
+}
+
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin/
@@ -20,7 +43,7 @@ makeinstall_target() {
   cp ${PKG_DIR}/sources/rclonectl ${INSTALL}/usr/bin/
   cp ${PKG_DIR}/sources/cloud_backup ${INSTALL}/usr/bin/
   cp ${PKG_DIR}/sources/cloud_restore ${INSTALL}/usr/bin/
-  cp ${PKG_BUILD}/rclone-v${PKG_VERSION}-linux-arm64/rclone ${INSTALL}/usr/bin/
+  cp ${PKG_BUILD}/${PKG_RCLONE} ${INSTALL}/usr/bin/
   chmod 0755 ${INSTALL}/usr/bin/*
   cp ${PKG_DIR}/sources/rsync-rules.conf ${INSTALL}/usr/config/
   cp ${PKG_DIR}/sources/rsync.conf ${INSTALL}/usr/config/

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="emulationstation"
-PKG_VERSION="e4deea6"
+PKG_VERSION="5bc0515"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
* Fix rclone on x86_64 builds
* Add support for running a cloud backup immediately after exiting a game. (GAME SETTINGS, Requires configured rclone.)