### PR TITLE
Restore Audio Settings

### DIFF
--- a/packages/jelos/sources/autostart/common/005-alsa
+++ b/packages/jelos/sources/autostart/common/005-alsa
@@ -4,16 +4,14 @@
 
 . /etc/profile
 
-### REMINDER: This needs to be refactored or it will break audio on other devices.
-# Revert to default when bluetooth was still selected at last shutdown.
+# Revert to stored setting when bluetooth was still selected at last shutdown.
 # This is a workaround - headsets that auto-connect at boot tend to be
 # unreliable, so for now it's better to force a manual reconnect.
-#LAST_AUDIO_DEVICE=$(set-audio get)
-#if [[ "${LAST_AUDIO_DEVICE}" =~ ^Device.* ]]
-#then
-#  set-audio set "DEFAULT (SYSTEM PROVIDED)"
-#  set-audio esset "DEFAULT (SYSTEM PROVIDED)"
-#fi
+LAST_AUDIO_DEVICE=$(set-audio get)
+if [[ "${LAST_AUDIO_DEVICE}" =~ ^Device.* ]]
+then
+  set-audio restore
+fi
 
 if [ ! -e "/storage/.config/asound.conf" ]
 then

--- a/packages/jelos/sources/scripts/set-audio
+++ b/packages/jelos/sources/scripts/set-audio
@@ -6,6 +6,31 @@
 
 ES_SETTINGS="/storage/.config/emulationstation/es_settings.cfg"
 
+function save_state()
+{
+  ACTIVE_DEVICE=$(get_audio_device)
+  ACTIVE_PATH=$(get_es_path)
+  echo "$ACTIVE_DEVICE" > /tmp/active_device.cfg
+  echo "$ACTIVE_PATH" > /tmp/active_path.cfg
+  cp -f /storage/.config/asound.conf /tmp 
+  cp -f /storage/.config/asound.state /tmp
+  zip -j -r /storage/.cache/audio_settings.zip /tmp/active_device.cfg /tmp/active_path.cfg /tmp/asound.*
+}
+
+function restore_state()
+{
+  if [ -e /storage/.cache/audio_settings.zip ]
+  then
+    unzip -o -d /tmp/ /storage/.cache/audio_settings.zip
+    STORED_DEVICE=$(cat /tmp/active_device.cfg)
+    STORED_PATH=$(cat /tmp/active_path.cfg)
+    mv /tmp/asound.conf /storage/.config/
+    mv /tmp/asound.state /storage/.config/
+    set_audio_device "${STORED_DEVICE}"
+    set_es_path "${STORED_PATH}"
+  fi
+}
+
 function list_audio_controls() {
   IFS=""
   ACTIVE_DEVICE=$(get_audio_device)
@@ -89,7 +114,8 @@ function set_audio_device() {
     # This doesn't seem necessary anymore, re-activate in case of issues.
     # bluetoothctl disconnect ${MAC}
     if bluetoothctl connect ${MAC}
-    then 
+    then
+      save_state 
       cp /usr/config/asound.conf.bluealsa /storage/.config/asound.conf
       set_es_path "DEFAULT (SYSTEM PROVIDED)"
     fi 
@@ -190,5 +216,11 @@ case $1 in
   ;;
   esget)
     get_es_path
+  ;;
+  save)
+    save_state
+  ;;
+  restore)
+    restore_state
   ;;
 esac

