### PR TITLE
Update control-gen.cpp

### DIFF
--- a/packages/games/tools/control-gen/control-gen.cpp
+++ b/packages/games/tools/control-gen/control-gen.cpp
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <SDL.h>
+#include <cstdlib>
 
 int main()
 {


### PR DESCRIPTION
Had a build failure when building 353P and the compiler had an error saying atexit on line 10 was undefined and suggested to add cstdlib as an include. Was able to build successfully after
