### PR TITLE
Fix MelonDS SA audio

### DIFF
--- a/packages/games/emulators/melondssa/patches/003-fix-audio.patch
+++ b/packages/games/emulators/melondssa/patches/003-fix-audio.patch
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2023-present BrooksyTech (https://github.com/brooksytech)
+
+diff --git a/src/frontend/qt_sdl/Platform.cpp b/src/frontend/qt_sdl/Platform.cpp
+index f9eaf42..ff4bc03 100644
+--- a/src/frontend/qt_sdl/Platform.cpp
++++ b/src/frontend/qt_sdl/Platform.cpp
+@@ -81,7 +81,7 @@ void IPCInit()
+     {
+         if (!(mask & (1<<i)))
+         {
+-            IPCInstanceID = i;
++            IPCInstanceID = 0;
+             *(u16*)&data[0] |= (1<<i);
+             break;
+         }


### PR DESCRIPTION
Audio would no longer work for MelonDS after the first time you ran it. Had to reboot the system. This resolved the issue. 