### PR TITLE
Update Emulators and Packages

### DIFF
--- a/packages/games/emulators/dolphinsa/package.mk
+++ b/packages/games/emulators/dolphinsa/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present BrooksyTech (https://github.com/brooksytech)
 
 PKG_NAME="dolphinsa"
-PKG_VERSION="8d477c65c9a72020a5839299c0dcf130304cb2e6"
+PKG_VERSION="4d164fcb77487b0cb732e0423961fd042c3e7e3b"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/dolphin-emu/dolphin"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/games/emulators/duckstationsa/package.mk
+++ b/packages/games/emulators/duckstationsa/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="duckstationsa"
 PKG_LICENSE="GPLv3"
-PKG_VERSION="6a7407565a61fb470a495cc98068db729b8f1e4f"
+PKG_VERSION="55e0e7ffbea9143f7809a926cf11c6986971881a"
 PKG_DEPENDS_TARGET="toolchain SDL2 nasm:host pulseaudio openssl libidn2 nghttp2 zlib curl libevdev ecm"
 PKG_SITE="https://github.com/stenzek/duckstation"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/games/emulators/duckstationsa/patches/002-fix-evdev-compile.patch
+++ b/packages/games/emulators/duckstationsa/patches/002-fix-evdev-compile.patch
@@ -1,0 +1,23 @@
+diff --git a/src/frontend-common/evdev_input_source.cpp b/src/frontend-common/evdev_input_source.cpp
+index 970e0ca4..480fb0ba 100644
+--- a/src/frontend-common/evdev_input_source.cpp
++++ b/src/frontend-common/evdev_input_source.cpp
+@@ -328,7 +328,7 @@ std::optional<InputBindingKey> EvdevInputSource::ParseKeyString(const std::strin
+       if (abinding == axis.name)
+       {
+         key.source_subtype = InputSubclass::ControllerAxis;
+-        key.negative = (binding[0] == '-');
++        // key.negative = (binding[0] == '-');
+         key.data = axis.id;
+         return key;
+       }
+@@ -365,7 +365,8 @@ std::string EvdevInputSource::ConvertKeyToString(InputBindingKey key)
+         {
+           if (static_cast<u32>(axis.id) == key.data)
+           {
+-            ret = fmt::format("{}/{}{}", cd->uniq, key.negative ? "-" : "+", axis.name);
++            //ret = fmt::format("{}/{}{}", cd->uniq, key.negative ? "-" : "+", axis.name);
++            ret = fmt::format("{}/{}{}", cd->uniq, axis.name);
+             break;
+           }
+         }

--- a/packages/games/emulators/yuzusa/package.mk
+++ b/packages/games/emulators/yuzusa/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present BrooksyTech (https://github.com/brooksytech)
 
 PKG_NAME="yuzusa"
-PKG_VERSION="f99f618d45ad862c4bc23fc28c91d1c48218a3cb"
+PKG_VERSION="c5743d5499db336718b93a6954ec1168c660fbec"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/yuzu-emu/yuzu"

--- a/packages/games/libretro/lrps2/package.mk
+++ b/packages/games/libretro/lrps2/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Fewtarius
 
 PKG_NAME="lrps2"
-PKG_VERSION="1f88fb5e663ff8b516dbca00f81fac271333b4aa"
+PKG_VERSION="f3c8743d6a42fe429f703b476fecfdb5655a98a9"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_DEPENDS_TARGET="toolchain alsa-lib freetype zlib libpng libaio libsamplerate libfmt libpcap soundtouch yamlcpp wxwidgets"

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -16,9 +16,10 @@ case ${DEVICE} in
         PKG_GIT_CLONE_BRANCH="csf"
   ;;
   *)
-        PKG_VERSION="d5394296becfc97bc992c82d6f5d013b35b5275a"
-        PKG_SITE="https://gitlab.freedesktop.org/mesa/mesa"
-        PKG_URL="${PKG_SITE}.git"
+	PKG_VERSION="22.3.5"
+	PKG_SHA256="3eed2ecae2bc674494566faab9fcc9beb21cd804c7ba2b59a1694f3d7236e6a9"
+	PKG_SITE="http://www.mesa3d.org/"
+	PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"
   ;;
 esac
 

--- a/packages/kernel/linux-firmware/libmali_rk3588/package.mk
+++ b/packages/kernel/linux-firmware/libmali_rk3588/package.mk
@@ -2,6 +2,7 @@
 # Copyright (C) 2022-present BrooksyTech (https://github.com/brooksytech)
 
 PKG_NAME="libmali_rk3588"
+PKG_VERSION="1.0"
 PKG_LICENSE="GPLv3"
 PKG_ARCH="arm aarch64"
 PKG_DEPENDS_TARGET="kernel-firmware"

--- a/packages/sysutils/pciutils/package.mk
+++ b/packages/sysutils/pciutils/package.mk
@@ -4,7 +4,7 @@
 
 PKG_NAME="pciutils"
 PKG_VERSION="3.9.0"
-PKG_ARCH="x86_64"
+PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://mj.ucw.cz/pciutils.shtml"
 PKG_URL="http://www.kernel.org/pub/software/utils/pciutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -30,9 +30,7 @@ makeinstall_target() {
   make ${PKG_MAKE_OPTS} DESTDIR=${SYSROOT_PREFIX} install
   make ${PKG_MAKE_OPTS} DESTDIR=${SYSROOT_PREFIX} install-lib
   make ${PKG_MAKE_OPTS} DESTDIR=${INSTALL} install-lib
-  if [ "${TARGET_ARCH}" = x86_64 ]; then
-    make ${PKG_MAKE_OPTS} DESTDIR=${INSTALL} install
-  fi
+  make ${PKG_MAKE_OPTS} DESTDIR=${INSTALL} install
 }
 
 post_makeinstall_target() {

--- a/packages/ui/emulationstation/config/device/RK3588/es_systems.cfg
+++ b/packages/ui/emulationstation/config/device/RK3588/es_systems.cfg
@@ -1180,16 +1180,9 @@
       <emulators>
          <emulator name="retroarch">
             <cores>
-               <core>parallel_n64</core>
+               <core default="true">parallel_n64</core>
                <core>mupen64plus</core>
-               <core default="true">mupen64plus_next</core>
-            </cores>
-         </emulator>
-         <emulator name="mupen64plussa">
-            <cores>
-               <core>m64p_gliden64</core>
-               <core>m64p_gl64mk2</core>
-               <core>m64p_rice</core>
+               <core>mupen64plus_next</core>
             </cores>
          </emulator>
       </emulators>


### PR DESCRIPTION
*Update YuzuSA, DolphinSA, DuckstationSA, and LRPS2
*Enable PciUtils on arm
*Bump Mesa to 23.3.5 (No more lockups so far!)
*Clean up ES systems for RK3588
*Fix version number on RK3588 libmali firmware blob