### PR TITLE
Fixed the themes not being populated to

### DIFF
--- a/packages/sysutils/systemd/scripts/userconfig-setup
+++ b/packages/sysutils/systemd/scripts/userconfig-setup
@@ -26,6 +26,8 @@ then
   rsync -a --ignore-existing --exclude=es_systems.cfg /usr/config/* /storage/.config/
   mkdir -p /storage/.config/emulationstation/themes
   ln -s /usr/share/themes/es-theme-art-book-next /storage/.config/emulationstation/themes/system-theme
+  ln -s /usr/share/themes/es-theme-minielec /storage/.config/emulationstation/themes/es-theme-minielec
+  ln -s /usr/share/themes/es-theme-minimal /storage/.config/emulationstation/themes/es-theme-minimal
 
   ### Link the game controller database so it is managed with OS updates.
   rm -f /storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt


### PR DESCRIPTION
## Description

Fixed the themes not being populated to "/storage/.config/emulationstation/themes/" when installed from the clean img.
This was only done on an update of the system (tar update), now it will work on a clean install.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Clean install of the firmware (distro) and populated when booted up.

- [x] Clean install

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
