### PR TITLE
Disable blinking blue LED on S922X

### DIFF
--- a/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/001-hardwareinit
+++ b/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/001-hardwareinit
@@ -8,6 +8,10 @@
 
 echo powersave > /sys/devices/platform/soc/ffe40000.gpu/devfreq/ffe40000.gpu/governor
 
+### Disable blue blinking led
+
+echo none > /sys/class/leds/blue\:/trigger
+
 ### Sleep is currently broken, so we'll disable it.
 
 cat <<EOF >/storage/.config/sleep.conf.d/sleep.conf


### PR DESCRIPTION
This disabled the blue activity led, there is still the red power led. 