### PR TITLE
Fix occasional build errors on wifi drivers.

### DIFF
--- a/packages/kernel/linux-drivers/RTL8188EU/package.mk
+++ b/packages/kernel/linux-drivers/RTL8188EU/package.mk
@@ -11,6 +11,7 @@ PKG_DEPENDS_TARGET="toolchain linux kernel-firmware"
 PKG_NEED_UNPACK="${LINUX_DEPENDS}"
 PKG_LONGDESC="Realtek RTL81xxEU Linux 3.x driver"
 PKG_IS_KERNEL_PKG="yes"
+PKG_TOOLCHAIN="make"
 
 pre_make_target() {
   unset LDFLAGS

--- a/packages/kernel/linux-drivers/RTL8188FU/package.mk
+++ b/packages/kernel/linux-drivers/RTL8188FU/package.mk
@@ -7,6 +7,7 @@ PKG_DEPENDS_TARGET="toolchain linux kernel-firmware"
 PKG_NEED_UNPACK="${LINUX_DEPENDS}"
 PKG_LONGDESC="Realtek RTL81xxFU Linux firmware"
 PKG_IS_KERNEL_PKG="yes"
+PKG_TOOLCHAIN="make"
 
 pre_make_target() {
   unset LDFLAGS

--- a/packages/kernel/linux-drivers/RTL8192CU/package.mk
+++ b/packages/kernel/linux-drivers/RTL8192CU/package.mk
@@ -9,6 +9,7 @@ PKG_SITE="https://github.com/pvaret/rtl8192cu-fixes"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
 PKG_LONGDESC="Realtek RTL81xxCU Linux 3.x driver"
 PKG_IS_KERNEL_PKG="yes"
+PKG_TOOLCHAIN="make"
 
 pre_make_target() {
   unset LDFLAGS

--- a/packages/kernel/linux-drivers/RTL8192EU/package.mk
+++ b/packages/kernel/linux-drivers/RTL8192EU/package.mk
@@ -9,6 +9,7 @@ PKG_SITE="https://github.com/Mange/rtl8192eu-linux-driver"
 PKG_URL="https://github.com/Mange/rtl8192eu-linux-driver/archive/${PKG_VERSION}.tar.gz"
 PKG_LONGDESC="Realtek RTL8192EU Linux 3.x driver"
 PKG_IS_KERNEL_PKG="yes"
+PKG_TOOLCHAIN="make"
 
 pre_make_target() {
   unset LDFLAGS

--- a/packages/kernel/linux-drivers/RTL8812AU/package.mk
+++ b/packages/kernel/linux-drivers/RTL8812AU/package.mk
@@ -12,6 +12,7 @@ PKG_DEPENDS_TARGET="toolchain linux"
 PKG_NEED_UNPACK="${LINUX_DEPENDS}"
 PKG_LONGDESC="Realtek 8812AU driver for 4.4-5.x"
 PKG_IS_KERNEL_PKG="yes"
+PKG_TOOLCHAIN="make"
 
 pre_make_target() {
   unset LDFLAGS

--- a/packages/kernel/linux-drivers/RTL8814AU/package.mk
+++ b/packages/kernel/linux-drivers/RTL8814AU/package.mk
@@ -12,6 +12,7 @@ PKG_DEPENDS_TARGET="toolchain linux"
 PKG_NEED_UNPACK="${LINUX_DEPENDS}"
 PKG_LONGDESC="Realtek 8814AU driver for 4.4-5.x"
 PKG_IS_KERNEL_PKG="yes"
+PKG_TOOLCHAIN="make"
 
 pre_make_target() {
   unset LDFLAGS

--- a/packages/kernel/linux-drivers/RTL8821AU/package.mk
+++ b/packages/kernel/linux-drivers/RTL8821AU/package.mk
@@ -12,6 +12,7 @@ PKG_DEPENDS_TARGET="toolchain linux"
 PKG_NEED_UNPACK="${LINUX_DEPENDS}"
 PKG_LONGDESC="Realtek 8821AU driver for 4.4-5.x"
 PKG_IS_KERNEL_PKG="yes"
+PKG_TOOLCHAIN="make"
 
 pre_make_target() {
   unset LDFLAGS

--- a/packages/kernel/linux-drivers/RTL8821CU/package.mk
+++ b/packages/kernel/linux-drivers/RTL8821CU/package.mk
@@ -12,6 +12,7 @@ PKG_DEPENDS_TARGET="toolchain linux"
 PKG_NEED_UNPACK="${LINUX_DEPENDS}"
 PKG_LONGDESC="Realtek 8821CU driver for 4.4-5.x"
 PKG_IS_KERNEL_PKG="yes"
+PKG_TOOLCHAIN="make"
 
 pre_make_target() {
   unset LDFLAGS

--- a/packages/kernel/linux-drivers/RTL88x2BU/package.mk
+++ b/packages/kernel/linux-drivers/RTL88x2BU/package.mk
@@ -12,6 +12,7 @@ PKG_DEPENDS_TARGET="toolchain linux"
 PKG_NEED_UNPACK="${LINUX_DEPENDS}"
 PKG_LONGDESC="Realtek 88x2BU driver for 4.4-5.x"
 PKG_IS_KERNEL_PKG="yes"
+PKG_TOOLCHAIN="make"
 
 pre_make_target() {
   unset LDFLAGS


### PR DESCRIPTION
Every few builds on the S922X kernel I get a package toolchain not found on one of the wifi drivers. 

This should resolve it. 