### PR TITLE
Update S992X kernel patch, fix gpu gov bug, update ES features for Dolphin & Athersx2

### DIFF
--- a/packages/emulators/standalone/aethersx2-sa/config/S922X/aethersx2/inis/PCSX2.ini
+++ b/packages/emulators/standalone/aethersx2-sa/config/S922X/aethersx2/inis/PCSX2.ini
@@ -194,7 +194,7 @@ OutputModule = cubeb
 Latency = 100
 SynchMode = 0
 SpeakerConfiguration = 0
-BackendName = 
+BackendName =
 
 [DEV9/Eth]
 EthEnable = false
@@ -224,16 +224,16 @@ HddSizeSectors = 83886080
 
 
 [EmuCore/Gamefixes]
-VuAddSubHack = false
-FpuMulHack = false
+VuAddSubHack = true
+FpuMulHack = true
 FpuNegDivHack = false
 XgKickHack = false
-EETimingHack = false
+EETimingHack = true
 SoftwareRendererFMVHack = false
 SkipMPEGHack = false
 OPHFlagHack = false
-DMABusyHack = false
-VIFFIFOHack = false
+DMABusyHack = true
+VIFFIFOHack = true
 VIF1StallHack = false
 GIFFIFOHack = false
 GoemonTlbHack = false

--- a/packages/emulators/standalone/aethersx2-sa/scripts/start_aethersx2.sh
+++ b/packages/emulators/standalone/aethersx2-sa/scripts/start_aethersx2.sh
@@ -40,6 +40,7 @@ fi
   #Emulation Station Features
   GAME=$(echo "${1}"| sed "s#^/.*/##")
   ASPECT=$(get_setting aspect_ratio ps2 "${GAME}")
+  FILTER=$(get_setting bilinear_filtering ps2 "${GAME}")
   FPS=$(get_setting show_fps ps2 "${GAME}")
   RATE=$(get_setting ee_cycle_rate ps2 "${GAME}")
   SKIP=$(get_setting ee_cycle_skip ps2 "${GAME}")
@@ -60,6 +61,24 @@ fi
 	then
   		sed -i '/^AspectRatio =/c\AspectRatio = Stretch' /storage/.config/aethersx2/inis/PCSX2.ini
 	fi
+
+  #Bilinear Filtering
+        if [ "$FILTER" = "0" ]
+        then
+                sed -i '/^filter =/c\filter = 0' /storage/.config/aethersx2/inis/PCSX2.ini
+        fi
+        if [ "$FILTER" = "1" ]
+        then
+                sed -i '/^filter =/c\filter = 1' /storage/.config/aethersx2/inis/PCSX2.ini
+        fi
+        if [ "$FILTER" = "2" ]
+        then
+                sed -i '/^filter =/c\filter = 2' /storage/.config/aethersx2/inis/PCSX2.ini
+        fi
+        if [ "$FILTER" = "3" ]
+        then
+                sed -i '/^filter =/c\filter = 3' /storage/.config/aethersx2/inis/PCSX2.ini
+        fi
 
   #Graphics Backend
 	if [ "$GRENDERER" = "0" ]

--- a/packages/emulators/standalone/dolphin-sa/config/S922X/Dolphin.ini
+++ b/packages/emulators/standalone/dolphin-sa/config/S922X/Dolphin.ini
@@ -77,7 +77,7 @@ Fastmem = True
 CPUThread = True
 DSPHLE = True
 SkipIdle = True
-SyncOnSkipIdle = True
+SyncOnSkipIdle = False
 SyncGPU = False
 SyncGpuMaxDistance = 200000
 SyncGpuMinDistance = -200000
@@ -120,9 +120,9 @@ RunCompareServer = False
 RunCompareClient = False
 EmulationSpeed = 1.00000000
 FrameSkip = 0x00000003
-Overclock = 4.00000000
+Overclock = 1.0
 OverclockEnable = False
-GFXBackend = Vulkan 
+GFXBackend = Vulkan
 GPUDeterminismMode = auto
 PerfMapDir = 
 [Movie]
@@ -138,6 +138,7 @@ DumpUCode = False
 Backend = ALSA
 Volume = 100
 CaptureLog = False
+DSPThread = True
 [Input]
 BackgroundInput = False
 [FifoPlayer]

