### PR TITLE
Enables built-in updater in ES by distro option

### DIFF
--- a/distributions/JELOS/options
+++ b/distributions/JELOS/options
@@ -149,3 +149,5 @@
 # Settings package name - blank if not required
   DISTRO_PKG_SETTINGS=""
 
+# Enable Updates
+  ENABLE_UPDATES="no"

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -27,8 +27,13 @@ if [ ! "${OPENGLES_SUPPORT}" = no ]; then
   PKG_CMAKE_OPTS_TARGET+=" -DGLES2=1"
 fi
 
+if [ ! "${ENABLE_UPDATES}" = "no" ]; then
+  PKG_CMAKE_OPTS_TARGET+=" -DENABLE_UPDATES=1"
+else
+  PKG_CMAKE_OPTS_TARGET+=" -DENABLE_UPDATES=0"
+fi
 
-PKG_CMAKE_OPTS_TARGET+=" -DENABLE_UPDATES=0 -DENABLE_EMUELEC=1 -DDISABLE_KODI=1 -DENABLE_FILEMANAGER=0 -DCEC=0"
+PKG_CMAKE_OPTS_TARGET+=" -DENABLE_EMUELEC=1 -DDISABLE_KODI=1 -DENABLE_FILEMANAGER=0 -DCEC=0"
 
 ##########################################################################################################
 # The following allows building Emulation station from local copy by using EMULATIONSTATION_SRC.
@@ -51,7 +56,7 @@ PKG_CMAKE_OPTS_TARGET+=" -DENABLE_UPDATES=0 -DENABLE_EMUELEC=1 -DDISABLE_KODI=1 
 #
 # Run from the device:
 # --------------------
-# Copy ./emulationstation binary found in build.JELOS-<device>.aarch64/emulationstation-*/.install_pkg/usr/bin/ 
+# Copy ./emulationstation binary found in build.JELOS-<device>.aarch64/emulationstation-*/.install_pkg/usr/bin/
 # Via ssh, run emulationstation with
 # systemctl stop emustation
 # chmod +x ./emulationstation


### PR DESCRIPTION
## Description

This will allow the built-in updater to work in Emulation Station to allow community builds to have update functionality.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Yes, I've tested this on my fork, built, flashed, tagged, then tagged again and updated.

**Test Configuration**:
* Build OS name and version: arch linux
* Docker (Y/N): y
* JELOS Branch: main

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code