### PR TITLE
Improvements - Moonlight, ES splash

### DIFF
--- a/packages/apps/moonlight/autostart/010-moonlight
+++ b/packages/apps/moonlight/autostart/010-moonlight
@@ -1,0 +1,9 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023-present Fewtarius (https://github.com/fewtarius)
+
+FBWIDTH=$(fbset | awk '/geometry/ {print $2}')
+FBHEIGHT=$(fbset | awk '/geometry/ {print $2}')
+
+sed -i "s#@MWIDTH@#${FBWIDTH}#g" /storage/.config/moonlight/moonlight.conf
+sed -i "s#@MHEIGHT@#${FBHEIGHT}#g" /usr/config/moonlight/moonlight.conf

--- a/packages/apps/moonlight/package.mk
+++ b/packages/apps/moonlight/package.mk
@@ -29,12 +29,6 @@ fi
 post_makeinstall_target() {
   mkdir -p ${INSTALL}/usr/config/moonlight
     cp -R ${PKG_BUILD}/moonlight.conf ${INSTALL}/usr/config/moonlight
-    if [ "${ARCH}" = "aarch64" ] && [ -n "${SPLASH_RESOLUTION}" ]; then
-      # Patch config file - stream in native screen resolution.
-      sed -i "s/#width = 1280/width = ${SPLASH_RESOLUTION%x*}/g" "${INSTALL}/usr/config/moonlight/moonlight.conf"
-      sed -i "s/#height = 720/height = ${SPLASH_RESOLUTION#*x}/g" "${INSTALL}/usr/config/moonlight/moonlight.conf"
-    fi
-
-	rm ${INSTALL}/usr/etc/moonlight.conf 
-	rm ${INSTALL}/usr/share/moonlight/gamecontrollerdb.txt 
+    rm ${INSTALL}/usr/etc/moonlight.conf 
+    rm ${INSTALL}/usr/share/moonlight/gamecontrollerdb.txt 
 }

--- a/packages/apps/moonlight/sources/moonlight.conf
+++ b/packages/apps/moonlight/sources/moonlight.conf
@@ -3,8 +3,8 @@
 #address = 1.2.3.4
 
 ## Video streaming configuration
-#width = 1280
-#height = 720
+width = @MWIDTH@
+height = @MHEIGHT@
 fps = 30
 
 ## Output rotation (independent of xrandr or framebuffer settings!)

--- a/packages/jelos/sources/post-update
+++ b/packages/jelos/sources/post-update
@@ -29,11 +29,44 @@ rsync -a --ignore-existing /usr/config/game /storage/.config/
 rsync -a /usr/config/modules /storage/.config/
 
 echo "Update logo..." >>${LOG}
-if [ ! -L "/storage/.config/emulationstation/resources/logo.png" ]
+FBWIDTH=$(fbset | awk '/geometry/ {print $2}')
+FBHEIGHT=$(fbset | awk '/geometry/ {print $3}')
+
+ASPECT=$(printf "%.2f" $(echo "(${FBWIDTH} / ${FBHEIGHT})" | bc -l))
+
+case ${ASPECT} in
+  1.31|0.76)
+   ASPECT="3:2"
+  ;;
+  1.33|0.75)
+   ASPECT="4:3"
+  ;;
+  1.67|0.60)
+   ASPECT="5:3"
+  ;;
+  1.76|0.56)
+   ASPECT="16:9"
+  ;;
+esac
+
+if [ -f "/storage/.config/emulationstation/resources/logo.png" ]
 then
   rm -f /storage/.config/emulationstation/resources/logo.png ||:
-  ln -sf /usr/config/splash/splash.png /storage/.config/emulationstation/resources/logo.png
 fi
