### PR TITLE
RG552 60hz Panel fix from @Locutus73

### DIFF
--- a/projects/Rockchip/packages/linux/package.mk
+++ b/projects/Rockchip/packages/linux/package.mk
@@ -26,7 +26,7 @@ case ${DEVICE} in
   ;;
   RG552)
     PKG_URL="https://github.com/brooksytech/rk3399-kernel-5.19.git"
-    PKG_VERSION="f1c01bbdb7d4539eac2221f2650a14201860d928"
+    PKG_VERSION="db9acc833faead79f78f33477a099523f2dffa7e"
     PKG_GIT_CLONE_BRANCH="dev"
   ;;
   RG353P|RG503)


### PR DESCRIPTION
Update the refresh rate of RG552 panel for close to 60hz. 

https://github.com/Locutus73/rk3399-kernel-5.19/commit/5311ccecdbca43b454ab375bdd2847707cb47dfc

Thanks to @Locutus73 for the fix. 