--- a/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_gc.sh
+++ b/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_gc.sh
@@ -41,6 +41,7 @@ fi
   GAME=$(echo "${1}"| sed "s#^/.*/##")
   AA=$(get_setting anti_aliasing gamecube "${GAME}")
   ASPECT=$(get_setting aspect_ratio gamecube "${GAME}")
+  CLOCK=$(get_setting clock_speed gamecube "${GAME}")
   RENDERER=$(get_setting graphics_backend gamecube "${GAME}")
   IRES=$(get_setting internal_resolution gamecube "${GAME}")
   FPS=$(get_setting show_fps gamecube "${GAME}")
@@ -101,6 +102,34 @@ fi
 	then
   		sed -i '/AspectRatio/c\AspectRatio = 3' /storage/.config/dolphin-emu/GFX.ini
 	fi
+
+  #Clock Speed
+	sed -i '/^OverclockEnable =/c\OverclockEnable = False' /storage/.config/dolphin-emu/Dolphin.ini
+        if [ "$CLOCK" = "0" ]
+        then
+                sed -i '/^Overclock =/c\Overclock = 0.5' /storage/.config/dolphin-emu/Dolphin.ini
+                sed -i '/^OverclockEnable =/c\OverclockEnable = True' /storage/.config/dolphin-emu/Dolphin.ini
+        fi
+        if [ "$CLOCK" = "1" ]
+        then
+                sed -i '/^Overclock =/c\Overclock = 0.75' /storage/.config/dolphin-emu/Dolphin.ini
+                sed -i '/^OverclockEnable =/c\OverclockEnable = True' /storage/.config/dolphin-emu/Dolphin.ini
+        fi
+        if [ "$CLOCK" = "2" ]
+        then
+                sed -i '/^Overclock =/c\Overclock = 1.0' /storage/.config/dolphin-emu/Dolphin.ini
+                sed -i '/^OverclockEnable =/c\OverclockEnable = False' /storage/.config/dolphin-emu/Dolphin.ini
+        fi
+        if [ "$CLOCK" = "3" ]
+        then
+                sed -i '/^Overclock =/c\Overclock = 1.25' /storage/.config/dolphin-emu/Dolphin.ini
+                sed -i '/^OverclockEnable =/c\OverclockEnable = True' /storage/.config/dolphin-emu/Dolphin.ini
+        fi
+        if [ "$CLOCK" = "4" ]
+        then
+                sed -i '/^Overclock =/c\Overclock = 1.5' /storage/.config/dolphin-emu/Dolphin.ini
+                sed -i '/^OverclockEnable =/c\OverclockEnable = True' /storage/.config/dolphin-emu/Dolphin.ini
+        fi
 
   #Video Backend
 	if [ "$RENDERER" = "opengl" ]

--- a/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_wii.sh
+++ b/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_wii.sh
@@ -44,6 +44,7 @@ ln -sf /storage/roms/savestates/wii /storage/.config/dolphin-emu/StateSaves
   GAME=$(echo "${1}"| sed "s#^/.*/##")
   AA=$(get_setting anti_aliasing wii "${GAME}")
   ASPECT=$(get_setting aspect_ratio wii "${GAME}")
+  CLOCK=$(get_setting clock_speed wii "${GAME}")
   RENDERER=$(get_setting graphics_backend wii "${GAME}")
   IRES=$(get_setting internal_resolution wii "${GAME}")
   FPS=$(get_setting show_fps wii "${GAME}")
@@ -104,6 +105,34 @@ ln -sf /storage/roms/savestates/wii /storage/.config/dolphin-emu/StateSaves
 	then
   		sed -i '/AspectRatio/c\AspectRatio = 3' /storage/.config/dolphin-emu/GFX.ini
 	fi
