### PR TITLE
fixes ES segfault on M1 builds

### DIFF
--- a/packages/tools/sysutils/freeimage/package.mk
+++ b/packages/tools/sysutils/freeimage/package.mk
@@ -11,6 +11,6 @@ PKG_SOURCE_DIR="FreeImage"
 PKG_LONGDESC="FreeImage library"
 
 pre_make_target() {
-  export CXXFLAGS="$CXXFLAGS -Wno-narrowing -std=c++11"
-  export CFLAGS="$CFLAGS -DPNG_ARM_NEON_OPT=0"
+  export CXXFLAGS="$CXXFLAGS -Wno-narrowing -std=c++11 -fPIC"
+  export CFLAGS="$CFLAGS -DPNG_ARM_NEON_OPT=0 -fPIC"
 }


### PR DESCRIPTION
caused by missing `-fPIC` flag in freeimage