### PR TITLE
S922X: enable audio hack

### DIFF
--- a/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/asound.gou
+++ b/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/asound.gou
@@ -1,56 +1,3 @@
-#!/bin/bash
-# SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
-
-. /etc/profile
-
-### Set a custom device so we don't clobber it.
-set-audio set "CUSTOM (UNMANAGED)"
-set-audio esset "Master"
-
-cat <<EOF >/storage/.config/asound.conf
-ctl.!default {
-  type hw
-  card 0
-}
-
-pcm.!default {
-	type plug
-	slave.pcm "softvol"
-}
-
-pcm.softvol {
-    type softvol
-    slave.pcm "dmixer"
-    control {
-        name "Pre-Amp"
-        card 0
-    }
-    min_dB -5.0
-    max_dB 20.0
-    resolution 6
-}
-
-pcm.dmixer  {
-	type dmix
-	ipc_key 1024
-	slave {
-	    pcm "hw:0,0"
-	    period_time 0
-	    period_size 4096
-	    buffer_size 131072
-	    rate 176400
-	}
-	bindings {
-	    0 0
-	    1 1
-	}
-}
-EOF
-
-if [ ! -e "/storage/.config/asound.state" ]
-then
-  cat <<EOF >/storage/.config/asound.state
 state.Ultra {
 	control.1 {
 		iface MIXER
@@ -312,8 +259,3 @@ state.Ultra {
 		}
 	}
 }
-EOF
-fi
-
-alsactl init
-alsactl -U --file /usr/lib/autostart/quirks/Hardkernel\ ODROID-GO-Ultra/asound.gou restore

--- a/packages/ui/emulationstation/config/device/S922X/es_systems.cfg
+++ b/packages/ui/emulationstation/config/device/S922X/es_systems.cfg
@@ -1778,8 +1778,8 @@
          </emulator>
          <emulator name="retroarch">
             <cores>
-               <core default="true">yabasanshiro</core>
-               <core>beetle_saturn</core>
+               <core>yabasanshiro</core>
+               <core default="true">beetle_saturn</core>
             </cores>
          </emulator>
       </emulators>


### PR DESCRIPTION
Yes this audio fix is a hack. It seems to work every time so going to roll with it for now. 

Also change the default saturn core to beetle saturn. The other ones need to be fixed. 