### PR TITLE
OGU write u-boot.bin to img

### DIFF
--- a/packages/emulators/standalone/retroarch/package.mk
+++ b/packages/emulators/standalone/retroarch/package.mk
@@ -88,9 +88,9 @@ makeinstall_target() {
 
   case ${ARCH} in
     aarch64)
-  #   cp -vP ${ROOT}/build.${DISTRO}-${DEVICE}.arm/retroarch-*/.install_pkg/usr/bin/retroarch ${INSTALL}/usr/bin/retroarch32
-#     mkdir -p ${INSTALL}/usr/share/retroarch/filters/32bit/
- #    cp -rvP ${ROOT}/build.${DISTRO}-${DEVICE}.arm/retroarch-*/.install_pkg/usr/share/retroarch/filters/64bit/* ${INSTALL}/usr/share/retroarch/filters/32bit/
+     cp -vP ${ROOT}/build.${DISTRO}-${DEVICE}.arm/retroarch-*/.install_pkg/usr/bin/retroarch ${INSTALL}/usr/bin/retroarch32
+     mkdir -p ${INSTALL}/usr/share/retroarch/filters/32bit/
+     cp -rvP ${ROOT}/build.${DISTRO}-${DEVICE}.arm/retroarch-*/.install_pkg/usr/share/retroarch/filters/64bit/* ${INSTALL}/usr/share/retroarch/filters/32bit/
     ;;
   esac
 

--- a/projects/Amlogic/bootloader/release
+++ b/projects/Amlogic/bootloader/release
@@ -6,18 +6,14 @@ if [ -n "${UBOOT_CONFIG}" ]; then
   BOOTLOADER_DIR=$(get_build_dir ${BOOTLOADER})
   KERNEL_DIR=$(get_build_dir linux)
 
-#  case "${PKG_SOC}" in
-#    s922x)
-#      if [ -f ${BOOTLOADER_DIR}/u-boot.bin ]; then
-#        cp -a ${BOOTLOADER_DIR}/u-boot.bin ${RELEASE_DIR}/3rdparty/bootloader
-#      fi
-#    ;;
-#  esac
+  case "${PKG_SOC}" in
+    s922x) 
+      if [ -f ${INSTALL}/usr/share/bootloader/u-boot.bin ]; then
+        cp -a ${INSTALL}/usr/share/bootloader/u-boot.bin ${RELEASE_DIR}/3rdparty/bootloader
+      fi
+    ;;
+  esac
 fi
-
-#if [ -f ${INSTALL}/usr/share/bootloader/boot.ini ]; then
-#  cp -a ${INSTALL}/usr/share/bootloader/boot.ini ${RELEASE_DIR}/3rdparty/bootloader
-#fi
 
 LINUX_DTS_DIR=$(get_build_dir linux)/arch/${TARGET_KERNEL_ARCH}/boot/dts/
 for dtb in $(find ${LINUX_DTS_DIR} -name "*.dtb") ; do

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -298,6 +298,11 @@ if [ "${PROJECT}" = "Generic" ]; then
   [ -n "${SUDO_USER}" ] && chown "${SUDO_USER}:" "${DISK_BASENAME}.ova"
 fi
 
+if [ "${DEVICE}" = "OGU" ]; then
+  echo "image: write u-boot.bin to disk..."
+  dd if="${RELEASE_DIR}/3rdparty/bootloader/u-boot.bin" of="${DISK}" conv=fsync,notrunc bs=512 seek=1 >"${SAVE_ERROR}" 2>&1 || show_error
+fi
+
 # gzip
 echo "image: compressing..."
 pigz --best --force "${DISK}"


### PR DESCRIPTION
Disk image should now be bootable without needing to manually flash the u-boot.bin

also fix retroarch package error. 