### PR TITLE
HDMI fix for SDL2 content.

### DIFF
--- a/packages/graphics/SDL2/patches/0003-drm-resolution.patch
+++ b/packages/graphics/SDL2/patches/0003-drm-resolution.patch
@@ -1,0 +1,59 @@
+diff --git a/src/video/kmsdrm/SDL_kmsdrmvideo.c b/src/video/kmsdrm/SDL_kmsdrmvideo.c
+index fbc2c96..cedc739 100644
+--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
++++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
+@@ -609,6 +609,24 @@ void KMSDRM_AddDisplay (_THIS, drmModeConnector *connector, drmModeRes *resource
+         goto cleanup;
+     }
+ 
++    // batocera - set resolution
++    {
++      FILE* fdDrmMode;
++      int drmMode;
++      if((fdDrmMode = fopen("/var/run/drmMode", "r")) != NULL) {
++	if(fscanf(fdDrmMode, "%i", &drmMode) == 1) {
++	  if(drmMode>=0 && drmMode<connector->count_modes) {
++	    drmModeCrtc *pcrtc = KMSDRM_drmModeGetCrtc(viddata->drm_fd, encoder->crtc_id);
++	    if(pcrtc != NULL) {
++	      KMSDRM_drmModeSetCrtc(viddata->drm_fd, pcrtc->crtc_id, pcrtc->buffer_id, 0, 0, &connector->connector_id, 1, &connector->modes[drmMode]);
++	    }
++	  }
++	}
++	fclose(fdDrmMode);
++      }
++    }
++    //
++
+     /* Try to find a CRTC connected to this encoder */
+     crtc = KMSDRM_drmModeGetCrtc(viddata->drm_fd, encoder->crtc_id);
+ 
+@@ -1107,8 +1125,27 @@ KMSDRM_GetDisplayModes(_THIS, SDL_VideoDisplay * display)
+     SDL_DisplayMode mode;
+     int i;
+ 
++    // batocera
++    int wantedMode = 0;
++    {
++      FILE* fdDrmMode;
++      int drmMode;
++      if((fdDrmMode = fopen("/var/run/drmMode", "r")) != NULL) {
++	if(fscanf(fdDrmMode, "%i", &drmMode) == 1) {
++	  if(drmMode>=0 && drmMode<conn->count_modes) {
++	    wantedMode = drmMode;
++	  }
++	}
++	fclose(fdDrmMode);
++      }
++    }
++    //
++
+     for (i = 0; i < conn->count_modes; i++) {
+-        SDL_DisplayModeData *modedata = SDL_calloc(1, sizeof(SDL_DisplayModeData));
++        SDL_DisplayModeData *modedata;
++        if(i != wantedMode) continue; // batocera
++
++        modedata = SDL_calloc(1, sizeof(SDL_DisplayModeData));
+ 
+         if (modedata) {
+             modedata->mode_index = i;
+

--- a/packages/sysutils/autostart/sources/common/030_hdmi_check
+++ b/packages/sysutils/autostart/sources/common/030_hdmi_check
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2023-present Fewtarius (https://github.com/fewtarius)
+# Copyright (C) 2023-present christianhaitian (https://github.com/christianhaitian)
+# Copyright (C) 2023-present Rocky5 (https://github.com/rocky5)
 
 # The purpose of this script is to permanently set the resolution
 # output for hdmi when connected.

--- a/packages/sysutils/autostart/sources/common/030_hdmi_check.sh
+++ b/packages/sysutils/autostart/sources/common/030_hdmi_check.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# The purpose of this script is to permanently set the resolution
+# output for hdmi when connected.
+
+xres="$(cat /sys/class/graphics/fb0/modes | grep -o -P '(?<=:).*(?=p-)' | cut -dx -f1)"
+
+# drm_tool source available at https://github.com/christianhaitian/drm_tool.git
+
+mode="$(/usr/bin/drm_tool list |  awk '/1280x720.*60/ {print substr($2,1,length($2)-1); exit}')"
+mode2="$(/usr/bin/drm_tool list |  awk '/1920x1080.*60/ {print substr($2,1,length($2)-1); exit}')"
+
+# Now we tell drm what the hdmi mode is by writing to /var/run/drmMode
+# This will get picked up by SDL2 as long as it's been patched with the batocera
+# drm resolution patch.  This patch can be found at 
+# https://github.com/christianhaitian/rk3566_core_builds/raw/master/patches/sdl2-patch-0003-drm-resolution.patch
+
+if [ $xres -eq "1280" ]; then
+  echo $mode | tee /var/run/drmMode
+elif [ $xres -eq "1920" ]; then
+  echo $mode2 | tee /var/run/drmConn
+else
+  echo 0 | tee /var/run/drmMode
+  echo 1 | tee /var/run/drmConn
+fi


### PR DESCRIPTION
Ported from ArkOS to JELOS. So credit to Christian Haitian.

## Description

Patches SDL2 to accept forced resolutions, so fixes HDMI output for homebrew.

Fixes # (issue)

## Type of change
- [#] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?
On my device, multiple times now. RG353M in HDMI mode.

## Checklist:

- [#] My code follows the style guidelines of this project
- [#] I have performed a self-review of my own code