### PR TITLE
Container support, and cleanup work.

### DIFF
--- a/distributions/JELOS/options
+++ b/distributions/JELOS/options
@@ -90,6 +90,12 @@
 # build and install hfs filesystem utilities (yes / no)
   HFSTOOLS="yes"
 
+# Target an emulation device
+  EMULATION_DEVICE="${EMULATION_DEVICE:-yes}"
+
+# Add support for containers
+  CONTAINER_SUPPORT="${CONTAINER_SUPPORT:-no}"
+
 # Windowmanager to use (fluxbox / none)
   WINDOWMANAGER="none"
 

--- a/packages/jelos/autostart/001-setup
+++ b/packages/jelos/autostart/001-setup
@@ -4,7 +4,8 @@
 
 . /etc/profile
 
-if [ ! -L "/storage/.emulationstation" ]
+if [ ! -L "/storage/.emulationstation" ] && \
+   [ -d /storage/.config/emulationstation ]
 then
   ln -sf /storage/.config/emulationstation /storage/.emulationstation
 fi

--- a/packages/jelos/autostart/010-uimode
+++ b/packages/jelos/autostart/010-uimode
@@ -5,7 +5,8 @@
 . /etc/profile
 
 UIMODE=$(get_setting desktop.enabled)
-if [ "${UIMODE}" = "1" ]
+if [ "${UIMODE}" = "1" ] || \
+   [ ! -e "/usr/bin/emulationstation" ]
 then
   cp -f /usr/share/weston/weston.ini /storage/.config/weston.ini
 else
@@ -13,7 +14,8 @@ else
 fi
 
 STARTUP=$(get_setting weston.startup)
-if [ -z "${STARTUP}" ]
+if [ -z "${STARTUP}" ] && \
+   [ -e "/usr/bin/emulationstation" ]
 then
   STARTUP="/usr/bin/start_es.sh"
   set_setting weston.startup "${STARTUP}"

--- a/packages/jelos/package.mk
+++ b/packages/jelos/package.mk
@@ -14,50 +14,6 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 PKG_TOOLCHAIN="make"
 
-PKG_BASEOS="plymouth-lite grep wget util-linux xmlstarlet gnupg gzip patchelf imagemagick \
-            terminus-font vim bash pyudev dialog six git dbus-python coreutils \
-            alsa-ucm-conf fbgrab modules system-utils autostart quirks powerstate powertop ectool"
-
-PKG_UI="emulationstation es-themes"
-
-PKG_UI_TOOLS="fileman"
-
-PKG_SOFTWARE=""
-
-case "${ENABLE_32BIT}" in
-  true)
-    PKG_COMPAT="lib32"
-  ;;
-esac
-
-PKG_MULTIMEDIA="ffmpeg vlc mpv"
-
-PKG_NETWORK="network synctools pygobject"
-
-PKG_TOOLS="i2c-tools evtest jslisten"
-
-### Project specific variables
-case "${PROJECT}" in
-  PC)
-    PKG_BASEOS+=" installer"
-  ;;
-  *)
-    PKG_EMUS+=" retropie-shaders"
-  ;;
-esac
-
-if [ ! "${OPENGL}" = "no" ]
-then
-  PKG_DEPENDS_TARGET+=" mesa-demos glmark2"
-fi
-
-if [ ! -z "${BASE_ONLY}" ]
-then
-  PKG_DEPENDS_TARGET+=" ${PKG_BASEOS} ${PKG_NETWORK} ${PKG_TOOLS} ${PKG_UI}"
-else
-  PKG_DEPENDS_TARGET+=" ${PKG_BASEOS} ${PKG_NETWORK} ${PKG_TOOLS} ${PKG_UI} ${PKG_UI_TOOLS} ${PKG_COMPAT} ${PKG_MULTIMEDIA} ${PKG_SOFTWARE}"
-fi
-
 make_target() {
   :
 }

