### PR TITLE
Fix Yuzu controls for YuzuSA

### DIFF
--- a/packages/games/emulators/yuzusa/config/sdl2-config.ini
+++ b/packages/games/emulators/yuzusa/config/sdl2-config.ini
@@ -1,14 +1,20 @@
 
-[ControlsGeneral]
+
+[ControlsP0]
 # The input devices and parameters for each Switch native input
+# The config section determines the player number where the config will be applied on. For example "ControlsP0", "ControlsP1", ...
 # It should be in the format of "engine:[engine_name],[param1]:[value1],[param2]:[value2]..."
 # Escape characters $0 (for ':'), $1 (for ',') and $2 (for '$') can be used in values
+
+# Indicates if this player should be connected at boot
+connected=1
 
 # for button input, the following devices are available:
 #  - "keyboard" (default) for keyboard input. Required parameters:
 #      - "code": the code of the key to bind
 #  - "sdl" for joystick input using SDL. Required parameters:
-#      - "joystick": the index of the joystick to bind
+#      - "guid": SDL identification GUID of the joystick
+#      - "port": the index of the joystick to bind
 #      - "button"(optional): the index of the button to bind
 #      - "hat"(optional): the index of the hat to bind as direction buttons
 #      - "axis"(optional): the index of the axis to bind
@@ -18,30 +24,29 @@
 #      - "direction"(only used for axis): "+" means the button is triggered when the axis value
 #          is greater than the threshold; "-" means the button is triggered when the axis value
 #          is smaller than the threshold
-[ControlsP0]
-button_a=
-button_b=
-button_x=
-button_y=
-button_lstick=
-button_rstick=
-button_l=
-button_r=
-button_zl=
-button_zr=
-button_plus=
-button_minus=
-button_dleft=
-button_dup=
-button_dright=
-button_ddown=
+button_a=button:1,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+button_b=button:0,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+button_x=button:3,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+button_y=button:2,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+button_lstick=button:9,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+button_rstick=button:10,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+button_l=button:4,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+button_r=button:5,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+button_zl=threshold:0.500000,axis:2,guid:030000005e0400008e02000010010000,port:0,invert:+,engine:sdl
+button_zr=threshold:0.500000,axis:5,guid:030000005e0400008e02000010010000,port:0,invert:+,engine:sdl
+button_plus=button:7,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+button_minus=button:6,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+button_dleft=hat:0,direction:left,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+button_dup=hat:0,direction:up,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+button_dright=hat:0,direction:right,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+button_ddown=hat:0,direction:down,guid:030000005e0400008e02000010010000,port:0,engine:sdl
 button_lstick_left=
 button_lstick_up=
 button_lstick_right=
 button_lstick_down=
 button_sl=
 button_sr=
-button_home=
+button_home=button:8,guid:030000005e0400008e02000010010000,port:0,engine:sdl
 button_screenshot=
 
 # for analog input, the following devices are available:
@@ -52,12 +57,29 @@ button_screenshot=
 #      - "modifier_scale": a float number representing the applied modifier scale to the analog input.
 #          Must be in range of 0.0-1.0. Defaults to 0.5
 #  - "sdl" for joystick input using SDL. Required parameters:
-#      - "joystick": the index of the joystick to bind
+#      - "guid": SDL identification GUID of the joystick
+#      - "port": the index of the joystick to bind
 #      - "axis_x": the index of the axis to bind as x-axis (default to 0)
 #      - "axis_y": the index of the axis to bind as y-axis (default to 1)
-lstick=
-rstick=
+lstick=deadzone:0.150000,invert_y:+,invert_x:+,offset_y:0.000000,axis_y:1,offset_x:-0.000000,axis_x:0,guid:030000005e0400008e02000010010000,port:0,engine:sdl
+rstick=deadzone:0.150000,invert_y:+,invert_x:+,offset_y:0.000000,axis_y:4,offset_x:-0.000000,axis_x:3,guid:030000005e0400008e02000010010000,port:0,engine:sdl
 
+# for motion input, the following devices are available:
+#  - "keyboard" (default) for emulating random motion input from buttons. Required parameters:
+#      - "code": the code of the key to bind
+#  - "sdl" for motion input using SDL. Required parameters:
+#      - "guid": SDL identification GUID of the joystick
+#      - "port": the index of the joystick to bind
+#      - "motion": the index of the motion sensor to bind
+#  - "cemuhookudp" for motion input using Cemu Hook protocol. Required parameters:
+#      - "guid": the IP address of the cemu hook server encoded to a hex string. for example 192.168.0.1 = "c0a80001"
+#      - "port": the port of the cemu hook server
+#      - "pad": the index of the joystick
+#      - "motion": the index of the motion sensor of the joystick to bind
+motionleft=
+motionright=
+
+[ControlsGeneral]
 # To use the debug_pad, prepend `debug_pad_` before each button setting above.
 # i.e. debug_pad_button_a=
 
@@ -179,6 +201,10 @@ cpuopt_fastmem_exclusives =
 # 0: Disabled, 1 (default): Enabled
 cpuopt_recompile_exclusives =
 
+# Enable optimization to ignore invalid memory accesses (faster guest memory access)
+# 0: Disabled, 1 (default): Enabled
+cpuopt_ignore_memory_aborts =
+
 # Enable unfuse FMA (improve performance on CPUs without FMA)
 # Only enabled if cpu_accuracy is set to Unsafe. Automatically chosen with cpu_accuracy = Auto-select.
 # 0: Disabled, 1 (default): Enabled
@@ -212,7 +238,7 @@ cpuopt_unsafe_ignore_global_monitor =
 [Renderer]
 # Which backend API to use.
 # 0: OpenGL, 1 (default): Vulkan
-backend =
+backend = 1
 
 # Enable graphics API debugging mode.
 # 0 (default): Disabled, 1: Enabled
@@ -333,7 +359,7 @@ bg_green =
 # cubeb: Cubeb audio engine (if available)
 # sdl2: SDL2 audio engine (if available)
 # null: No audio output
-output_engine = sdl2
+output_engine =
 
 # Which audio device to use.
 # auto (default): Auto-select

--- a/packages/games/emulators/yuzusa/package.mk
+++ b/packages/games/emulators/yuzusa/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present BrooksyTech (https://github.com/brooksytech)
 
 PKG_NAME="yuzusa"
-PKG_VERSION="1b11e0f0d3209603e67b26f3ef22f1d1a493bbdc"
+PKG_VERSION="9fdacb5e3a03928a5671670d0db1e0058daf344e"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/yuzu-emu/yuzu"


### PR DESCRIPTION
This fixes the controls for Yuzusa.

Uses the standard yuzu to xbox 360 mapping. This currently only works for the Neo Aya Air / Air pro. 

Will need to come up with a better system to dynamically map controls. Probably just need to get the correct controller id. 

There are no savestates in yuzu. Use jslisten hotkey combo to exit the game. 