### PR TITLE
Fix modules and bump libusb for yuzu

### DIFF
--- a/packages/misc/modules/package.mk
+++ b/packages/misc/modules/package.mk
@@ -27,11 +27,11 @@ makeinstall_target() {
 post_makeinstall_target() {
   case ${ARCH} in
     x86_64)
-      rm -f "${INSTALL}/usr/config/modules/*32bit*"
-      rm -f "${INSTALL}/usr/config/modules/*Master*"
+      rm -f ${INSTALL}/usr/config/modules/*32bit*
+      rm -f ${INSTALL}/usr/config/modules/*Master*
     ;;
     *)
-      rm -f "${INSTALL}/usr/config/modules/Install*"
+      rm -f ${INSTALL}/usr/config/modules/Install*
     ;;
   esac
 }

--- a/packages/sysutils/libusb/package.mk
+++ b/packages/sysutils/libusb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libusb"
-PKG_VERSION="1.0.22"
-PKG_SHA256="75aeb9d59a4fdb800d329a545c2e6799f732362193b465ea198f2aa275518157"
+PKG_VERSION="1.0.26"
+PKG_SHA256="12ce7a61fc9854d1d2a1ffe095f7b5fac19ddba095c259e6067a46500381b5a5"
 PKG_LICENSE="LGPLv2.1"
 PKG_SITE="http://libusb.info/"
 PKG_URL="$SOURCEFORGE_SRC/libusb/files/$PKG_NAME-$PKG_VERSION.tar.bz2"


### PR DESCRIPTION
Fixed modules not correctly cleaning non compatible modules. 

Building yuzu would sometimes fail with unsupported libusb. Bump this package should fix that. 