--- a/packages/services/docker/cli/package.mk
+++ b/packages/services/docker/cli/package.mk
@@ -43,5 +43,7 @@ make_target() {
 }
 
 makeinstall_target() {
-  :
+  mkdir -p ${INSTALL}/usr/bin
+  cp bin/* ${INSTALL}/usr/bin
+  chmod 0755 ${INSTALL}/usr/bin/*
 }

--- a/packages/services/docker/containerd/package.mk
+++ b/packages/services/docker/containerd/package.mk
@@ -39,3 +39,9 @@ make_target() {
   ${GOLANG} build -v -o bin/containerd-shim         -a -tags "static_build no_btrfs" -ldflags "${LDFLAGS}" ./cmd/containerd-shim
   ${GOLANG} build -v -o bin/containerd-shim-runc-v2 -a -tags "static_build no_btrfs" -ldflags "${LDFLAGS}" ./cmd/containerd-shim-runc-v2
 }
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+  cp bin/* ${INSTALL}/usr/bin
+  chmod 0755 ${INSTALL}/usr/bin/*
+}

--- a/packages/services/docker/moby/package.mk
+++ b/packages/services/docker/moby/package.mk
@@ -50,5 +50,7 @@ make_target() {
 }
 
 makeinstall_target() {
-  :
+  mkdir -p ${INSTALL}/usr/bin
+  cp bin/* ${INSTALL}/usr/bin
+  chmod 0755 ${INSTALL}/usr/bin/*
 }

--- a/packages/services/docker/runc/package.mk
+++ b/packages/services/docker/runc/package.mk
@@ -32,3 +32,9 @@ make_target() {
   mkdir -p bin
   ${GOLANG} build -v -o bin/runc -a -tags "cgo static_build" -ldflags "${LDFLAGS}" ./
 }
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+  cp bin/* ${INSTALL}/usr/bin
+  chmod 0755 ${INSTALL}/usr/bin/*
+}

--- a/packages/sysutils/systemd/scripts/userconfig-setup
+++ b/packages/sysutils/systemd/scripts/userconfig-setup
@@ -9,28 +9,29 @@
 if [ ! -e "/storage/.configured" ]
 then
   # Copy config files, but don't overwrite.  Only run if /storage is fresh
-  ## cp -iRp /usr/config/* /storage/.config/ &>/dev/null
-  ## ignore es_systems.cfg and switch to rsync
   rsync -a --ignore-existing --exclude=es_systems.cfg /usr/config/* /storage/.config/ 2>&1 >/var/log/configure.log
-  mkdir -p /storage/.config/emulationstation/themes 2>&1 >>/var/log/configure.log
-  ln -s /usr/share/themes/es-theme-art-book-next /storage/.config/emulationstation/themes/system-theme 2>&1 >>/var/log/configure.log
-  ln -s /usr/share/themes/es-theme-minielec /storage/.config/emulationstation/themes/es-theme-minielec 2>&1 >>/var/log/configure.log
-  ln -s /usr/share/themes/es-theme-minimal /storage/.config/emulationstation/themes/es-theme-minimal 2>&1 >>/var/log/configure.log
 
-  ### Link the game controller database so it is managed with OS updates.
-  rm -f /storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt 2>&1 >>/var/log/configure.log
-  ln -s /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt /storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt 2>&1 >>/var/log/configure.log
+  if [ -e "/usr/bin/emulationstation" ]
+  then
+    mkdir -p /storage/.config/emulationstation/themes 2>&1 >>/var/log/configure.log
+    ln -s /usr/share/themes/es-theme-art-book-next /storage/.config/emulationstation/themes/system-theme 2>&1 >>/var/log/configure.log
+    ln -s /usr/share/themes/es-theme-minielec /storage/.config/emulationstation/themes/es-theme-minielec 2>&1 >>/var/log/configure.log
+    ln -s /usr/share/themes/es-theme-minimal /storage/.config/emulationstation/themes/es-theme-minimal 2>&1 >>/var/log/configure.log
 
-  ### Remove and link es configs so they are managed with OS updates.
-  for es_cfg in es_features.cfg es_systems.cfg
-  do
-    ln -s /usr/config/emulationstation/${es_cfg} /storage/.config/emulationstation/${es_cfg} 2>&1 >>/var/log/configure.log
-  done
+    ### Link the game controller database so it is managed with OS updates.
+    rm -f /storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt 2>&1 >>/var/log/configure.log
+    ln -s /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt /storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt 2>&1 >>/var/log/configure.log
 
-  ### Link the ES splash to the distribution splash
-  rm -f /storage/.config/emulationstation/resources/logo.png 2>&1 >>/var/log/configure.log
-  ln -sf /usr/config/splash/splash.png /storage/.config/emulationstation/resources/logo.png 2>&1 >>/var/log/configure.log
+    ### Remove and link es configs so they are managed with OS updates.
+    for es_cfg in es_features.cfg es_systems.cfg
+    do
+      ln -s /usr/config/emulationstation/${es_cfg} /storage/.config/emulationstation/${es_cfg} 2>&1 >>/var/log/configure.log
+    done
 
+    ### Link the ES splash to the distribution splash
+    rm -f /storage/.config/emulationstation/resources/logo.png 2>&1 >>/var/log/configure.log
+    ln -sf /usr/config/splash/splash.png /storage/.config/emulationstation/resources/logo.png 2>&1 >>/var/log/configure.log
+  fi
   mkdir -p /storage/.config/modprobe.d 2>&1 >>/var/log/configure.log
   touch /storage/.configured 2>&1 >>/var/log/configure.log
 fi
@@ -41,7 +42,8 @@ then
   ldconfig -X 2>&1 >>/var/log/configure.log
 fi
 
-if [ ! -d "/storage/.config/emulationstation/locale" ]
+if [ ! -d "/storage/.config/emulationstation/locale" ] && \
+   [ -e "/usr/bin/emulationstation" ]
 then
   rsync -a --delete /usr/config/locale/ /storage/.config/emulationstation/locale/ 2>&1 >>/var/log/configure.log
 fi

--- a/packages/tools/sysutils/six/package.mk
+++ b/packages/tools/sysutils/six/package.mk
@@ -2,8 +2,7 @@
 # Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="six"
-PKG_VERSION="aa4e90bcd7b7bc13a71dfaebcb2021f4caaa8432"
-PKG_SHA256="c96447798c18575887c4eddc9bf05fc09ba52d008584f0e5c2d8337795572d61"
+PKG_VERSION="3b7efbcca41857da03fb01f004ccc425ab82dfbf"
 PKG_LICENSE="OSS"
 PKG_SITE="https://github.com/benjaminp/six"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"

--- a/packages/virtual/docker/package.mk
+++ b/packages/virtual/docker/package.mk
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2022 - Fewtarius
+
+PKG_NAME="docker"
+PKG_LICENSE="Apache-2.0"
+PKG_SITE="www.jelos.org"
+PKG_SECTION="virtual"
+PKG_LONGDESC="Container support software metapackage."
+
+PKG_CONTAINERSUPPORT="cli containerd moby runc tini"
+
+PKG_DEPENDS_TARGET="${PKG_CONTAINERSUPPORT}"
+

--- a/packages/virtual/emulators/package.mk
+++ b/packages/virtual/emulators/package.mk
@@ -40,16 +40,19 @@ case "${DEVICE}" in
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 flycast-lr pcsx_rearmed-lr"
     PKG_EMUS+=" aethersx2-sa duckstation-sa pcsx_rearmed-lr box64 yabasanshiro-sa"
     LIBRETRO_CORES+=" beetle-psx-lr bsnes-hd-lr dolphin-lr mame-lr box64"
+    PKG_RETROARCH+=" retropie-shaders"
   ;;
   RK3566)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 flycast-lr pcsx_rearmed-lr"
     PKG_DEPENDS_TARGET+=" common-shaders glsl-shaders mupen64plus-sa box64"
     PKG_EMUS+=" dolphin-sa drastic-sa yabasanshiro-sa"
+    PKG_RETROARCH+=" retropie-shaders"
   ;;
   S922X)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 flycast-lr pcsx_rearmed-lr"
     PKG_EMUS+=" aethersx2-sa dolphin-sa drastic-sa duckstation-sa mupen64plus-sa yabasanshiro-sa box64"
     LIBRETRO_CORES+=" beetle-psx-lr bsnes-hd-lr flycast-lr dolphin-lr yabasanshiro-sa"
+    PKG_RETROARCH+=" retropie-shaders"
 esac
 
 PKG_DEPENDS_TARGET+=" ${PKG_EMUS} ${EMUS_32BIT} ${PKG_RETROARCH} ${LIBRETRO_CORES}"

--- a/packages/virtual/image/package.mk
+++ b/packages/virtual/image/package.mk
@@ -4,12 +4,49 @@
 PKG_NAME="image"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
-PKG_DEPENDS_TARGET="toolchain squashfs-tools:host dosfstools:host fakeroot:host kmod:host mtools:host populatefs:host libc gcc linux linux-drivers linux-firmware ${BOOTLOADER} busybox util-linux corefonts misc-packages debug usb-modeswitch unzip poppler textviewer jq socat p7zip file bluez splash initramfs jelos"
+
 PKG_SECTION="virtual"
 PKG_LONGDESC="Root package used to build and create complete image"
 
+PKG_DEPENDS_TARGET="toolchain squashfs-tools:host dosfstools:host fakeroot:host kmod:host \
+                    mtools:host populatefs:host libc gcc linux linux-drivers linux-firmware \
+                    ${BOOTLOADER} busybox util-linux corefonts misc-packages debug \
+                    usb-modeswitch unzip poppler perl textviewer jq socat p7zip file bluez \
+                    splash initramfs plymouth-lite grep wget util-linux patchelf imagemagick \
+                    terminus-font bash coreutils alsa-ucm-conf modules system-utils \
+                    autostart quirks powerstate powertop ectool gnupg gzip six xmlstarlet \
+                    vim pyudev dialog git dbus-python network synctools pygobject libzip \
+                    libao alsa-lib lzo zstd lz4 empty jelos"
+
+PKG_UI="emulationstation es-themes"
+
+PKG_UI_TOOLS="fileman fbgrab"
+
+PKG_MULTIMEDIA="ffmpeg vlc mpv"
+
+PKG_TOOLS="i2c-tools evtest jslisten"
+
+if [ "${BASE_ONLY}" = "true" ]
+then
+  EMULATION_DEVICE=false
+else
+  PKG_DEPENDS_TARGET+=" ${PKG_TOOLS} ${PKG_UI} ${PKG_UI_TOOLS} ${PKG_MULTIMEDIA}"
+fi
+
+# Device is an emulation focused device
+[ "${EMULATION_DEVICE}" = "yes" ] && PKG_DEPENDS_TARGET+=" emulators gamesupport"
+
+# Add support for containers
+[ "${CONTAINER_SUPPORT}" = "yes" ] && PKG_DEPENDS_TARGET+=" docker"
+
+# 32Bit package support
+[ "${ENABLE_32BIT}" == true ] && PKG_DEPENDS_TARGET+=" lib32"
+
 # Architecture specific tools
 [ "${ARCH}" = "x86_64" ] && PKG_DEPENDS_TARGET+=" ryzenadj lm_sensors dmidecode xterm"
+
+# GL demos and tools
+[ "${OPENGL_SUPPORT}" = "yes" ]&& PKG_DEPENDS_TARGET+=" mesa-demos glmark2"
 
 # Sound support
 [ "${ALSA_SUPPORT}" = "yes" ] && PKG_DEPENDS_TARGET+=" alsa"

--- a/projects/Amlogic/devices/S922X/options
+++ b/projects/Amlogic/devices/S922X/options
@@ -74,7 +74,7 @@
     EXTRA_CMDLINE="rootwait quiet console=ttyAML0,115200n8 console=tty0 no_console_suspend net.ifnames=0 consoleblank=0 fbcon=rotate:3"
 
   # additional packages to install
-    ADDITIONAL_PACKAGES=" emulators gamesupport"
+  #  ADDITIONAL_PACKAGES=""
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,

--- a/projects/PC/devices/AMD64/options
+++ b/projects/PC/devices/AMD64/options
@@ -41,7 +41,7 @@
     GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi vmware virtio"
 
   # additional packages to install
-    ADDITIONAL_PACKAGES=" emulators gamesupport"
+  #  ADDITIONAL_PACKAGES=""
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,
@@ -53,7 +53,7 @@
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
   #  ADDITIONAL_DRIVERS=""
-  ADDITIONAL_DRIVERS="RTL8812AU RTL8814AU RTL8821AU RTL8821CU RTL88x2BU"
+    ADDITIONAL_DRIVERS="RTL8812AU RTL8814AU RTL8821AU RTL8821CU RTL88x2BU"
 
   # build and install driver addons (yes / no)
     DRIVER_ADDONS_SUPPORT="no"

--- a/projects/PC/options
+++ b/projects/PC/options
@@ -67,3 +67,6 @@
 
   # Default size of the ova image, in MB, eg. 4096
     OVA_SIZE="4096"
+
+  # Installation support
+    INSTALLER_SUPPORT="yes"

--- a/projects/Rockchip/devices/RK3566/options
+++ b/projects/Rockchip/devices/RK3566/options
@@ -69,7 +69,7 @@
     EXTRA_CMDLINE="quiet rootwait console=ttyUSB0,1500000 console=tty0 ssh consoleblank=0 systemd.show_status=0 loglevel=0 panic=20 video=HDMI-A-1:1280x720@60"
 
   # additional packages to install
-    ADDITIONAL_PACKAGES=" emulators gamesupport"
+  #  ADDITIONAL_PACKAGES=""
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,
@@ -92,7 +92,7 @@
 
   # debug tty path
     DEBUG_TTY="/dev/ttyFIQ0"
-    
+
   # build and install PulseAudio support (yes / no)
     PULSEAUDIO_SUPPORT="yes"
 

--- a/projects/Rockchip/devices/RK3588/options
+++ b/projects/Rockchip/devices/RK3588/options
@@ -76,7 +76,7 @@
     EXTRA_CMDLINE="rootwait quiet loglevel=0 console=ttyUSB0,1500000 console=tty0 coherent_pool=2M ssh consoleblank=0 panic=20"
 
   # additional packages to install
-    ADDITIONAL_PACKAGES=" emulators gamesupport"
+  #  ADDITIONAL_PACKAGES=""
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,
@@ -98,7 +98,7 @@
 
   # debug tty path
     DEBUG_TTY="/dev/ttyFIQ0"
-   
+
   # build and install PulseAudio support (yes / no)
     PULSEAUDIO_SUPPORT="yes"
  


### PR DESCRIPTION
* Add support for building without emulators `export EMULATION_DEVICE="no"`.
* Add support for building container support `export CONTAINER_SUPPORT="yes"`.
* Correct a condition where a base build kernel panics on boot.
* Migrate JELOS package dependencies to virtual packages where they belong.