+
+convert /usr/config/splash/splash.png \
+        -gravity center \
+        -crop ${ASPECT} +repage \
+        /tmp/.logo.png
+
+convert /tmp/.logo.png \
+        -quality 100 \
+        -resize ${FBWIDTH}x${FBHEIGHT} \
+        -background black \
+        -gravity center \
+        /storage/.config/emulationstation/resources/logo.png
+
+rm -f /tmp/.logo.png
 
 echo "Sync modules..." >>${LOG}
 rsync -a /usr/config/modules/* /storage/.config/modules/

--- a/packages/sysutils/systemd/scripts/userconfig-setup
+++ b/packages/sysutils/systemd/scripts/userconfig-setup
@@ -31,9 +31,46 @@ then
       ln -s /usr/config/emulationstation/${es_cfg} /storage/.config/emulationstation/${es_cfg}  >>/var/log/configure.log 2>&1
     done
 
-    ### Link the ES splash to the distribution splash
-    rm -f /storage/.config/emulationstation/resources/logo.png  >>/var/log/configure.log 2>&1
-    ln -sf /usr/config/splash/splash.png /storage/.config/emulationstation/resources/logo.png  >>/var/log/configure.log 2>&1
+    ### Configure the ES splash to the distribution splash
+    FBWIDTH=$(fbset | awk '/geometry/ {print $2}')
+    FBHEIGHT=$(fbset | awk '/geometry/ {print $3}')
+
+    ASPECT=$(printf "%.2f" $(echo "(${FBWIDTH} / ${FBHEIGHT})" | bc -l))
+
+    case ${ASPECT} in
+      1.31|0.76)
+        ASPECT="3:2"
+      ;;
+      1.33|0.75)
+        ASPECT="4:3"
+      ;;
+      1.67|0.60)
+        ASPECT="5:3"
+      ;;
+      1.76|0.56)
+        ASPECT="16:9"
+      ;;
+    esac
+
+    if [ -f "/storage/.config/emulationstation/resources/logo.png" ]
+    then
+      rm -f /storage/.config/emulationstation/resources/logo.png ||:
+    fi
+
+    convert /usr/config/splash/splash.png \
+            -gravity center \
+            -crop ${ASPECT} +repage \
+            /tmp/.logo.png
+
+    convert /tmp/.logo.png \
+            -quality 100 \
+            -resize ${FBWIDTH}x${FBHEIGHT} \
+            -background black \
+            -gravity center \
+            /storage/.config/emulationstation/resources/logo.png
+
+    rm -f /tmp/.logo.png
+
   fi
   mkdir -p /storage/.config/modprobe.d  >>/var/log/configure.log 2>&1
   touch /storage/.configured  >>/var/log/configure.log 2>&1

--- a/packages/ui/splash/package.mk
+++ b/packages/ui/splash/package.mk
@@ -21,27 +21,10 @@ make_target() {
 
 mksplash() {
   SPLASH="${ROOT}/distributions/${DISTRO}/splash/splash.png"
-  if [ -n "${SPLASH_RESOLUTION}" ]
-  then
-
-    # Switch the resolution so the rotated image will scale correctly.
-    HRES=$(echo "${SPLASH_RESOLUTION}" | awk 'BEGIN {FS="x"} {print $1}')
-    VRES=$(echo "${SPLASH_RESOLUTION}" | awk 'BEGIN {FS="x"} {print $2}')
-    if [ "${VRES}" -gt "${HRES}" ]
-    then
-      convert ${SPLASH} -quality 100 -background black -resize ${VRES}x${HRES} -gravity center -extent ${VRES}x${HRES} ${1}/splash.png
-    else
-      convert ${SPLASH} -quality 100 -background black -resize ${SPLASH_RESOLUTION} -gravity center -extent ${SPLASH_RESOLUTION} ${1}/splash.png
-    fi
-    convert ${SPLASH} -rotate 90 -quality 100 -background black -resize ${SPLASH_RESOLUTION} -gravity center -extent ${SPLASH_RESOLUTION} ${1}/splash_90.png
-    convert ${SPLASH} -rotate 180 -quality 100 -background black -resize ${SPLASH_RESOLUTION} -gravity center -extent ${SPLASH_RESOLUTION} ${1}/splash_180.png
-    convert ${SPLASH} -rotate 270 -quality 100 -background black -resize ${SPLASH_RESOLUTION} -gravity center -extent ${SPLASH_RESOLUTION} ${1}/splash_270.png
-  else
-    cp ${SPLASH} ${1}
-    convert ${SPLASH} -rotate 90 -quality 100 -background black -gravity center ${1}/splash_90.png
-    convert ${SPLASH} -rotate 180 -quality 100 -background black -gravity center ${1}/splash_180.png
-    convert ${SPLASH} -rotate 270 -quality 100 -background black -gravity center ${1}/splash_270.png
-  fi
+  cp ${SPLASH} ${1}
+  convert ${SPLASH} -rotate 90 -quality 100 -background black -gravity center ${1}/splash_90.png
+  convert ${SPLASH} -rotate 180 -quality 100 -background black -gravity center ${1}/splash_180.png
+  convert ${SPLASH} -rotate 270 -quality 100 -background black -gravity center ${1}/splash_270.png
 }
 
 makeinstall_init() {

--- a/projects/Amlogic/devices/S922X/options
+++ b/projects/Amlogic/devices/S922X/options
@@ -45,9 +45,6 @@
   # Define the CPU
     HW_CPU="Amlogic S922x"
 
-  # Display Resolution
-    SPLASH_RESOLUTION="480x854"
-
   # Mali GPU family
     MALI_FAMILY="g52"
     GRAPHIC_DRIVERS="panfrost"

--- a/projects/Rockchip/devices/RK3566/options
+++ b/projects/Rockchip/devices/RK3566/options
@@ -45,9 +45,6 @@
   # Additional kernel make parameters (for example to specify the u-boot loadaddress)
     KERNEL_MAKE_EXTRACMD=" $(for DTB in "${DEVICE_DTB[@]}"; do echo -n "rockchip/${DTB}.dtb "; done)"
 
-  # Display Resolution
-    SPLASH_RESOLUTION="640x480"
- 
   # Define the CPU
     HW_CPU="Rockchip RK3566"
  


### PR DESCRIPTION
* Switch moonlight to use autostart so the configuration is updated per device from the framebuffer resolution.
* Properly scale the ES splash regardless of aspect ratio and screen size.