### PR TITLE
Set GOCACHE path for go and syncthing

### DIFF
--- a/packages/lang/go/package.mk
+++ b/packages/lang/go/package.mk
@@ -16,6 +16,7 @@ configure_host() {
   export HOME=${ROOT}
   export GOOS=linux
   export GOROOT_FINAL=${TOOLCHAIN}/lib/golang
+  export GOCACHE=${HOME}/.cache/go-build
   if [ -x /usr/lib/go/bin/go ]; then
     export GOROOT_BOOTSTRAP=/usr/lib/go
   else

--- a/packages/network/syncthing/package.mk
+++ b/packages/network/syncthing/package.mk
@@ -20,7 +20,8 @@ configure_target() {
 }
 
 make_target() {
-  HOME=${ROOT} ${GOLANG} build -a -ldflags "${LDFLAGS}" -o bin/syncthing -v ./cmd/syncthing
+  HOME=${ROOT} GOCACHE=${ROOT}/.cache/go-build \
+       ${GOLANG} build -a -ldflags "${LDFLAGS}" -o bin/syncthing -v ./cmd/syncthing
 }
 
 makeinstall_target() {


### PR DESCRIPTION
## Description

I was trying to build on fedora with podman using `DOCKER_WORK_DIR=/work make docker-RK3566`.

The go and syncthing packages were failing with permission denied when trying to create the go cache in the home directory.

I'm not sure whether this should be set in the `go_configure` function in `config/functions`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

I ran `DOCKER_WORK_DIR=/work make docker-RK3566`

**Test Configuration**:
* Build OS name and version: Fedora 38
* Docker (Y/N): Y (podman)
* JELOS Branch: dev/main
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
