### PR TITLE
* Improve power savings for AMD64 based devices.

### DIFF
--- a/packages/jelos/autostart/002-kernel
+++ b/packages/jelos/autostart/002-kernel
@@ -8,6 +8,6 @@ tocon "Applying kernel parameters..."
 sysctl vm.swappiness=1
 sysctl kernel.nmi_watchdog=0
 sysctl vm.laptop_mode=5
-sysctl vm.dirty_writeback_centisecs=1500
+sysctl vm.dirty_writeback_centisecs=6000
 
 toggle-ipv6

--- a/packages/sysutils/powerstate/profile.d/03-powerfunctions
+++ b/packages/sysutils/powerstate/profile.d/03-powerfunctions
@@ -86,3 +86,10 @@ device_powersave() {
     echo ${PSMODE} >"${DEVICE}" 2>/dev/null
   done
 }
+
+device_powerlevel() {
+  for device in $(find /sys/devices/pci* -name level)
+  do
+    echo ${1} >${device} 2>/dev/null
+  done
+}

--- a/packages/sysutils/powerstate/sources/powerstate.sh
+++ b/packages/sysutils/powerstate/sources/powerstate.sh
@@ -36,6 +36,7 @@ do
           gpu_performance_level ${GPUPROFILE}
           pcie_aspm_policy powersave
           device_powersave 1
+          device_powerlevel auto
         ;;
         *)
           log $0 "Switching to performance mode."
@@ -45,6 +46,7 @@ do
           gpu_performance_level auto
           pcie_aspm_policy default
           device_powersave 0
+          device_powerlevel on
         ;;
       esac
     fi

--- a/projects/PC/devices/AMD64/options
+++ b/projects/PC/devices/AMD64/options
@@ -12,7 +12,7 @@
     esac
 
   # kernel command line
-    EXTRA_CMDLINE="quiet console=tty0 ssh consoleblank=0 systemd.show_status=0 loglevel=0 panic=20 intel_pstate=active amd_pstate=active amd_pstate.shared_mem=1 amdgpu.dpm=1"
+    EXTRA_CMDLINE="quiet console=tty0 ssh consoleblank=0 systemd.show_status=0 loglevel=0 panic=20 intel_pstate=active amd_pstate=active amd_pstate.shared_mem=1 amdgpu.dpm=1 usbcore.autosuspend=5"
 
   # Partition label
     PARTITION_TABLE="msdos"

--- a/projects/PC/packages/linux/modprobe.d/audio.conf
+++ b/projects/PC/packages/linux/modprobe.d/audio.conf
@@ -1,0 +1,3 @@
+options snd_hda_intel power_save=1
+options snd_ac97_codec power_save=1
+

--- a/projects/PC/packages/linux/modprobe.d/iwlwifi.conf
+++ b/projects/PC/packages/linux/modprobe.d/iwlwifi.conf
@@ -1,2 +1,4 @@
+options iwlwifi power_save=1 power_level=5
+options iwlwifi uapsd_disable=0
 options iwlmvm power_scheme=3
-options iwlwifi power_save=Y power_level=5
+options iwldvm force_cam=0


### PR DESCRIPTION
  * AYANEO Air Pro: 5.32 W, 7 hours - SNES test.
  * AYANEO Air Plus: 7.89 W, 5 hours, 44 minutes - SNES test.
