### PR TITLE
Adds controller LED management to EmulationStation on Ayaneo devices.

### DIFF
--- a/packages/jelos/profile.d/02-distribution
+++ b/packages/jelos/profile.d/02-distribution
@@ -39,10 +39,17 @@ get_setting() {
   fi
 }
 
-set_setting() {
+del_setting() {
   if [[ "${1}" =~ ^[[:alnum:]] ]]
   then
     sed -i "/^${1}=/d" "${J_CONF}"
+  fi
+}
+
+set_setting() {
+  if [[ "${1}" =~ ^[[:alnum:]] ]]
+  then
+    del_setting "${1}"
     echo "${1}=${2}" >> "${J_CONF}"
   fi
 }

--- a/packages/sysutils/ectool/package.mk
+++ b/packages/sysutils/ectool/package.mk
@@ -12,6 +12,7 @@ PKG_LONGDESC="A simple tool for manipulating the embedded controller."
 
 make_target() {
   cd util/ectool
+  export PREFIX=/usr
   make
 }
 

--- a/packages/sysutils/powerstate/sources/powerstate.sh
+++ b/packages/sysutils/powerstate/sources/powerstate.sh
@@ -31,6 +31,7 @@ do
               set_setting system.gpuperf auto
             fi
           fi
+          led_mgr
           audio_powersave 1
           cpu_perftune battery
           gpu_performance_level ${GPUMODE}
@@ -40,6 +41,7 @@ do
         ;;
         *)
           log $0 "Switching to performance mode."
+          led_mgr
           audio_powersave 0
           cpu_perftune performance
           gpu_performance_level profile_standard

--- a/packages/sysutils/sleep/sources/sleep.sh
+++ b/packages/sysutils/sleep/sources/sleep.sh
@@ -97,6 +97,7 @@ case $1 in
     touch /run/.last_sleep_time
   ;;
   post)
+    led_mgr
     alsastate restore
     modules start
     powerstate start

--- a/packages/sysutils/system-utils/package.mk
+++ b/packages/sysutils/system-utils/package.mk
@@ -21,6 +21,7 @@ makeinstall_target() {
   cp ${PKG_DIR}/sources/scripts/system_utils ${INSTALL}/usr/bin
   cp ${PKG_DIR}/sources/scripts/volume_sense ${INSTALL}/usr/bin
   cp ${PKG_DIR}/sources/scripts/bluetooth_sense ${INSTALL}/usr/bin
+  cp ${PKG_DIR}/sources/scripts/led_mgr ${INSTALL}/usr/bin
   if [ -d "${PKG_DIR}/sources/devices/${DEVICE}" ]
   then
     cp ${PKG_DIR}/sources/devices/${DEVICE}/* ${INSTALL}/usr/bin

--- a/packages/sysutils/system-utils/sources/autostart/handheld/003-controllerled
+++ b/packages/sysutils/system-utils/sources/autostart/handheld/003-controllerled
@@ -1,0 +1,7 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
+
+. /etc/profile
+
+/usr/bin/led_mgr

--- a/packages/sysutils/system-utils/sources/scripts/led_mgr
+++ b/packages/sysutils/system-utils/sources/scripts/led_mgr
@@ -1,0 +1,145 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2020-present Fewtarius
+
+#
+# A simple tool to manipulate the joystick LEDs using ectool, thanks to
+# Maya (https://github.com/Maccraft123) for reverse engineering.
+#
+# Schema:
+#
+# 0x6d - LED PWM control (0x03)
+#
+# 0xb1 - Support for 4 zones and RGB color
+#
+# RGB colors:
+#
+# 1 - Red
+# 2 - Green
+# 3 - Blue
+#
+# Zones:
+#
+# Right (2), Down (5), Left (8) , Up (11)
+#
+# Note: Set 0xb1 to 02 for off.
+#
+# 0xbf - Set expected mode
+#
+# 0x10 - Enable
+# 0xe2 - Tint (+ Red for Purple, + Green for Teal)
+# 0xe3-0e5 - Tint + blink (unused)
+#
+# 0xff - Close channel
+#
+
+. /etc/profile
+
+ECTOOL="/usr/sbin/ectool"
+DEBUG=false
+
+function debug_out() {
+  $DEBUG && echo "led_mgr: $*"
+}
+
+function ec_writecmd() {
+  ${ECTOOL} -w 0x6d -z 0x03 >/dev/null 2>&1
+}
+
+function mode() {
+  debug_out "Set mode ${1}"
+  ${ECTOOL} -w 0xbf -z ${1} >/dev/null 2>&1
+  ${ECTOOL} -w 0xbf -z ff >/dev/null 2>&1
+}
+
+function off() {
+  ec_writecmd
+  for twice in 1 2
+  do
+    ### RGB off command
+    ${ECTOOL} -w 0xb1 -z 0x02 >/dev/null 2>&1
+    mode 0x10
+  done
+}
+
+function brightness() {
+  debug_out "Set brightness ${1}"
+  ${ECTOOL} -w 0xb2 -z 0x${1}  >/dev/null 2>&1
+  mode 0x10
+  set_setting led.brightness ${1}
+}
+
+function color() {
+  ## Writing twice seems more reliable than inserting a delay.
+  for twice in 1 2
+  do
+    for zone in 2 5 8 11
+    do
+      zone=$(( ${zone} + ${1} ))
+      zone=$(printf '%02x' ${zone})
+      debug_out "Set color 0x${zone}"
+      ${ECTOOL} -w 0xb1 -z 0x${zone} >/dev/null 2>&1
+      brightness ${2}
+    done
+  done
+}
+
+if [ "${2}" ]
+then
+  LEDBRIGHTNESS=${2}
+else
+  LEDBRIGHTNESS=$(get_setting led.brightness)
+  if [ -z "${LEDBRIGHTNESS}" ]
+  then
+    LEDBRIGHTNESS=ff
+  fi
+fi
+debug_out "led brightness: ${LEDBRIGHTNESS}"
+
+case $1 in
+  red)
+    off
+    color 1 ${LEDBRIGHTNESS}
+    set_setting led.color red
+  ;;
+  green)
+    off
+    color 2 ${LEDBRIGHTNESS}
+    set_setting led.color green
+  ;;
+  blue)
+    off
+    color 3 ${LEDBRIGHTNESS}
+    set_setting led.color blue
+  ;;
+  teal)
+    off
+    mode 0xe2
+    color 2 ${LEDBRIGHTNESS}
+    set_setting led.color teal
+  ;;
+  purple)
+    off
+    mode 0xe2
+    color 1 ${LEDBRIGHTNESS}
+    set_setting led.color purple
+  ;;
+  off)
+    off
+    set_setting led.color off
+  ;;
+  default)
+    del_setting led.color
+    del_setting led.brightness
+  ;;
+  *)
+    COLOR=$(get_setting led.color)
+    LEDBRIGHTNESS=$(get_setting led.brightness)
+    if [ ! -z "${COLOR}" ]
+    then
+      off
+      led_mgr ${COLOR} ${LEDBRIGHTNESS}
+    fi
+  ;;
+esac
+

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="emulationstation"
-PKG_VERSION="67ebda6"
+PKG_VERSION="5faae0f"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
* Add support for LED management on the Ayaneo Air Pro and possibly other models which can be found in system settings.  Thanks to @Maccraft123 for reverse engineering and sharing the EC registers.  Additional documentation can be found in the led_mgmt script.
* Add ability to delete a setting from system.cfg "del_setting".
