### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ limitations under the License.
 ## Flashing
 * Download the latest [version of JELOS](https://github.com/JustEnoughLinuxOS/distribution/releases) (.img.gz) for your device.
 * Decompress the image.
-* Write the image to an SDCARD using an imaging tool.  Common imaging tools include [Balena Etcher](https://www.balena.
-io/etcher/), [Raspberry Pi Imager](https://www.raspberrypi.com/software/), and [Win32 Disk Imager](https://sourceforge.net/projects/win32diskimager/).  If you're skilled with the command line, dd works fine too.
+* Write the image to an SDCARD using an imaging tool.  Common imaging tools include [Balena Etcher](https://www.balena.io/etcher/), [Raspberry Pi Imager](https://www.raspberrypi.com/software/), and [Win32 Disk Imager](https://sourceforge.net/projects/win32diskimager/).  If you're skilled with the command line, dd works fine too.
 
 ## Installation
 * JELOS includes an installation tool.  The installation tool can be found in the tools menu.


### PR DESCRIPTION
# Pull Request Template

## Description

There was a \n in the inline link of Balena Etcher imaging tool, breaking syntax. I just removed it.

## How Has This Been Tested Locally?

No tests. Didn't make any changes to the code.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
