### PR TITLE
Add QT5 support. Thanks @LibreELEC-RR

### DIFF
--- a/packages/audio/flac-system/package.mk
+++ b/packages/audio/flac-system/package.mk
@@ -1,0 +1,39 @@
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Frank Hartung (supervisedthinking (@) gmail.com)
+
+PKG_NAME="flac-system"
+PKG_VERSION="$(get_pkg_version flac)"
+PKG_LICENSE="GFDL-1.2"
+PKG_SITE="https://xiph.org/flac/"
+PKG_URL="http://downloads.xiph.org/releases/flac/flac-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain libogg-system flac"
+PKG_LONGDESC="An Free Lossless Audio Codec."
+PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+pic"
+
+if [ "${TARGET_ARCH}" = "x86_64" ]; then
+  PKG_DEPENDS_TARGET+=" nasm:host"
+fi
+
+pre_configure_target() {
+  PKG_CONFIGURE_OPTS_TARGET="--disable-rpath \
+                             --disable-altivec \
+                             --disable-doxygen-docs \
+                             --disable-thorough-tests \
+                             --disable-cpplibs \
+                             --disable-xmms-plugin \
+                             --disable-oggtest \
+                             --with-ogg=${SYSROOT_PREFIX}/usr \
+                             --with-gnu-ld"
+
+  if target_has_feature sse; then
+    PKG_CONFIGURE_OPTS_TARGET+=" --enable-sse"
+  else
+    PKG_CONFIGURE_OPTS_TARGET+=" --disable-sse"
+  fi
+}
+
+post_makeinstall_target() {
+  safe_remove ${INSTALL}/usr/bin
+}

--- a/packages/audio/libogg-system/package.mk
+++ b/packages/audio/libogg-system/package.mk
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Frank Hartung (supervisedthinking (@) gmail.com)
+
+PKG_NAME="libogg-system"
+PKG_VERSION="$(get_pkg_version libogg)"
+PKG_LICENSE="BSD"
+PKG_SITE="https://www.xiph.org/ogg/"
+PKG_URL="http://downloads.xiph.org/releases/ogg/libogg-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain libogg"
+PKG_LONGDESC="Libogg contains necessary functionality to create, decode, and work with Ogg bitstreams."
+PKG_BUILD_FLAGS="+pic"
+
+PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=ON \
+                       -DINSTALL_DOCS=OFF"

--- a/packages/audio/libvorbis-system/package.mk
+++ b/packages/audio/libvorbis-system/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Frank Hartung (supervisedthinking (@) gmail.com)
+
+PKG_NAME="libvorbis-system"
+PKG_VERSION="$(get_pkg_version libvorbis)"
+PKG_LICENSE="BSD"
+PKG_SITE="http://www.vorbis.com/"
+PKG_URL="http://downloads.xiph.org/releases/vorbis/libvorbis-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain libogg-system libvorbis"
+PKG_LONGDESC="Lossless audio compression tools using the ogg-vorbis algorithms."
+PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+pic"
+
+PKG_CONFIGURE_OPTS_TARGET="--with-ogg=${SYSROOT_PREFIX}/usr \
+                           --disable-docs \
+                           --disable-examples \
+                           --disable-oggtest"

