### PR TITLE
Add .conf to DOSBox extensions

### DIFF
--- a/packages/ui/emulationstation/config/device/RK3326/es_systems.cfg
+++ b/packages/ui/emulationstation/config/device/RK3326/es_systems.cfg
@@ -950,7 +950,7 @@
       <release>1981</release>
       <hardware>computer</hardware>
       <path>/storage/roms/pc</path>
-      <extension>.com .COM .bat .BAT .exe .EXE .dosz .DOSZ</extension>
+      <extension>.com .COM .bat .BAT .exe .EXE .dosz .DOSZ .conf .CONF</extension>
       <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
       <platform>pc</platform>
       <theme>pc</theme>

--- a/packages/ui/emulationstation/config/device/RK3566/es_systems.cfg
+++ b/packages/ui/emulationstation/config/device/RK3566/es_systems.cfg
@@ -988,7 +988,7 @@
       <release>1981</release>
       <hardware>computer</hardware>
       <path>/storage/roms/pc</path>
-      <extension>.com .COM .bat .BAT .exe .EXE .dosz .DOSZ</extension>
+      <extension>.com .COM .bat .BAT .exe .EXE .dosz .DOSZ .conf .CONF</extension>
       <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
       <platform>pc</platform>
       <theme>pc</theme>

--- a/packages/ui/emulationstation/config/device/RK3588/es_systems.cfg
+++ b/packages/ui/emulationstation/config/device/RK3588/es_systems.cfg
@@ -988,7 +988,7 @@
       <release>1981</release>
       <hardware>computer</hardware>
       <path>/storage/roms/pc</path>
-      <extension>.com .COM .bat .BAT .exe .EXE .dosz .DOSZ</extension>
+      <extension>.com .COM .bat .BAT .exe .EXE .dosz .DOSZ .conf .CONF</extension>
       <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
       <platform>pc</platform>
       <theme>pc</theme>

--- a/packages/ui/emulationstation/config/device/S922X/es_systems.cfg
+++ b/packages/ui/emulationstation/config/device/S922X/es_systems.cfg
@@ -996,7 +996,7 @@
       <release>1981</release>
       <hardware>computer</hardware>
       <path>/storage/roms/pc</path>
-      <extension>.com .COM .bat .BAT .exe .EXE .dosz .DOSZ</extension>
+      <extension>.com .COM .bat .BAT .exe .EXE .dosz .DOSZ .conf .CONF</extension>
       <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
       <platform>pc</platform>
       <theme>pc</theme>


### PR DESCRIPTION
Missing .conf extension for DOSBox Pure
https://docs.libretro.com/library/dosbox_pure/#loading-of-dosboxconf-files