### PR TITLE
Make ZeroTier pick up networks from a file

### DIFF
--- a/packages/network/zerotier-one/package.mk
+++ b/packages/network/zerotier-one/package.mk
@@ -27,9 +27,10 @@ makeinstall_target() {
     make DESTDIR=${INSTALL} install
     rm -rf ${INSTALL}/usr/share/man/
 
+    install -Dm755 ${PKG_DIR}/scripts/zerotier-join.sh ${INSTALL}/usr/sbin/
     mkdir -p ${INSTALL}/usr/lib/systemd/system
-    cp -R ${PKG_DIR}/system.d/zerotier-one.service ${INSTALL}/usr/lib/systemd/system/
+    install -Dm644 ${PKG_DIR}/system.d/zerotier-one.service ${INSTALL}/usr/lib/systemd/system/
     mkdir -p ${INSTALL}/etc/profile.d/
-    cp -R ${PKG_DIR}/profile.d/95-zerotier ${INSTALL}/etc/profile.d/
+    install -Dm755 ${PKG_DIR}/profile.d/95-zerotier ${INSTALL}/etc/profile.d/
 }
 

--- a/packages/network/zerotier-one/package.mk
+++ b/packages/network/zerotier-one/package.mk
@@ -13,8 +13,8 @@ PKG_TOOLCHAIN="manual"
 
 
 pre_unpack() {
-  mkdir -p ${PKG_BUILD}
-  tar --strip-components=1 -xf $SOURCES/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz -C ${PKG_BUILD} ZeroTierOne-${PKG_VERSION}
+    mkdir -p ${PKG_BUILD}
+    tar --strip-components=1 -xf $SOURCES/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz -C ${PKG_BUILD} ZeroTierOne-${PKG_VERSION}
 }
 
 
@@ -29,7 +29,7 @@ makeinstall_target() {
 
     mkdir -p ${INSTALL}/usr/lib/systemd/system
     cp -R ${PKG_DIR}/system.d/zerotier-one.service ${INSTALL}/usr/lib/systemd/system/
-	mkdir -p ${INSTALL}/etc/profile.d/
-	cp -R ${PKG_DIR}/profile.d/95-zerotier ${INSTALL}/etc/profile.d/
+    mkdir -p ${INSTALL}/etc/profile.d/
+    cp -R ${PKG_DIR}/profile.d/95-zerotier ${INSTALL}/etc/profile.d/
 }
 

--- a/packages/network/zerotier-one/scripts/zerotier-join.sh
+++ b/packages/network/zerotier-one/scripts/zerotier-join.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2023-present NeoTheFox (https://github.com/NeoTheFox)
+
+NETWORKS_FILE=/storage/.config/zerotier-networks
+[[ -f ${NETWORKS_FILE} ]] || (echo "No networks defined" && exit 0)
+
+shopt -s expand_aliases
+alias zerotier-cli="zerotier-cli -D/storage/.config/zerotier/"
+
+zerotier-cli listnetworks | cut -d' ' -f 3 | while read net
+do
+    [[ "$net" == "<nwid>" ]] && continue
+    echo "Checking $net"
+    grep -Fxq $net ${NETWORKS_FILE} || (echo "Leaving $net (not in the file)" && zerotier-cli leave $net)
+done
+
+cat ${NETWORKS_FILE} | while read net
+do
+    echo "Joining $net"
+    zerotier-cli join $net
+done
+
+# Just in case the last join fails...
+exit 0

--- a/packages/network/zerotier-one/system.d/zerotier-one.service
+++ b/packages/network/zerotier-one/system.d/zerotier-one.service
@@ -5,9 +5,11 @@ After=network-pre.target
 
 [Service]
 ExecStart=/usr/sbin/zerotier-one /storage/.config/zerotier/
+ExecStartPost=/usr/sbin/zerotier-join.sh
 Restart=always
 KillMode=process
 Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is a little script to streamline the user experience while using ZeroTier.

If a user creates ```/storage/.config/zerotier-networks``` file then this script automatically joins every network listed in this file, and removes any networks absent from the file.
This makes it way easier to connect, without using a terminal.

Tested on ODROID GO Ultra