+
+  #Clock Speed
+        sed -i '/^OverclockEnable =/c\OverclockEnable = False' /storage/.config/dolphin-emu/Dolphin.ini
+        if [ "$CLOCK" = "0" ]
+        then
+                sed -i '/^Overclock =/c\Overclock = 0.5' /storage/.config/dolphin-emu/Dolphin.ini
+                sed -i '/^OverclockEnable =/c\OverclockEnable = True' /storage/.config/dolphin-emu/Dolphin.ini
+        fi
+        if [ "$CLOCK" = "1" ]
+        then
+                sed -i '/^Overclock =/c\Overclock = 0.75' /storage/.config/dolphin-emu/Dolphin.ini
+                sed -i '/^OverclockEnable =/c\OverclockEnable = True' /storage/.config/dolphin-emu/Dolphin.ini
+        fi
+        if [ "$CLOCK" = "2" ]
+        then
+                sed -i '/^Overclock =/c\Overclock = 1.0' /storage/.config/dolphin-emu/Dolphin.ini
+                sed -i '/^OverclockEnable =/c\OverclockEnable = False' /storage/.config/dolphin-emu/Dolphin.ini
+        fi
+        if [ "$CLOCK" = "3" ]
+        then
+                sed -i '/^Overclock =/c\Overclock = 1.25' /storage/.config/dolphin-emu/Dolphin.ini
+                sed -i '/^OverclockEnable =/c\OverclockEnable = True' /storage/.config/dolphin-emu/Dolphin.ini
+        fi
+        if [ "$CLOCK" = "4" ]
+        then
+                sed -i '/^Overclock =/c\Overclock = 1.5' /storage/.config/dolphin-emu/Dolphin.ini
+                sed -i '/^OverclockEnable =/c\OverclockEnable = True' /storage/.config/dolphin-emu/Dolphin.ini
+        fi
 
   #Video Backend
 	if [ "$RENDERER" = "opengl" ]

--- a/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/001-hardwareinit
+++ b/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/001-hardwareinit
@@ -4,10 +4,6 @@
 
 . /etc/profile
 
-### Set GPU Govorner to powersave during boot
-
-echo powersave > /sys/devices/platform/soc/ffe40000.gpu/devfreq/ffe40000.gpu/governor
-
 ### Disable blue blinking led
 
 echo none > /sys/class/leds/blue\:/trigger

--- a/packages/jelos/profile.d/99-freqfunctions
+++ b/packages/jelos/profile.d/99-freqfunctions
@@ -88,14 +88,14 @@ performance() {
 ondemand() {
   set_cpu_gov ondemand
   set_amdgpu_perf auto
-  set_gpu_gov ondemand
+  set_gpu_gov simple_ondemand
   set_dmc_gov ondemand
 }
 
 schedutil() {
   set_cpu_gov schedutil
   set_amdgpu_perf auto
-  set_gpu_gov ondemand
+  set_gpu_gov simple_ondemand
   set_dmc_gov ondemand
 }
 

--- a/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/packages/ui/emulationstation/config/common/es_features.cfg
@@ -62,6 +62,13 @@
         <choice name="4/3" value="2"/>
         <choice name="stretch" value="3"/>
       </feature>
+      <feature name="clock speed">
+        <choice name="50%" value="0"/>
+        <choice name="75%" value="1"/>
+        <choice name="100% (default)" value="2"/>
+        <choice name="125%" value="3"/>
+        <choice name="150%" value="4"/>
+      </feature>
       <feature name="graphics backend">
         <choice name="opengl" value="opengl"/>
         <choice name="vulkan" value="vulkan"/>
@@ -102,6 +109,13 @@
         <choice name="16/9" value="1"/>
         <choice name="4/3" value="2"/>
         <choice name="stretch" value="3"/>
+      </feature>
+      <feature name="clock speed">
+        <choice name="50%" value="0"/>
+        <choice name="75%" value="1"/>
+        <choice name="100% (default)" value="2"/>
+        <choice name="125%" value="3"/>
+        <choice name="150%" value="4"/>
       </feature>
       <feature name="graphics backend">
         <choice name="opengl" value="opengl"/>
@@ -309,6 +323,12 @@
         <choice name="4/3" value="0"/>
         <choice name="16/9" value="1"/>
         <choice name="stretch" value="2"/>
+      </feature>
+      <feature name="bilinear filtering">
+        <choice name="nearest" value="0"/>
+        <choice name="forced" value="1"/>
+        <choice name="ps2" value="2"/>
+        <choice name="forced exc. srpite" value="3"/>
       </feature>
       <feature name="ee cycle rate">
         <choice name="50% speed" value="0"/>


### PR DESCRIPTION
-Aethersx2-SA - filter options in ES
-Dolphin-SA - internal cpu overclock/underclock options
-Adjust S922X kernel patch. Thanks to Hardkernel and MDRJR
-Fix GPU gov bug. 