--- a/packages/jelos/sources/scripts/set-audio
+++ b/packages/jelos/sources/scripts/set-audio
@@ -96,6 +96,7 @@ function list_audio_devices() {
 }
 
 function set_audio_device() {
+  SELECTION="$1"
   # When switching from a non-bluetooth to a bluetooth device,
   # store the last configuration in order to restore it on reboot.
   if is_bluetooth "${SELECTION}"
@@ -107,7 +108,6 @@ function set_audio_device() {
     fi
   fi
 
-  SELECTION="$1"
   set_setting system.audiodevice "${SELECTION}"
   if [ "${SELECTION}" == "DEFAULT (SYSTEM PROVIDED)" ]
   then

--- a/packages/jelos/sources/scripts/set-audio
+++ b/packages/jelos/sources/scripts/set-audio
@@ -27,9 +27,9 @@ function restore_state()
     STORED_PATH=$(cat /tmp/active_path.cfg)
     mv /tmp/asound.conf /storage/.config/
     mv /tmp/asound.state /storage/.config/
-    set_audio_device "${STORED_DEVICE}"
-    set_es_path "${STORED_PATH}"
     rm -f ${STORED_SETTINGS}
+    set-audio esset "${STORED_PATH}"
+    set-audio set "${STORED_DEVICE}"
   fi
 }
 

--- a/packages/jelos/sources/scripts/set-audio
+++ b/packages/jelos/sources/scripts/set-audio
@@ -5,6 +5,7 @@
 . /etc/profile
 
 ES_SETTINGS="/storage/.config/emulationstation/es_settings.cfg"
+STORED_SETTINGS="/storage/.cache/audio_settings.zip"
 
 function save_state()
 {
@@ -14,20 +15,21 @@ function save_state()
   echo "$ACTIVE_PATH" > /tmp/active_path.cfg
   cp -f /storage/.config/asound.conf /tmp 
   cp -f /storage/.config/asound.state /tmp
-  zip -q -j -r /storage/.cache/audio_settings.zip /tmp/active_device.cfg /tmp/active_path.cfg /tmp/asound.*
+  zip -q -j -r ${STORED_SETTINGS} /tmp/active_device.cfg /tmp/active_path.cfg /tmp/asound.*
 }
 
 function restore_state()
 {
-  if [ -e /storage/.cache/audio_settings.zip ]
+  if [ -e ${STORED_SETTINGS} ]
   then
-    unzip -o -q -d /tmp/ /storage/.cache/audio_settings.zip
+    unzip -o -q -d /tmp/ ${STORED_SETTINGS}
     STORED_DEVICE=$(cat /tmp/active_device.cfg)
     STORED_PATH=$(cat /tmp/active_path.cfg)
     mv /tmp/asound.conf /storage/.config/
     mv /tmp/asound.state /storage/.config/
     set_audio_device "${STORED_DEVICE}"
     set_es_path "${STORED_PATH}"
+    rm -f ${STORED_SETTINGS}
   fi
 }
 

--- a/packages/jelos/sources/scripts/set-audio
+++ b/packages/jelos/sources/scripts/set-audio
@@ -14,14 +14,14 @@ function save_state()
   echo "$ACTIVE_PATH" > /tmp/active_path.cfg
   cp -f /storage/.config/asound.conf /tmp 
   cp -f /storage/.config/asound.state /tmp
-  zip -j -r /storage/.cache/audio_settings.zip /tmp/active_device.cfg /tmp/active_path.cfg /tmp/asound.*
+  zip -q -j -r /storage/.cache/audio_settings.zip /tmp/active_device.cfg /tmp/active_path.cfg /tmp/asound.*
 }
 
 function restore_state()
 {
   if [ -e /storage/.cache/audio_settings.zip ]
   then
-    unzip -o -d /tmp/ /storage/.cache/audio_settings.zip
+    unzip -o -q -d /tmp/ /storage/.cache/audio_settings.zip
     STORED_DEVICE=$(cat /tmp/active_device.cfg)
     STORED_PATH=$(cat /tmp/active_path.cfg)
     mv /tmp/asound.conf /storage/.config/
@@ -31,10 +31,22 @@ function restore_state()
   fi
 }
 
+# Check if an audio device string corresponds to a bluetooth device
+function is_bluetooth() {
+  if [[ "$1" =~ ^Device.* ]]
+  then
+    true
+    return
+  else
+    false
+    return
+  fi
+}
+
 function list_audio_controls() {
   IFS=""
   ACTIVE_DEVICE=$(get_audio_device)
-  if [[ "${ACTIVE_DEVICE}" =~ ^Device.* ]]
+  if is_bluetooth "${ACTIVE_DEVICE}"
   then
     CONTROLS=$(amixer -D bluealsa controls | sed -e 's#^.*name=##g' -e "s#'##g")
   else
@@ -82,6 +94,17 @@ function list_audio_devices() {
 }
 
 function set_audio_device() {
+  # When switching from a non-bluetooth to a bluetooth device,
+  # store the last configuration in order to restore it on reboot.
+  if is_bluetooth "${SELECTION}"
+  then
+    ACTIVE_DEVICE=$(get_audio_device)
+    if ! is_bluetooth "${ACTIVE_DEVICE}"
+    then
+      save_state 
+    fi
+  fi
+
   SELECTION="$1"
   set_setting system.audiodevice "${SELECTION}"
   if [ "${SELECTION}" == "DEFAULT (SYSTEM PROVIDED)" ]
@@ -107,7 +130,7 @@ function set_audio_device() {
   elif [ "${SELECTION}" == "CUSTOM (UNMANAGED)" ]
   then
     exit 0
-  elif [[ "${SELECTION}" =~ ^Device.* ]]
+  elif is_bluetooth "${SELECTION}"
   then
     MAC=$(echo "${SELECTION}" | awk '/^Device/ {print $2}')
     # Reconnect device in case it auto-connected.
@@ -115,7 +138,6 @@ function set_audio_device() {
     # bluetoothctl disconnect ${MAC}
     if bluetoothctl connect ${MAC}
     then
-      save_state 
       cp /usr/config/asound.conf.bluealsa /storage/.config/asound.conf
       set_es_path "DEFAULT (SYSTEM PROVIDED)"
     fi 


### PR DESCRIPTION
# Restore Audio Settings

## Description
This adds functionality to set-audio that stores the previous (non-bluetooth) audio device settings when a bluetooth device is selected. These settings will be restored at boot if the bt device is still active.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
## How Has This Been Tested Locally?

- [X] Verified saving and restoring audio device settings works with various bt and non-bt settings.

**Test Configuration**:
* Build OS name and version: Ubuntu 20.04
* Docker (Y/N): Y
* JELOS Branch: dev

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