--- a/packages/devel/qt5/package.mk
+++ b/packages/devel/qt5/package.mk
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2018-present Frank Hartung (supervisedthinking @ gmail.com)
+
+PKG_NAME="qt5"
+PKG_VERSION="87c5b4694ffd6fd891c26fce02776fc65cac1bd1" # 5.15.7+r176 (KDE Qt5PatchCollection)
+PKG_LICENSE="GPL"
+PKG_SITE="http://qt-project.org"
+PKG_URL="https://invent.kde.org/qt/qt/qt5.git"
+PKG_DEPENDS_TARGET="toolchain openssl libjpeg-turbo libpng pcre2 sqlite zlib freetype SDL2 libxkbcommon gstreamer gst-plugins-base gst-plugins-good gst-libav"
+PKG_LONGDESC="A cross-platform application and UI framework"
+GET_HANDLER_SUPPORT="git"
+PKG_GIT_CLONE_BRANCH="kde/5.15"
+PKG_GIT_CLONE_SINGLE="yes"
+
+post_unpack() {
+  # Clean up superflous Qt5 submodules
+  for PKG_QT5_SUBMODULES in \
+    qt3d qtactiveqt qtandroidextras qtcanvas3d qtcharts qtconnectivity qtdatavis3d qtdoc qtdocgallery \
+    qtfeedback qtlocation qtlottie qtmacextras qtnetworkauth qtpurchasing qtqa qtquickcontrols qtquicktimeline \
+    qtpim qtremoteobjects qtrepotools qtscript qtscxml qtsensors qtserialport qtserialbus qtspeech qtsystems \
+    qttranslations qtvirtualkeyboard qtwebchannel qtwebengine qtwebglplugin qtwebview qtwinextras qtx11extras
+  do
+    rm -rf ${PKG_BUILD}/${PKG_QT5_SUBMODULES}
+  done
+}
+
+configure_package() {
+  # Apply project specific patches
+  PKG_PATCH_DIRS="${PROJECT}"
+
+  # Build with OpenGL / OpenGLES support
+  if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+    PKG_DEPENDS_TARGET+=" ${OPENGL}"
+  elif [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+    PKG_DEPENDS_TARGET+=" ${OPENGLES}"
+  fi
+
+  # Build with XCB support for X11
+  if [ ${DISPLAYSERVER} = "x11" ]; then
+    PKG_DEPENDS_TARGET+=" xcb-util xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm"
+  fi
+
+  # Wayland support
+  if [ "${DISPLAYSERVER}" = "wl" ]; then
+    PKG_DEPENDS_TARGET+=" wayland"
+  fi
+}
+
+pre_configure_target() {
+  PKG_CONFIGURE_OPTS_TARGET="-prefix /usr
+                             -sysroot ${SYSROOT_PREFIX}
+                             -hostprefix ${TOOLCHAIN}
+                             -device linux-libreelec-g++
+                             -device-option CROSS_COMPILE=${TARGET_PREFIX}
+                             -fontconfig
+                             -opensource -confirm-license
+                             -release
+                             -shared
+                             -make libs
+                             -nomake examples -no-compile-examples
+                             -nomake tests
+                             -ccache
+                             -use-gold-linker
+                             -gstreamer 1.0
+                             -force-pkg-config
+                             -silent
+                             -no-ltcg
+                             -no-rpath
+                             -openssl-linked
+                             -system-libjpeg
+                             -system-libpng
+                             -system-pcre
+                             -system-sqlite
+                             -system-zlib
+                             -no-cups
+                             -no-evdev
+                             -no-glib
+                             -no-harfbuzz
+                             -no-iconv
+                             -no-icu
+                             -no-libproxy
+                             -no-mtdev
+                             -no-sql-mysql
+                             -no-strip
+                             -no-tiff
+                             -no-tslib
+                             -no-feature-linuxfb
+                             -no-feature-vulkan
+                             -no-feature-openal
+                             -no-feature-qml-debug
+                             -no-feature-printer
+                             -no-feature-vnc
+                             -skip qt3d
+                             -skip qtactiveqt
+                             -skip qtandroidextras
+                             -skip qtcanvas3d
+                             -skip qtcharts
+                             -skip qtconnectivity
+                             -skip qtdatavis3d
+                             -skip qtdoc
+                             -skip qtdocgallery
+                             -skip qtfeedback
+                             -skip qtlocation
+                             -skip qtlottie
+                             -skip qtmacextras
+                             -skip qtnetworkauth
+                             -skip qtpurchasing
+                             -skip qtqa
+                             -skip qtquickcontrols
+                             -skip qtquicktimeline
+                             -skip qtpim
+                             -skip qtremoteobjects
+                             -skip qtrepotools
+                             -skip qtscript
+                             -skip qtscxml
+                             -skip qtsensors
+                             -skip qtserialport
+                             -skip qtserialbus
+                             -skip qtspeech
+                             -skip qtsystems
+                             -skip qttranslations
+                             -skip qtvirtualkeyboard
+                             -skip qtwebchannel
+                             -skip qtwebengine
+                             -skip qtwebglplugin
+                             -skip qtwebview
+                             -skip qtwinextras
+                             -skip qtx11extras"
+
+  # Build with OpenGL or OpenGLES support
+  if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+    PKG_CONFIGURE_OPTS_TARGET+=" -opengl -no-eglfs"
+  elif [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+    PKG_CONFIGURE_OPTS_TARGET+=" -opengl es2"
+  fi
+
+  # Wayland support
+  if [ ! "${DISPLAYSERVER}" = "wl" ]; then
+    PKG_CONFIGURE_OPTS_TARGET+=" -skip qtwayland"
+  fi
+
+  # Build only Generic with reduced relocations https://bugreports.qt.io/browse/QTBUG-36129
+  if [ ${ARCH} = "x86_64" ]; then
+    PKG_CONFIGURE_OPTS_TARGET+=" -reduce-relocations"
+  fi
+}
+
+configure_target() {
+  # Create working dir
+  mkdir -p ${PKG_BUILD}/.${TARGET_NAME}
+  cd ${PKG_BUILD}/.${TARGET_NAME}
+
+  # Avoid eglfs_brcm detection by bcm_host.h
+  if [ "${DEVICE}" = "RPi4" -o "${DEVICE}" = "RPi2" ]; then
+    sed -e "s#bcm_host.h#bcm_host2.h#" -i ${PKG_BUILD}/qtbase/src/gui/configure.json
+  fi
+
+  # Create mkspecs file
+  QMAKE_CONF_DIR="${PKG_BUILD}/qtbase/mkspecs/devices/linux-libreelec-g++"
+  QMAKE_CONF="${QMAKE_CONF_DIR}/qmake.conf"
+  mkdir -p ${QMAKE_CONF_DIR}
+
+  # Set QMake Platform Flags
+  echo "MAKEFILE_GENERATOR       = UNIX"           > ${QMAKE_CONF}
+  echo "CONFIG                  += incremental"   >> ${QMAKE_CONF}
+  echo "QMAKE_INCREMENTAL_STYLE  = sublib"        >> ${QMAKE_CONF}
+  echo "include(../../common/linux.conf)"         >> ${QMAKE_CONF}
+  echo "include(../../common/gcc-base-unix.conf)" >> ${QMAKE_CONF}
+  echo "include(../../common/g++-unix.conf)"      >> ${QMAKE_CONF}
+  echo "load(device_config)"                      >> ${QMAKE_CONF}
+  echo "QMAKE_CC                = ${CC}"          >> ${QMAKE_CONF}
+  echo "QMAKE_CXX               = ${CXX}"         >> ${QMAKE_CONF}
+  echo "QMAKE_LINK              = ${CXX}"         >> ${QMAKE_CONF}
+  echo "QMAKE_LINK_SHLIB        = ${CXX}"         >> ${QMAKE_CONF}
+  echo "QMAKE_AR                = ${AR} cqs"      >> ${QMAKE_CONF}
+  echo "QMAKE_OBJCOPY           = ${OBJCOPY}"     >> ${QMAKE_CONF}
+  echo "QMAKE_NM                = ${NM} -P"       >> ${QMAKE_CONF}
+  echo "QMAKE_STRIP             = ${STRIP}"       >> ${QMAKE_CONF}
+  echo "QMAKE_CFLAGS            = ${CFLAGS}"      >> ${QMAKE_CONF}
+  echo "QMAKE_CXXFLAGS          = ${CXXFLAGS}"    >> ${QMAKE_CONF}
+  echo "QMAKE_LFLAGS            = ${LDFLAGS}"     >> ${QMAKE_CONF}
+  # Set Mesa 3D OpenGL ES based project flags
+  if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+    if [ ${DISPLAYSERVER} = "no" ]; then
+      echo "QMAKE_LIBS_EGL += -lEGL"              >> ${QMAKE_CONF}
+      echo "EGLFS_DEVICE_INTEGRATION = eglfs_kms" >> ${QMAKE_CONF}
+      echo "DEFINES += MESA_EGL_NO_X11_HEADERS"   >> ${QMAKE_CONF}
+    fi
+    if [ ! ${DISPLAYSERVER} = "x11" ]; then
+      echo "DEFINES += QT_EGL_NO_X11"             >> ${QMAKE_CONF}
+    fi
+  fi
+  echo "load(qt_config)"                            >> ${QMAKE_CONF}
+  echo '#include "../../linux-g++/qplatformdefs.h"' >> ${QMAKE_CONF_DIR}/qplatformdefs.h
+
+  unset CC CXX LD RANLIB AR AS CPPFLAGS CFLAGS LDFLAGS CXXFLAGS
+  export QT_FORCE_PKGCONFIG=yes
+  ${PKG_BUILD}/configure ${PKG_CONFIGURE_OPTS_TARGET}
+}
+
+post_makeinstall_target() {
+  # Remove references to the build directory from installed library dependencies
+  find ${PKG_ORIG_SYSROOT_PREFIX}/usr/lib/ -name \*.prl -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;
+
+  for PKG_CONFIGS in $(find "${PKG_ORIG_SYSROOT_PREFIX}/usr/lib" -type f -name "Qt*.pc" 2>/dev/null); do
+    sed -e "s#prefix=.*#prefix=/usr#g" -i "${PKG_CONFIGS}"
+  done
+
+  for PKG_PRI in $(find "${TOOLCHAIN}/mkspecs" -type f -name "*.pri" 2>/dev/null); do
+    sed -E "s#${PKG_ORIG_SYSROOT_PREFIX}/usr/lib/lib([^.]+)\.(so|a)# -l\1#g" -i "${PKG_PRI}"
+  done
+
+  # Create directories
+  mkdir -p ${INSTALL}/usr/lib
+  mkdir -p ${INSTALL}/usr/plugins
+  mkdir -p ${INSTALL}/usr/qml
+
+  # Sysroot path to Qt5 files
+  PKG_QT5_SYSROOT_PATH=${PKG_ORIG_SYSROOT_PREFIX:-${SYSROOT_PREFIX}}/usr
+
+  # Install Qt5 libs
+  for PKG_QT5_LIBS in \
+    libQt5Concurrent libQt5Core libQt5DBus libQt5Gamepad libQt5Gui libQt5Multimedia libQt5MultimediaGstTools libQt5MultimediaQuick \
+    libQt5MultimediaWidgets libQt5Network libQt5OpenGL libQt5Qml libQt5QmlModels libQt5QmlWorkerScript libQt5Quick libQt5QuickControls2 libQt5QuickParticles \
+    libQt5QuickTemplates2 libQt5QuickTest libQt5Sql libQt5Svg libQt5Test libQt5Widgets libQt5WebSockets libQt5Xml
+  do
+    cp -PR ${PKG_QT5_SYSROOT_PATH}/lib/${PKG_QT5_LIBS}.so* ${INSTALL}/usr/lib
+  done
+
+  # Install Qt5 plugins
+  for PKG_QT5_PLUGINS in \
+    audio gamepads imageformats iconengines mediaservice platforms playlistformats sqldrivers
+  do
+    cp -PR ${PKG_QT5_SYSROOT_PATH}/plugins/${PKG_QT5_PLUGINS} ${INSTALL}/usr/plugins
+  done
+
+  # Install Qt5 QML
+  for PKG_QT5_QML in \
+    Qt QtGamepad QtGraphicalEffects QtMultimedia QtQuick QtQuick.2 QtTest
+  do
+    cp -PR ${PKG_QT5_SYSROOT_PATH}/qml/${PKG_QT5_QML} ${INSTALL}/usr/qml
+  done
+
+  # Install libs, plugins & qml for Wayland/X11 display server
+  if [ ${DISPLAYSERVER} = "x11" ]; then
+    cp -PR ${PKG_QT5_SYSROOT_PATH}/lib/libQt5XcbQpa.so*      ${INSTALL}/usr/lib
+    cp -PR ${PKG_QT5_SYSROOT_PATH}/plugins/xcbglintegrations ${INSTALL}/usr/plugins
+  elif [ ${DISPLAYSERVER} = "wl" ]; then
+    cp -PR ${PKG_QT5_SYSROOT_PATH}/lib/libQt5WaylandClient.so*     ${INSTALL}/usr/lib
+    cp -PR ${PKG_QT5_SYSROOT_PATH}/lib/libQt5WaylandCompositor.so* ${INSTALL}/usr/lib
+
+    cp -PR ${PKG_QT5_SYSROOT_PATH}/plugins/platforms/libqwayland*              ${INSTALL}/usr/plugins/platforms
+    cp -PR ${PKG_QT5_SYSROOT_PATH}/plugins/wayland-decoration-client           ${INSTALL}/usr/plugins
+    cp -PR ${PKG_QT5_SYSROOT_PATH}/plugins/wayland-graphics-integration-client ${INSTALL}/usr/plugins
+    cp -PR ${PKG_QT5_SYSROOT_PATH}/plugins/wayland-graphics-integration-server ${INSTALL}/usr/plugins
+    cp -PR ${PKG_QT5_SYSROOT_PATH}/plugins/wayland-shell-integration           ${INSTALL}/usr/plugins
+
+    cp -PR ${PKG_QT5_SYSROOT_PATH}/qml/QtWayland ${INSTALL}/usr/qml
+  fi
+
+  # Install EGLFS libs & plugins if OpenGLES is supported
+  if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+    if [ ${DISPLAYSERVER} = "no" ]; then
+      cp -PR ${PKG_QT5_SYSROOT_PATH}/lib/libQt5EglFSDeviceIntegration.so* ${INSTALL}/usr/lib
+      cp -PR ${PKG_QT5_SYSROOT_PATH}/plugins/egldeviceintegrations        ${INSTALL}/usr/plugins
+    fi
+  fi
+}

--- a/packages/multimedia/gstreamer/gst-libav/package.mk
+++ b/packages/multimedia/gstreamer/gst-libav/package.mk
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2018-present Frank Hartung (supervisedthinking (@) gmail.com)
+
+PKG_NAME="gst-libav"
+PKG_VERSION="$(get_pkg_version gstreamer)"
+PKG_LICENSE="GPL-2.0-or-later"
+PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-libav.html"
+PKG_URL="https://gstreamer.freedesktop.org/src/gst-libav/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain gstreamer gst-plugins-base ffmpeg"
+PKG_LONGDESC="GStreamer plugin for the FFmpeg libav library"

--- a/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
@@ -2,8 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gst-plugins-bad"
-PKG_VERSION="1.21.2"
-PKG_SHA256="92fb4556e867d368f11178f659451a1110be2dcb71f54a1c00bc2173315d7697"
+PKG_VERSION="$(get_pkg_version gstreamer)"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-plugins-bad.html"
 PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-bad/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/gstreamer/gst-plugins-base/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-base/package.mk
@@ -2,8 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gst-plugins-base"
-PKG_VERSION="1.21.2"
-PKG_SHA256="1497013105d2fe783818dd6fe7a54f29c211f02c7080d98cbe62ffa847562068"
+PKG_VERSION="$(get_pkg_version gstreamer)"
 PKG_LICENSE="GPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-plugins-base.html"
 PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-base/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -12,57 +11,26 @@ PKG_LONGDESC="Base GStreamer plugins and helper libraries"
 PKG_BUILD_FLAGS="-gold"
 
 pre_configure_target() {
-  PKG_MESON_OPTS_TARGET="-Dgl=disabled \
-                         -Dadder=disabled \
-                         -Dapp=disabled \
-                         -Daudioconvert=disabled \
-                         -Daudiomixer=disabled \
-                         -Daudiorate=disabled \
-                         -Daudioresample=disabled \
-                         -Daudiotestsrc=disabled \
-                         -Dcompositor=disabled \
-                         -Dencoding=disabled \
-                         -Dgio=disabled \
-                         -Dgio-typefinder=disabled \
-                         -Doverlaycomposition=disabled \
-                         -Dpbtypes=disabled \
-                         -Dplayback=disabled \
-                         -Drawparse=enabled \
-                         -Dsubparse=enabled \
-                         -Dtcp=disabled \
-                         -Dtypefind=disabled \
-                         -Dvideoconvertscale=disabled \
-                         -Dvideorate=disabled \
-                         -Dvideotestsrc=disabled \
-                         -Dvolume=disabled \
-                         -Dalsa=disabled \
-                         -Dcdparanoia=disabled \
-                         -Dlibvisual=disabled \
-                         -Dogg=disabled \
-                         -Dopus=disabled \
-                         -Dpango=disabled \
-                         -Dtheora=disabled \
-                         -Dtremor=disabled \
-                         -Dvorbis=disabled \
-                         -Dx11=disabled \
-                         -Dxshm=disabled \
-                         -Dxi=disabled \
-                         -Dxvideo=disabled \
-                         -Dexamples=disabled \
+  PKG_MESON_OPTS_TARGET="-Dexamples=disabled \
                          -Dtests=disabled \
-                         -Dtools=disabled \
-                         -Dintrospection=disabled \
-                         -Dnls=disabled \
-                         -Dorc=disabled \
                          -Dgobject-cast-checks=disabled \
-                         -Dglib-asserts=disabled \
-                         -Dglib-checks=disabled \
                          -Dpackage-name=gst-plugins-base \
                          -Dpackage-origin=LibreELEC.tv \
-                         -Ddoc=disabled"
+                         -Ddoc=disabled \
+                         -Dnls=disabled"
+
+  # Fix undefined symbol glPointSizePointerOES
+  if [ "${OPENGLES}" = "bcm2835-driver" ]; then
+    TARGET_LDFLAGS+=" -lEGL -lGLESv2"
+  fi
+  # Fix missing dispmanx
+  if [ "${DEVICE}" = "RPi4" -o "${DEVICE}" = "RPi3" ]; then
+    PKG_MESON_OPTS_TARGET+=" -Dgl_winsys="egl""
+  fi
 }
 
 post_makeinstall_target() {
   # clean up
-  safe_remove ${INSTALL}
+  safe_remove ${INSTALL}/usr/bin
+  safe_remove ${INSTALL}/usr/share
 }

--- a/packages/multimedia/gstreamer/gst-plugins-good/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-good/package.mk
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2018-present Frank Hartung (supervisedthinking (@) gmail.com)
+
+PKG_NAME="gst-plugins-good"
+PKG_VERSION="$(get_pkg_version gstreamer)"
+PKG_SHA256="d17dca7a9ddb6b389f8d419834b5bac2ec0c5a5207c25773b1f5a57246282e84"
+PKG_LICENSE="LGPL-2.1-or-later"
+PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-plugins-good.html"
+PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-good/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain gstreamer gst-plugins-base"
+PKG_LONGDESC="Good GStreamer plugins and helper libraries"
+
+PKG_MESON_OPTS_TARGET="-Dgdk-pixbuf=disabled \
+                       -Dqt5=disabled \
+                       -Dtaglib=disabled \
+                       -Dexamples=disabled \
+                       -Dtests=disabled \
+                       -Dnls=disabled"
+
+  # Fix missing dispmanx
+  if [ "${DEVICE}" = "RPi4" -o "${DEVICE}" = "RPi2" ]; then
+    PKG_MESON_OPTS_TARGET+=" -Drpicamsrc=disabled"
+  fi
+
+post_makeinstall_target(){
+  # Clean up
+  safe_remove ${INSTALL}/usr/share
+}

--- a/packages/multimedia/gstreamer/gstreamer/package.mk
+++ b/packages/multimedia/gstreamer/gstreamer/package.mk
@@ -2,45 +2,25 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gstreamer"
-PKG_VERSION="1.21.2"
-PKG_SHA256="27d7139ff517a52a49b91908e6bb150df930f05c3c0ea7de20624cf7be40f640"
+PKG_VERSION="1.21.3"
+PKG_SHA256="27a75236bce2b10b188fe0c0087c6ceb9ee13c18fe9bf7437e0234a0e4afa226"
 PKG_LICENSE="GPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org"
 PKG_URL="https://gstreamer.freedesktop.org/src/gstreamer/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain glib glib:host"
+PKG_DEPENDS_TARGET="toolchain glib glib:host ffmpeg libvorbis-system flac-system"
 PKG_LONGDESC="GStreamer open-source multimedia framework core library"
 
 pre_configure_target() {
-  PKG_MESON_OPTS_TARGET="-Dgst_debug=false \
-                         -Dgst_parse=true \
-                         -Dregistry=false \
-                         -Dtracer_hooks=false \
-                         -Doption-parsing=true \
-                         -Dpoisoning=false \
-                         -Dcheck=disabled \
-                         -Dlibunwind=disabled \
-                         -Dlibdw=disabled \
-                         -Ddbghelp=disabled \
-                         -Dbash-completion=disabled \
-                         -Dcoretracers=disabled \
-                         -Dexamples=disabled \
-                         -Dtests=disabled \
-                         -Dbenchmarks=disabled \
-                         -Dtools=disabled \
-                         -Ddoc=disabled \
-                         -Dintrospection=disabled \
-                         -Dnls=disabled \
-                         -Dgobject-cast-checks=disabled \
-                         -Dglib-asserts=disabled \
-                         -Dglib-checks=disabled \
-                         -Dextra-checks=disabled \
-                         -Dpackage-name="gstreamer"
-                         -Dpackage-origin="LibreELEC.tv"
-                         -Ddoc=disabled"
+PKG_MESON_OPTS_TARGET="-Dlibunwind=disabled \
+                       -Dexamples=disabled \
+                       -Dtests=disabled \
+                       -Dnls=disabled \
+                       -Dpackage-name=gstreamer \
+                       -Dpackage-origin=LibreELEC.tv \
+                       -Ddoc=disabled"
 }
 
 post_makeinstall_target() {
   # clean up
   safe_remove ${INSTALL}/usr/share
-  safe_remove ${INSTALL}/usr/lib/{libgstcontroller-1.0*,libgstnet-1.0*}
 }


### PR DESCRIPTION
This adds QT5 support and all needed dependencies. Tested on YuzuSA

Thanks to @supervisedthinking & @LibreELEC-RR:
https://github.com/SupervisedThinking/LibreELEC-RR/blob/1f6f9a000fdd7b27a576db5e5b16d904856360a5/packages/supervisedthinking/toolkit/qt5/package.mk 

To run an application under qtwayland do one of the two:
- ./_application-name_ -platform wayland-egl
- Add **export QT_QPA_PLATFORM=wayland-egl** to your sh script

I did some research and you can do -platform **wayland** or **wayland-egl** but sounds like the latter is the correct way. 