### PR TITLE
Set es shader menu to show .glslp only

### DIFF
--- a/packages/jelos/sources/scripts/getshaders
+++ b/packages/jelos/sources/scripts/getshaders
@@ -10,7 +10,7 @@ if [[ "${UI_SERVICE}" =~ ^weston ]]
 then
   SHADERS='*.slang*'
 else
-  SHADERS='*.glsl*'
+  SHADERS='*.glslp*'
 fi
 
 for dir in /tmp/shaders


### PR DESCRIPTION
When in emulationstation, setting a .glsl shader file as the default doesn't work in retroarch, so change the menu to show only .glslp files which apply properly

Tested on my RG353P 
