### PR TITLE
Experimental - Panfrost enable Arb Buffer Storage

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -10,6 +10,7 @@ PKG_URL="${PKG_SITE}.git"
 PKG_DEPENDS_TARGET="toolchain expat libdrm Mako:host"
 PKG_LONGDESC="Mesa is a 3-D graphics library with an API."
 PKG_TOOLCHAIN="meson"
+PKG_PATCH_DIRS+="${DEVICE}"
 
 get_graphicdrivers
 

--- a/packages/graphics/mesa/patches/RG552/000-enable-arb-buffer-storage.patch
+++ b/packages/graphics/mesa/patches/RG552/000-enable-arb-buffer-storage.patch
@@ -1,0 +1,24 @@
+diff --git a/src/gallium/drivers/panfrost/pan_resource.c b/src/gallium/drivers/panfrost/pan_resource.c
+index 228e4520135..f0be106ff81 100644
+--- a/src/gallium/drivers/panfrost/pan_resource.c
++++ b/src/gallium/drivers/panfrost/pan_resource.c
+@@ -1010,6 +1010,7 @@ panfrost_ptr_map(struct pipe_context *pctx,
+
+         if (!create_new_bo &&
+             !(usage & PIPE_MAP_UNSYNCHRONIZED) &&
++            !(resource->flags & PIPE_RESOURCE_FLAG_MAP_PERSISTENT) &&
+             (usage & PIPE_MAP_WRITE) &&
+             !(resource->target == PIPE_BUFFER
+               && !util_ranges_intersect(&rsrc->valid_buffer_range, box->x, box->x + box->width)) &&
+diff --git a/src/gallium/drivers/panfrost/pan_screen.c b/src/gallium/drivers/panfrost/pan_screen.c
+index f44d0fdc2ce..971b8b97163 100644
+--- a/src/gallium/drivers/panfrost/pan_screen.c
++++ b/src/gallium/drivers/panfrost/pan_screen.c
+@@ -113,6 +113,7 @@ panfrost_get_param(struct pipe_screen *screen, enum pipe_cap param)
+         case PIPE_CAP_MIXED_COLOR_DEPTH_BITS:
+         case PIPE_CAP_FRAGMENT_SHADER_TEXTURE_LOD:
+         case PIPE_CAP_VERTEX_COLOR_UNCLAMPED:
++        case PIPE_CAP_BUFFER_MAP_PERSISTENT_COHERENT:
+         case PIPE_CAP_POINT_SPRITE:
+         case PIPE_CAP_DEPTH_CLIP_DISABLE:
+         case PIPE_CAP_DEPTH_CLIP_DISABLE_SEPARATE:


### PR DESCRIPTION
Hopefully this will fix Dolphin textures on the RG552.

Recently added to Mesa upstream. Adding as a patch for now.

https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/19351/diffs?commit_id=10ace5de3afa213b654a9a8bc1b06281896dd5f5#diff-content-41a8efa688404d4b92a6d072e8f8f27c656583a2

Need to test before merge. Confirm that it compiles. 