### PR TITLE
Update post-update

### DIFF
--- a/packages/jelos/sources/post-update
+++ b/packages/jelos/sources/post-update
@@ -119,3 +119,11 @@ then
   echo "Make sure weston is our default." >>${LOG}
   set_setting weston.startup "/usr/bin/start_es.sh"
 fi
+
+# Fixing asound.state on RG552 with broken values
+if [ "${HW_DEVICE}" == "RG552" ] && \
+   [ "$(grep -i 'value.*Invert' /storage/.config/asound.state)" ]
+then
+  echo "Fix asound.state." >>${LOG}
+  cp /usr/config/asound.state /storage/.config/asound.state
+fi


### PR DESCRIPTION
Fixing asound.state on RG552 with broken values

# Pull Request Template

## Description

Copyng a correct asound.state (volume, mono mix, inverted right channel polarity, etc) to /storage/.config/asound.state on RG552s with broken values

Fixes # (issue)

Bad audio (volume, mono mix, inverted right channel polarity, etc) on RG552 devices

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested Locally?

Tested on a RG552 through SSH

**Test Configuration**:
* Build OS name and version: custom JELOS build
* Docker (Y/N): N
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
