### PR TITLE
Add Headphone Output toggle to S922X

### DIFF
--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="emulationstation"
-PKG_VERSION="5f153d3"
+PKG_VERSION="1eadb90edf04d40b2f92307e7767334975234c55"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
This is linked the following change:

https://github.com/JustEnoughLinuxOS/emulationstation/commit/8ed01293e4bbf0648d39eef286cdad880827bac4