### PR TITLE
Better handle systems with crossdev installed

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -84,7 +84,7 @@ case "${DISTRO}" in
       ;;
     gentoo|sabayon)
       deps+=(g++ mkfontscale mkfontdir bdftopcf xsltproc java python3)
-      deps_pkg+=("gcc[cxx]" mkfontscale mkfontdir bdftopcf libxslt virtual/jre python3)
+      deps_pkg+=("sys-devel/gcc[cxx]" mkfontscale mkfontdir bdftopcf libxslt virtual/jre python3)
       files_pkg=(glibc ncurses)
       perl_pkg=(JSON XML-Parser)
       ;;


### PR DESCRIPTION
# Pull Request Template

## Description

If you have build tools installed for multiple architectures then 'gcc' could be an ambiguous reference.  I have 'cross-avr/gcc' and 'sys-devel/gcc' available on my system for example.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

1. Install 'crossdev' overlay from [Gentoo Wiki](https://wiki.gentoo.org/wiki/Crossdev)
2. Run 'make RG353P'
3. See check-deps fail (silently) when 'gcc[cxx]' can't be resolved
4. Apply changes
5. See check-deps resolve 'gcc' correctly


**Test Configuration**:
* Build OS name and version: Gentoo
* Docker (Y/N): N
* JELOS Branch: main
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
