### PR TITLE
Initial Powkiddy RGB10 Max 3 Support

### DIFF
--- a/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3/001-deviceconfig
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3/001-deviceconfig
@@ -1,0 +1,31 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
+
+cat <<EOF >/storage/.config/profile.d/001-deviceconfig
+# Device Features
+DEVICE_HAS_FAN=false
+DEVICE_VOLUMECTL=true
+DEVICE_POWER_LED=false
+DEVICE_PLAYBACK_PATH_SPK="SPK"
+DEVICE_PLAYBACK_PATH_HP="HP"
+DEVICE_BRIGHTNESS="128"
+UI_SERVICE="weston.service"
+
+# GPIOS
+DEVICE_TEMP_SENSOR="$(find /sys/devices/pci*/* -path "*/nvme" -prune -o -name temp1_input -print)"
+
+# FREQ Governors
+CPU_FREQ=("/sys/devices/system/cpu/cpufreq/policy0" "/sys/devices/system/cpu/cpufreq/policy2")
+GPU_FREQ=("/sys/devices/platform/soc/ffe40000.gpu/devfreq/ffe40000.gpu")
+
+# Affinity
+SLOW_CORES="taskset -c 0-1"
+FAST_CORES="taskset -c 2-5"
+
+# Volume Keys
+DEVICE_KEY_VOLUMEDOWN=114
+DEVICE_KEY_VOLUMEUP=115
+DEVICE_FUNC_KEYA_MODIFIER="BTN_TR2"
+DEVICE_FUNC_KEYB_MODIFIER="BTN_TL2"
+EOF

--- a/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3/001-hardwareinit
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3/001-hardwareinit
@@ -1,0 +1,17 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
+
+. /etc/profile
+
+### Disable blue blinking led
+
+echo none > /sys/class/leds/blue\:/trigger
+
+### Sleep is currently broken, so we'll disable it.
+
+cat <<EOF >/storage/.config/sleep.conf.d/sleep.conf
+[Sleep]
+AllowSuspend=no
+SuspendState=freeze
+EOF

--- a/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3/003-audio
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3/003-audio
@@ -1,0 +1,260 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
+
+. /etc/profile
+
+### Set a custom device so we don't clobber it.
+set-audio set "CUSTOM (UNMANAGED)"
+set-audio esset "Master"
+
+amixer sset 'FRDDR_A SINK 1 SEL' 'OUT 1'
+amixer sset 'FRDDR_A SRC 1 EN' 'on'
+amixer sset 'TDMOUT_B SRC SEL' 'IN 0'
+
+cat <<EOF >/storage/.config/asound.conf
+pcm.!default {
+	type plug
+	slave.pcm "dmixer"
+}
+
+pcm.dmixer  {
+	type dmix
+	ipc_key 1024
+	slave {
+	    pcm "hw:0,0"
+	    period_time 0
+	    period_size 4096
+	    buffer_size 131072
+	    rate 96000
+	}
+	bindings {
+	    0 0
+	    1 1
+	}
+}
+EOF
+
+if [ ! -e "/storage/.config/asound.state" ]
+then
+  cat <<EOF >/storage/.config/asound.state
+state.Ultra {
+	control.1 {
+		iface MIXER
+		name 'Master Playback Volume'
+		value.0 223
+		value.1 223
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 252'
+			dbmin -9500
+			dbmax 0
+			dbvalue.0 -1094
+			dbvalue.1 -1094
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'Master Capture Volume'
+		value.0 226
+		value.1 226
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9500
+			dbmax 0
+			dbvalue.0 -1081
+			dbvalue.1 -1081
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'Mic Capture Gain'
+		value.0 6
+		value.1 6
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 15'
+			dbmin -1800
+			dbmax 2700
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'TDMOUT_B Lane 0 Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'TDMOUT_B Lane 1 Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'TDMOUT_B Lane 2 Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'TDMOUT_B Lane 3 Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'TDMOUT_B Gain Enable Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'FRDDR_A SRC 1 EN Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'FRDDR_A SRC 2 EN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'FRDDR_A SRC 3 EN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'FRDDR_A SINK 1 SEL'
+		value 'OUT 1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'OUT 0'
+			item.1 'OUT 1'
+			item.2 'OUT 2'
+			item.3 'OUT 3'
+			item.4 'OUT 4'
+			item.5 'OUT 5'
+			item.6 'OUT 6'
+			item.7 'OUT 7'
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'FRDDR_A SINK 2 SEL'
+		value 'OUT 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'OUT 0'
+			item.1 'OUT 1'
+			item.2 'OUT 2'
+			item.3 'OUT 3'
+			item.4 'OUT 4'
+			item.5 'OUT 5'
+			item.6 'OUT 6'
+			item.7 'OUT 7'
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'FRDDR_A SINK 3 SEL'
+		value 'OUT 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'OUT 0'
+			item.1 'OUT 1'
+			item.2 'OUT 2'
+			item.3 'OUT 3'
+			item.4 'OUT 4'
+			item.5 'OUT 5'
+			item.6 'OUT 6'
+			item.7 'OUT 7'
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'Playback Mux'
+		value SPK
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 HP
+			item.1 SPK
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'TDMOUT_B SRC SEL'
+		value 'IN 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'IN 0'
+			item.1 'IN 1'
+			item.2 'IN 2'
+		}
+	}
+}
+
+EOF
+fi

--- a/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3/004-game-configs
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3/004-game-configs
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023-present BrooksyTech (https://github.com/brooksytech)
+
+. /etc/profile
+
+#Set up gzdoom
+if [ ! -d "/storage/.config/gzdoom/" ]; then
+  cp -rf /usr/config/gzdoom /storage/.config/
+  sed -i '/Joy18=/c\Joy18=togglemap' /storage/.config/gzdoom/gzdoom.ini
+  sed -i '/Joy13=/c\Joy13=menu_main' /storage/.config/gzdoom/gzdoom.ini
+  sed -i '/vid_defheight=/c\vid_defheight=480' /storage/.config/gzdoom/gzdoom.ini
+  sed -i '/vid_defwidth=/c\vid_defwidth=854' /storage/.config/gzdoom/gzdoom.ini
+fi


### PR DESCRIPTION
Start working on the Powkiddy RGB10 Max 3.

Cloned the OGU DTS as meson-g12b-powkiddy-rgb10-max-3.dts

Needed to remap some of the gpio controls so layout would match the OGU.

Also needed to drop the OGU clocks as they were causing kernel panics / boot errors on my Max 3. 