### PR TITLE
Update bluez to version 5.66

### DIFF
--- a/packages/jelos/sources/scripts/set-audio
+++ b/packages/jelos/sources/scripts/set-audio
@@ -36,7 +36,7 @@ function list_audio_devices() {
   BTACTIVE=$(systemctl is-active bluetooth)
   if [ "${BTACTIVE}" == "active" ]
   then
-    BTDEVICES=$(bluetoothctl paired-devices)
+    BTDEVICES=$(bluetoothctl devices Paired)
     while read -r BTDEV
     do
       echo "${BTDEV}"

--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bluez"
-PKG_VERSION="5.62"
-PKG_SHA256="38090a5b750e17fc08d3e52178ed8d3254c5f4bd2c48830d5c1955b88e3bc0c2"
+PKG_VERSION="5.66"
+PKG_SHA256="39fea64b590c9492984a0c27a89fc203e1cdc74866086efb8f4698677ab2b574"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.bluez.org/"
 PKG_URL="https://www.kernel.org/pub/linux/bluetooth/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/network/bluez/patches/bluez-11_sixaxis-fix-PID-navigation-controller.patch
+++ b/packages/network/bluez/patches/bluez-11_sixaxis-fix-PID-navigation-controller.patch
@@ -1,23 +1,8 @@
-From ccc0a0cba8a2fdb8cfb148276e7c9413a3e22dc8 Mon Sep 17 00:00:00 2001
-From: MilhouseVH <milhouseVH.github@nmacleod.com>
-Date: Thu, 19 Sep 2019 22:48:19 +0100
-Subject: [PATCH] sixaxis: Fix PID for Navigation Controller
-
-Newsgroups: gmane.linux.bluez.kernel
-Date: 2015-06-15 18:28:26 GMT (36 weeks, 4 days, 21 hours and 32 minutes ago)
-
-Navigation Controller is using PID 0x042f over USB but PID 0x0268
-(same as Dualshock 3) over BT.
----
- plugins/sixaxis.c        | 8 +++++++-
- profiles/input/sixaxis.h | 2 ++
- 2 files changed, 9 insertions(+), 1 deletion(-)
-
 diff --git a/plugins/sixaxis.c b/plugins/sixaxis.c
-index 939fed7..f6baea7 100644
+index 544ab399a..9a0aa5d4f 100644
 --- a/plugins/sixaxis.c
 +++ b/plugins/sixaxis.c
-@@ -364,7 +364,13 @@ static bool setup_device(int fd, const char *sysfs_path,
+@@ -349,7 +349,13 @@ static bool setup_device(int fd, const char *sysfs_path,
  	info("sixaxis: setting up new device");
  
  	btd_device_device_set_name(device, cp->name);
@@ -29,14 +14,14 @@ index 939fed7..f6baea7 100644
 +	else
 +		btd_device_set_pnpid(device, cp->source, cp->vid, cp->pid, cp->version);
 +
- 	btd_device_set_trusted(device, false);
  	btd_device_set_temporary(device, true);
  
+ 	closure = g_new0(struct authentication_closure, 1);
 diff --git a/profiles/input/sixaxis.h b/profiles/input/sixaxis.h
-index 8e6f3cc..321a918 100644
+index ab8831995..0fe373204 100644
 --- a/profiles/input/sixaxis.h
 +++ b/profiles/input/sixaxis.h
-@@ -38,6 +38,7 @@ struct cable_pairing {
+@@ -25,6 +25,7 @@ struct cable_pairing {
  	uint16_t vid;
  	uint16_t pid;
  	uint16_t version;
@@ -44,7 +29,7 @@ index 8e6f3cc..321a918 100644
  	CablePairingType type;
  };
  
-@@ -59,6 +60,7 @@ get_pairing(uint16_t vid, uint16_t pid)
+@@ -54,6 +55,7 @@ get_pairing(uint16_t vid, uint16_t pid, const char *name)
  			.vid = 0x054c,
  			.pid = 0x042f,
  			.version = 0x0000,
@@ -52,6 +37,3 @@ index 8e6f3cc..321a918 100644
  			.type = CABLE_PAIRING_SIXAXIS,
  		},
  		{
--- 
-2.7.4
-

--- a/packages/network/bluez/patches/bluez-20-sixaxis-autotrust.patch
+++ b/packages/network/bluez/patches/bluez-20-sixaxis-autotrust.patch
@@ -1,25 +1,12 @@
-From 40c6e7c5a0d81a781c94e5a64661848018c1f8be Mon Sep 17 00:00:00 2001
-From: MilhouseVH <milhouseVH.github@nmacleod.com>
-Date: Thu, 19 Sep 2019 22:55:09 +0100
-Subject: [PATCH] sixaxis autotrust
-
----
- plugins/sixaxis.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git a/plugins/sixaxis.c b/plugins/sixaxis.c
-index f6baea7..c166304 100644
+index 9a0aa5d4f..810e33353 100644
 --- a/plugins/sixaxis.c
 +++ b/plugins/sixaxis.c
-@@ -371,7 +371,7 @@ static bool setup_device(int fd, const char *sysfs_path,
+@@ -356,6 +356,7 @@ static bool setup_device(int fd, const char *sysfs_path,
  	else
  		btd_device_set_pnpid(device, cp->source, cp->vid, cp->pid, cp->version);
  
--	btd_device_set_trusted(device, false);
 +	btd_device_set_trusted(device, true);
  	btd_device_set_temporary(device, true);
  
  	closure = g_new0(struct authentication_closure, 1);
--- 
-2.7.4
-


### PR DESCRIPTION
# BlueZ Update

## Description

This updates the bluez package from version 5.62 to 5.66. It fixes some BT audio related crashes of the bluetooth daemon.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran all bluetooth audio tests again and made sure that there are no regressions. Previously observed crashes are gone.
- [X] Verified bluetooth controller still working as it was before (tested with a PlayStation 4 controller).
- [X] Tested on RG353V and RG351V with bluetooth dongle attached to USB-C port.

**Test Configuration**:
* Build OS name and version: Ubuntu 20.04
* Docker (Y/N): Y
* JELOS Branch: dev

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
