### PR TITLE
Rework setsettings, set aspect in ES, fix gpu/dmc bug on RK3399 and S922X.

### DIFF
--- a/packages/jelos/config/system/configs/system.cfg
+++ b/packages/jelos/config/system/configs/system.cfg
@@ -173,6 +173,7 @@ system.battery.warning=1
 system.cpugovernor=schedutil
 system.hostname=@DEVICENAME@
 system.language=en_US
+system.loglevel=none
 system.overclock=off
 system.power.audio=1
 system.power.cpu=1

--- a/packages/jelos/profile.d/99-freqfunctions
+++ b/packages/jelos/profile.d/99-freqfunctions
@@ -61,7 +61,7 @@ set_dmc_gov() {
   then
     for governor in $1 dmc_$1 simple_$1
     do
-      echo $1 >${DMC_FREQ}/governor 2>/dev/null || echo dmc_$1 >${DMC_FREQ}/governor 2>/dev/null
+      echo ${governor} >${DMC_FREQ}/governor 2>/dev/null
       if [ "$?" = 0 ]
       then
         return
@@ -75,7 +75,7 @@ set_gpu_gov() {
   then
     for governor in $1 dmc_$1 simple_$1
     do
-      echo $1 >${GPU_FREQ}/governor 2>/dev/null
+      echo ${governor} >${GPU_FREQ}/governor 2>/dev/null
       if [ "$?" = 0 ]
       then
         return

--- a/packages/jelos/sources/post-update
+++ b/packages/jelos/sources/post-update
@@ -54,7 +54,20 @@ case ${ASPECT} in
   1.76|0.56)
    ASPECT="16:9"
   ;;
+  1.6|0.62)
+   ASPECT="16:10"
+  ;;
 esac
+
+### Set the aspect ratio in ES.
+ES_CONFIG="/storage/.config/emulationstation/es_settings.cfg"
+ES_ASPECT="${ASPECT/:/-}"
+if [ "$(grep subset.aspect-ratio ${ES_CONFIG})" ]
+then
+  sed -i 's|<string name="subset.aspect-ratio".*$|<string name="subset.aspect-ratio" value="'${ES_ASPECT}'"/>|g' ${ES_CONFIG}
+else
+  sed -i '/<\/config>/i \\t<string name="subset.aspect-ratio" value="'${ES_ASPECT}'"/>' ${ES_CONFIG}
+fi
 
 if [ -f "/storage/.config/emulationstation/resources/logo.png" ]
 then

--- a/packages/jelos/sources/scripts/runemu.sh
+++ b/packages/jelos/sources/scripts/runemu.sh
@@ -22,7 +22,7 @@ LOGSDIR="/var/log"
 LOGFILE="exec.log"
 TBASH="/usr/bin/bash"
 RATMPCONF="/storage/.config/retroarch/retroarch.cfg"
-RAAPPENDCONF="/tmp/raappend.cfg"
+RAAPPENDCONF="/tmp/.retroarch.cfg"
 NETPLAY="No"
 SHADERTMP="/tmp/shader"
 OUTPUT_LOG="${LOGSDIR}/${LOGFILE}"
@@ -47,7 +47,6 @@ EMULATOR="${EMULATOR%% *}"  # until a space is found
 ROMNAME="$1"
 BASEROMNAME=${ROMNAME##*/}
 GAMEFOLDER="${ROMNAME//${BASEROMNAME}}"
-
 
 ### Determine if we're running a Libretro core and append the libretro suffix
 if [[ $EMULATOR = "retroarch" ]]; then

--- a/packages/jelos/sources/scripts/setsettings.sh
+++ b/packages/jelos/sources/scripts/setsettings.sh
@@ -1,34 +1,31 @@
 #!/bin/bash
-
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
-# Copyright (C) 2020-present Fewtarius
-
-# IMPORTANT: This script should not return (echo) anything other than the shader if its set
+# Copyright (C) 2023-present Fewtarius
 
 . /etc/profile
 
-RETROACHIEVEMENTS=(arcade atari2600 atari7800 atarilynx colecovision famicom fbn fds gamegear gb gba gbah gbc gbch gbh genesis genh ggh intellivision mastersystem megacd megadrive megadrive-japan msx msx2 n64 neogeo neogeocd nes nesh ngp ngpc odyssey2 pcengine pcenginecd pcfx pokemini psp psx sega32x segacd sfc sg-1000 snes snesh snesmsu1 supergrafx supervision tg16 tg16cd vectrex virtualboy wonderswan wonderswancolor)
-NOREWIND=(sega32x psx zxspectrum odyssey2 mame n64 dreamcast atomiswave naomi neogeocd saturn psp pspminis)
-NORUNAHEAD=(psp sega32x n64 dreamcast atomiswave naomi neogeocd saturn)
-# The following systems are listed as they don't need the Analogue D-Pad mode on RA
-NOANALOGUE=(n64 psx wonderswan wonderswancolor psp pspminis dreamcast)
-IS32BITCORE=(pcsx_rearmed gpsp)
+###
+### System configuration variables
+###
 
-INDEXRATIOS=(4/3 16/9 16/10 16/15 21/9 1/1 2/1 3/2 3/4 4/1 9/16 5/4 6/5 7/9 8/3 8/7 19/12 19/14 30/17 32/9 config squarepixel core custom full)
-CONF="/storage/.config/system/configs/system.cfg"
-SOURCERACONF="/usr/config/retroarch/retroarch.cfg"
-RACONF="/storage/.config/retroarch/retroarch.cfg"
-RAAPPENDCONF="/tmp/raappend.cfg"
-RACORECONF="/storage/.config/retroarch/retroarch-core-options.cfg"
-SNAPSHOTS="/storage/roms/savestates"
+SYSTEM_CONFIG="/storage/.config/system/configs/system.cfg"
+RETROARCH_CONFIG="/storage/.config/retroarch/retroarch.cfg"
+RETROARCH_TEMPLATE="/usr/config/retroarch/retroarch.cfg"
+
+ROMS_DIR="/storage/roms"
+SNAPSHOTS="${ROMS_DIR}/savestates"
+
+TMP_CONFIG="/tmp/.retroarch.cfg"
+LOG_DIR="/var/log"
+LOG_FILE="exec.log"
+
+###
+### Variables parsed from the command line
+###
+
 PLATFORM=${1,,}
 ROM="${2##*/}"
 CORE=${3,,}
-SHADERSET=0
-LOGSDIR="/var/log"
-LOGFILE="exec.log"
-EE_DEVICE=${HW_DEVICE}
 
 #Autosave
 AUTOSAVE="$@"
@@ -39,93 +36,272 @@ AUTOSAVE="${AUTOSAVE% --*}"
 SNAPSHOT="$@"
 SNAPSHOT="${SNAPSHOT#*--snapshot=*}"
 
-### Enable logging
-if [ "$(get_setting string LogLevel)" == "minimal" ]; then
-	LOG=false
-else
-	LOG=true
-	VERBOSE=true
+###
+### Arrays containing various supported/non-supported attributes.
+###
+
+declare -a HAS_CHEEVOS=(    arcade
+                            atari2600
+                            atari7800
+                            atarilynx
+                            colecovision
+                            famicom
+                            fbn
+                            fds
+                            gamegear
+                            gb
+                            gba
+                            gbah
+                            gbc
+                            gbch
+                            gbh
+                            genesis
+                            genh
+                            ggh
+                            intellivision
+                            mastersystem
+                            megacd
+                            megadrive
+                            megadrive-japan
+                            msx
+                            msx2
+                            n64
+                            neogeo
+                            neogeocd
+                            nes
+                            nesh
+                            ngp
+                            ngpc
+                            odyssey2
+                            pcengine
+                            pcenginecd
+                            pcfx
+                            pokemini
+                            psp
+                            psx
+                            sega32x
+                            segacd
+                            sfc
+                            sg-1000
+                            snes
+                            snesh
+                            snesmsu1
+                            supergrafx
+                            supervision
+                            tg16
+                            tg16cd
+                            vectrex
+                            virtualboy
+                            wonderswan
+                            wonderswancolor
+)
+
+declare -a NO_REWIND=(  atomiswave
+                        dreamcast
+                        mame
+                        n64
+                        naomi
+                        neogeocd
+                        odyssey2
+                        psp
+                        pspminis
+                        psx
+                        saturn
+                        sega32x
+                        zxspectrum
+)
+
+declare -a NO_RUNAHEAD=(    atomiswave
+                            dreamcast
+                            n64
+                            naomi
+                            neogeocd
+                            psp
+                            saturn
+                            sega32x
+)
+
+declare -a NO_ANALOG=(  dreamcast
+                        n64
+                        psp
+                        pspminis
+                        psx
+                        wonderswan
+                        wonderswancolor
+)
+
+declare -a IS_32BIT=(   gpsp
+                        pcsx_rearmed
+)
+
+declare -a CORE_RATIOS=(    4/3
+                            16/9
+                            16/10
+                            16/15
+                            21/9
+                            1/1
+                            2/1
+                            3/2
+                            3/4
+                            4/1
+                            9/16
+                            5/4
+                            6/5
+                            7/9
+                            8/3
+                            8/7
+                            19/12
+                            19/14
+                            30/17
+                            32/9
+                            config
+                            squarepixel
+                            core
+                            custom
+                            full
+)
+
+declare -a LANG_CODES=( ["false"]="0"
+                        ["En"]="1"
+                        ["Fr"]="3"
+                        ["Pt"]="49"
+                        ["De"]="5"
+                        ["El"]="30"
+                        ["Es"]="2"
+                        ["Cs"]="8"
+                        ["Da"]="9"
+                        ["Hr"]="11"
+                        ["Hu"]="35"
+                        ["It"]="4"
+                        ["Ja"]="6"
+                        ["Ko"]="12"
+                        ["Nl"]="7"
+                        ["Nn"]="46"
+                        ["Po"]="48"
+                        ["Ro"]="50"
+                        ["Ru"]="51"
+                        ["Sv"]="10"
+                        ["Tr"]="59"
+                        ["Zh"]="13"
+)
+
+###
+### Fetch common settings
+###
+
+LOGGING=$(get_setting system.loglevel)
+
+###
+### Set up
+###
+
+### Create log directory if it doesn't exist
+if [ ! -d "${LOG_DIR}" ]
+then
+    mkdir -p ${LOG_DIR}
 fi
+
+### Copy the retroarch config file for editing
+if [ -f "${TMP_CONFIG}" ]
+then
+  rm -f "${TMP_CONFIG}"
+fi
+
+###
+### Core functions
+###
 
 function log() {
-	if [ ${LOG} == true ]; then
-		if [[ ! -d "$LOGSDIR" ]]; then
-			mkdir -p "$LOGSDIR"
-		fi
-		DATE=$(date +"%b %d %H:%M:%S")
-		echo "${DATE} ${MYNAME}: $*" 2>&1 >> ${LOGSDIR}/${LOGFILE}
-	fi
+    if [ ${LOGGING} = "verbose" ]
+    then
+        echo "$(printf '%(%c)T\n' -1): setsettings: $*" >> ${LOG_DIR}/${LOG_FILE} 2>&1
+    fi
 }
 
-## Create / delete raappend.cfg
-echo -n > "${RAAPPENDCONF}"
-
-### Move operations to /tmp so we're not writing to the microSD slowing us down.
-### Also test the file to ensure it's not 0 bytes which can happen if someone presses reset.
-if [ ! -s ${RACONF} ]; then
-	log $0 "Fix broken RA conf"
-	cp -f "${SOURCERACONF}" "${RACONF}"
-fi
-
-if [ ! -d "${SNAPSHOTS}/${PLATFORM}" ]; then
-	mkdir -p "${SNAPSHOTS}/${PLATFORM}"
-fi
-
-function doexit() {
-	log $0 "Exiting.."
-	sync
-	exit 0
+function cleanup() {
+    log "Work complete"
+    sync
+    exit
 }
 
-## This needs to be killed with fire.
-function get_game_setting() {
-	log $0 "Get Settings function (\"${1}\" \"${PLATFORM}\" \"${ROM}\")"
-	EES=$(get_setting "${1}" "${PLATFORM}" "${ROM}")
-	( [ -z "${EES}" ] || [ "${EES}" == "auto" ] ) && EES="false"
-	log $0 "Setting: (${EES})"
+function game_setting() {
+    if [ -n "${1}" ]
+    then
+        SETTING=$(get_setting "${1}" "${PLATFORM}" "${ROM}")
+        log "Fetch \"${1}\" \"${PLATFORM}\" \"${ROM}\"] (${SETTING})"
+        echo ${SETTING}
+    fi
 }
 
-
-function array_contains () {
-    local array="$1[@]"
-    local seeking=$2
-    local in=1
-    for element in "${!array}"; do
-        if [[ $element == "$seeking" ]]; then
-            in=0
-            break
-        fi
-    done
-    return $in
+function clean_setting() {
+    log "Remove setting [${1}]"
+    sed -i "/^${1}/d" ${RETROARCH_CONFIG} >/dev/null 2>&1
 }
 
-## Logging
-log $0 "setsettings.sh"
-log $0 "Platform: ${PLATFORM}"
-log $0 "ROM: ${ROM}"
-log $0 "Core: ${CORE}"
+function add_setting() {
+    if [ ! "${1}" = "none" ]
+    then
+        local OS_SETTING="$(game_setting ${1})"
+    fi
+    local RETROARCH_KEY="${2}"
+    local RETROARCH_VALUE="${3}"
+    if [ -z "${RETROARCH_VALUE}" ] && \
+       [ ! "${1}" = "none" ]
+    then
+            case ${OS_SETTING} in
+            0|false|none)
+                RETROARCH_VALUE="false"
+            ;;
+            1|true)
+                RETROARCH_VALUE="true"
+            ;;
+            *)
+                RETROARCH_VALUE="${OS_SETTING}"
+            ;;
+        esac
+    fi
+    clean_setting "${RETROARCH_KEY}"
+    echo "${RETROARCH_KEY} = \"${RETROARCH_VALUE}\"" >>${TMP_CONFIG}
+    log "Added setting: ${RETROARCH_KEY} = \"${RETROARCH_VALUE}\""
+}
 
-##
-## Global Setting that have to stay in retroarch.cfg
-## All settings that should apply when retroarch is run as standalone
-##
+function match() {
+    local seek="${1}"
+    shift
+    local myarray=(${@})
+    if [[ "${myarray[*]}" =~ ${seek} ]]
+    then
+        local MATCH="1"
+    else
+        local MATCH="0"
+    fi
+    log "Match: [${seek}] [${MATCH}] (${myarray[*]})"
+    echo ${MATCH}
+}
 
-MY_CONTROLLER=$(cat /storage/.controller)
-if [ "$(get_setting system.autohotkeys)" == "1" ]
-then
-  if [ -e "/tmp/joypads/${MY_CONTROLLER}.cfg" ]
-  then
-    cp /tmp/joypads/"${MY_CONTROLLER}.cfg" /tmp
-    sed -i "s# = #=#g" /tmp/"${MY_CONTROLLER}.cfg"
-    source /tmp/"${MY_CONTROLLER}.cfg"
-    sed -i "/input_enable_hotkey_btn/d" ${RACONF}
-    sed -i "/input_bind_hold/d" ${RACONF}
-    sed -i "/input_exit_emulator_btn/d" ${RACONF}
-    sed -i "/input_fps_toggle_btn/d" ${RACONF}
-    sed -i "/input_menu_toggle_btn/d" ${RACONF}
-    sed -i "/input_save_state_btn/d" ${RACONF}
-    sed -i "/input_load_state_btn/d" ${RACONF}
-    cat <<EOF >>${RACONF}
+###
+### Game data functions
+###
+
+### Configure retroarch hotkeys
+function configure_hotkeys() {
+    log "Configure hotkeys..."
+    local MY_CONTROLLER=$(cat /storage/.controller)
+    if [ "$(get_setting system.autohotkeys)" == "1" ]
+    then
+        if [ -e "/tmp/joypads/${MY_CONTROLLER}.cfg" ]
+        then
+            cp /tmp/joypads/"${MY_CONTROLLER}.cfg" /tmp
+            sed -i "s# = #=#g" /tmp/"${MY_CONTROLLER}.cfg"
+            source /tmp/"${MY_CONTROLLER}.cfg"
+            sed -i "/input_enable_hotkey_btn/d" ${RETROARCH_CONFIG}
+            sed -i "/input_bind_hold/d" ${RETROARCH_CONFIG}
+            sed -i "/input_exit_emulator_btn/d" ${RETROARCH_CONFIG}
+            sed -i "/input_fps_toggle_btn/d" ${RETROARCH_CONFIG}
+            sed -i "/input_menu_toggle_btn/d" ${RETROARCH_CONFIG}
+            sed -i "/input_save_state_btn/d" ${RETROARCH_CONFIG}
+            sed -i "/input_load_state_btn/d" ${RETROARCH_CONFIG}
+            cat <<EOF >>${RETROARCH_CONFIG}
 input_enable_hotkey_btn = "${input_select_btn}"
 input_bind_hold = "${input_select_btn}"
 input_exit_emulator_btn = "${input_start_btn}"
@@ -134,594 +310,434 @@ input_menu_toggle_btn = "${input_x_btn}"
 input_save_state_btn = "${input_r_btn}"
 input_load_state_btn = "${input_l_btn}"
 EOF
-    rm -f /tmp/"${MY_CONTROLLER}.cfg"
-  fi
-fi
-
-# RA menu rgui, ozone, glui or xmb (fallback if everthing else fails)
-# if empty (auto in ES) do nothing to enable configuration in RA
-get_game_setting "retroarch.menu_driver"
-if [ "${EES}" != "false" ]; then
-	# delete setting only if we set new ones
-	# therefore configuring in RA is still possible
-	sed -i "/menu_driver/d" ${RACONF}
-	sed -i "/menu_linear_filter/d" ${RACONF}
-	# Set new menu driver
-	if [ "${EES}" == "rgui" ]; then
-		# menu_liner_filter is only needed for rgui
-		echo 'menu_driver = "rgui"' >> ${RACONF}
-		echo 'menu_linear_filter = "true"' >> ${RACONF}
-	elif [ "${EES}" == "ozone" ]; then
-		echo 'menu_driver = "ozone"' >> ${RACONF}
-	elif [ "${EES}" == "glui" ]; then
-		echo 'menu_driver = "glui"' >> ${RACONF}
-	else
-		# play it save and set xmb if nothing else matches
-		echo 'menu_driver = "xmb"' >> ${RACONF}
-	fi
-fi
-
-
-##
-## Global Settings that go into the temorary config file
-##
-
-## FPS
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "showFPS"
-[ "${EES}" == "1" ] && echo 'fps_show = "true"' >> ${RAAPPENDCONF} || echo 'fps_show = "false"' >> ${RAAPPENDCONF}
-
-
-## RetroAchievements / Cheevos
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "retroachievements"
-for i in "${!RETROACHIEVEMENTS[@]}"; do
-	if [[ "${RETROACHIEVEMENTS[$i]}" = "${PLATFORM}" ]]; then
-		if [ "${EES}" == "1" ]; then
-			echo 'cheevos_enable = "true"' >> ${RAAPPENDCONF}
-			get_game_setting "retroachievements.username"
-			echo "cheevos_username = \"${EES}\"" >> ${RAAPPENDCONF}
-			get_game_setting "retroachievements.password"
-			echo "cheevos_password = \"${EES}\"" >> ${RAAPPENDCONF}
-
-			# retroachievements_hardcore_mode
-			get_game_setting "retroachievements.hardcore"
-			[ "${EES}" == "1" ] && echo 'cheevos_hardcore_mode_enable = "true"' >> ${RAAPPENDCONF} || echo 'cheevos_hardcore_mode_enable = "false"' >> ${RAAPPENDCONF}
-
-			# retroachievements_leaderboards
-			get_game_setting "retroachievements.leaderboards"
-			if [ "${EES}" == "enabled" ]; then
-				echo 'cheevos_leaderboards_enable = "true"' >> ${RAAPPENDCONF}
-			elif [ "${EES}" == "trackers only" ]; then
-				echo 'cheevos_leaderboards_enable = "trackers"' >> ${RAAPPENDCONF}
-			elif [ "${EES}" == "notifications only" ]; then
-				echo 'cheevos_leaderboards_enable = "notifications"' >> ${RAAPPENDCONF}
-			else
-				echo 'cheevos_leaderboards_enable = "false"' >> ${RAAPPENDCONF}
-			fi
-
-			# retroachievements_verbose_mode
-			get_game_setting "retroachievements.verbose"
-			[ "${EES}" == "1" ] && echo 'cheevos_verbose_enable = "true"' >> ${RAAPPENDCONF} || echo 'cheevos_verbose_enable = "false"' >> ${RAAPPENDCONF}
-
-			# retroachievements_automatic_screenshot
-			get_game_setting "retroachievements.screenshot"
-			[ "${EES}" == "1" ] && echo 'cheevos_auto_screenshot = "true"' >> ${RAAPPENDCONF} || echo 'cheevos_auto_screenshot = "false"' >> ${RAAPPENDCONF}
-
-			# cheevos_richpresence_enable
-			get_game_setting "retroachievements.richpresence"
-			[ "${EES}" == "1" ] && echo 'cheevos_richpresence_enable = "true"' >> ${RAAPPENDCONF} || echo 'cheevos_richpresence_enable = "false"' >> ${RAAPPENDCONF}
-
-			# cheevos_challenge_indicators
-			get_game_setting "retroachievements.challengeindicators"
-			[ "${EES}" == "1" ] && echo 'cheevos_challenge_indicators = "true"' >> ${RAAPPENDCONF} || echo 'cheevos_challenge_indicators = "false"' >> ${RAAPPENDCONF}
-
-			# cheevos_test_unofficial
-			get_game_setting "retroachievements.testunofficial"
-			[ "${EES}" == "1" ] && echo 'cheevos_test_unofficial = "true"' >> ${RAAPPENDCONF} || echo 'cheevos_test_unofficial = "false"' >> ${RAAPPENDCONF}
-
-			# cheevos_badges_enable
-			get_game_setting "retroachievements.badges"
-			[ "${EES}" == "1" ] && echo 'cheevos_badges_enable = "true"' >> ${RAAPPENDCONF} || echo 'cheevos_badges_enable = "false"' >> ${RAAPPENDCONF}
-
-			# cheevos_start_active
-			get_game_setting "retroachievements.active"
-			[ "${EES}" == "1" ] && echo 'cheevos_start_active = "true"' >> ${RAAPPENDCONF} || echo 'cheevos_start_active = "false"' >> ${RAAPPENDCONF}
-
-			# cheevos_unlock_sound_enable
-			get_game_setting "retroachievements.soundenable"
-			[ "${EES}" == "1" ] && echo 'cheevos_unlock_sound_enable = "true"' >> ${RAAPPENDCONF} || echo 'cheevos_unlock_sound_enable = "false"' >> ${RAAPPENDCONF}
-		else
-			echo 'cheevos_enable = "false"' >> ${RAAPPENDCONF}
-			echo 'cheevos_username = ""' >> ${RAAPPENDCONF}
-			echo 'cheevos_password = ""' >> ${RAAPPENDCONF}
-			echo 'cheevos_hardcore_mode_enable = "false"' >> ${RAAPPENDCONF}
-			echo 'cheevos_leaderboards_enable = "false"' >> ${RAAPPENDCONF}
-			echo 'cheevos_verbose_enable = "false"' >> ${RAAPPENDCONF}
-			echo 'cheevos_test_unofficial = "false"' >> ${RAAPPENDCONF}
-			echo 'cheevos_unlock_sound_enable = "false"' >> ${RAAPPENDCONF}
-			echo 'cheevos_auto_screenshot = "false"' >> ${RAAPPENDCONF}
-			echo 'cheevos_badges_enable = "false"' >> ${RAAPPENDCONF}
-			echo 'cheevos_start_active = "false"' >> ${RAAPPENDCONF}
-			echo 'cheevos_richpresence_enable = "false"' >> ${RAAPPENDCONF}
-			echo 'cheevos_challenge_indicators = "false"' >> ${RAAPPENDCONF}
-		fi
-	fi
-done
-
-## Netplay
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "netplay"
-if [ "${EES}" == "false" ] || [ "${EES}" == "none" ] || [ "${EES}" == "0" ]; then
-	echo 'netplay = false' >> ${RAAPPENDCONF}
-else
-	echo 'netplay = true' >> ${RAAPPENDCONF}
-	get_game_setting "netplay.mode"
-	NETPLAY_MODE=${EES}
-	# Security : hardcore mode disables save states, which would kill netplay
-	sed -i '/cheevos_hardcore_mode_enable =/d' ${RAAPPENDCONF}
-	echo 'cheevos_hardcore_mode_enable = "false"' >> ${RAAPPENDCONF}
-
-	if [[ "${NETPLAY_MODE}" == "host" ]]; then
-		# Quite strangely, host mode requires netplay_mode to be set to false when launched from command line
-		echo 'netplay_mode = false' >> ${RAAPPENDCONF}
-		echo 'netplay_client_swap_input = false' >> ${RAAPPENDCONF}
-		get_game_setting "netplay.port"
-		echo "netplay_ip_port = ${EES}" >> ${RAAPPENDCONF}
-	elif [[ "${NETPLAY_MODE}" == "client" ]]; then
-		# But client needs netplay_mode = true ... bug ?
-		echo 'netplay_mode = true' >> ${RAAPPENDCONF}
-		get_game_setting "netplay.client.ip"
-		echo "netplay_ip_address = ${EES}" >> ${RAAPPENDCONF}
-		get_game_setting "netplay.client.port"
-		echo "netplay_ip_port = ${EES}" >> ${RAAPPENDCONF}
-		echo 'netplay_client_swap_input = true' >> ${RAAPPENDCONF}
-	fi # Host or Client
-
-	# relay
-	get_game_setting "netplay.relay"
-	if [[ ! -z "${EES}" && "${EES}" != "false" ]]; then
-		echo 'netplay_use_mitm_server = true' >> ${RAAPPENDCONF}
-		echo "netplay_mitm_server = ${EES}" >> ${RAAPPENDCONF}
-	else
-		echo 'netplay_use_mitm_server = false' >> ${RAAPPENDCONF}
-		# sed -i "/netplay_mitm_server/d" ${RACONF}
-	fi
-
-	get_game_setting "netplay.frames"
-	echo "netplay_delay_frames = ${EES}" >> ${RAAPPENDCONF}
-	get_game_setting "netplay.nickname"
-	echo "netplay_nickname = ${EES}" >> ${RAAPPENDCONF}
-	# spectator mode
-	get_game_setting "netplay.spectator"
-	[ "${EES}" == "1" ] && echo 'netplay_spectator_mode_enable = true' >> ${RAAPPENDCONF} || echo 'netplay_spectator_mode_enable = false' >> ${RAAPPENDCONF}
-	get_game_setting "netplay_public_announce"
-	[ "${EES}" == "1" ] && echo 'netplay_public_announce = true' >> ${RAAPPENDCONF} || echo 'netplay_public_announce = false' >> ${RAAPPENDCONF}
-fi
-
-## AI Translation Service
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "ai_service_enabled"
-if [ "${EES}" == "false" ] || [ "${EES}" == "none" ] || [ "${EES}" == "0" ]; then
-	echo 'ai_service_enable = "false"' >> ${RAAPPENDCONF}
-else
-	# Translation table to get the values RA needs
-	declare -A LangCodes=( 	["false"]="0"
-							["En"]="1"
-							["Fr"]="3"
-							["Pt"]="49"
-							["De"]="5"
-							["El"]="30"
-							["Es"]="2"
-							["Cs"]="8"
-							["Da"]="9"
-							["Hr"]="11"
-							["Hu"]="35"
-							["It"]="4"
-							["Ja"]="6"
-							["Ko"]="12"
-							["Nl"]="7"
-							["Nn"]="46"
-							["Po"]="48"
-							["Ro"]="50"
-							["Ru"]="51"
-							["Sv"]="10"
-							["Tr"]="59"
-							["Zh"]="13"
-                  		)
-	echo 'ai_service_enable = "true"' >> ${RAAPPENDCONF}
-	get_game_setting "ai_target_lang"
-	AI_LANG=${EES}
-	# [[ "$AI_LANG" == "false" ]] && AI_LANG="0"
-	get_game_setting "ai_service_url"
-	AI_URL=${EES}
-	echo "ai_service_target_lang = \"${LangCodes[${AI_LANG}]}\"" >> ${RAAPPENDCONF}
-	if [ "${AI_URL}" == "false" ] || [ "${AI_URL}" == "auto" ] || [ "${AI_URL}" == "none" ]; then
-		echo "ai_service_url = \"http://ztranslate.net/service?api_key=BATOCERA&mode=Fast&output=png&target_lang=${AI_LANG}" >> ${RAAPPENDCONF}
-	else
-		echo "ai_service_url = \"${AI_URL}&mode=Fast&output=png&target_lang=${AI_LANG}" >> ${RAAPPENDCONF}
-	fi
-fi
-
-##
-## Global/System/Game specific settings
-##
-
-## Ratio
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "ratio"
-if [[ "${EES}" == "false" ]]; then
-	# 22 is the "Core Provided" aspect ratio and its set by default if no other is selected
-	echo 'aspect_ratio_index = "22"' >> ${RAAPPENDCONF}
-else
-for i in "${!INDEXRATIOS[@]}"; do
-	if [[ "${INDEXRATIOS[$i]}" = "${EES}" ]]; then
-		break
-	fi
-done
-	echo "aspect_ratio_index = \"${i}\"" >> ${RAAPPENDCONF}
-fi
-
-## Bilinear filtering
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "smooth"
-[ "${EES}" == "1" ] && echo 'video_smooth = "true"' >> ${RAAPPENDCONF} || echo 'video_smooth = "false"' >> ${RAAPPENDCONF}
-
-## Video Integer Scale
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "integerscale"
-[ "${EES}" == "1" ] && echo 'video_scale_integer = "true"' >> ${RAAPPENDCONF} || echo 'video_scale_integer = "false"' >> ${RAAPPENDCONF}
-
-## RGA Scaling / CTX Scaling
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting	"rgascale"
-[ "${EES}" == "1" ] && echo 'video_ctx_scaling = "true"' >> ${RAAPPENDCONF} || echo 'video_ctx_scaling = "false"' >> ${RAAPPENDCONF}
-
-## Shaderset
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "shaderset"
-if [ "${EES}" == "false" ] || [ "${EES}" == "none" ] || [ "${EES}" == "0" ]; then
-	echo 'video_shader_enable = "false"' >> ${RAAPPENDCONF}
-	echo 'video_shader = ""' >> ${RAAPPENDCONF}
-else
-	echo "video_shader = \"${EES}\"" >> ${RAAPPENDCONF}
-	echo 'video_shader_enable = "true"' >> ${RAAPPENDCONF}
-	echo "--set-shader /tmp/shaders/${EES}"
-fi
-
-## Filterset
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "filterset"
-if [ "${EES}" == "false" ] || [ "${EES}" == "none" ]; then
-	echo 'video_filter = ""' >> ${RAAPPENDCONF}
-else
-	# Turn off RGA scaling first - just in case
-	sed -i "/video_ctx_scaling/d" ${RAAPPENDCONF}
-	echo 'video_ctx_scaling = "false"' >> ${RAAPPENDCONF}
-	if array_contains IS32BITCORE ${CORE}; then
-		echo "video_filter = \"/usr/share/retroarch/filters/32bit/video/${EES}\"" >> ${RAAPPENDCONF}
-	else
-		echo "video_filter = \"/usr/share/retroarch/filters/64bit/video/${EES}\"" >> ${RAAPPENDCONF}
-	fi
-fi
-
-## Set correct path for video- and audio-filters
-if array_contains IS32BITCORE ${CORE}; then
-	echo 'audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"' >> ${RAAPPENDCONF}
-	echo 'video_filter_dir = "/usr/share/retroarch/filters/32bit/video"' >> ${RAAPPENDCONF}
-else
-	echo 'audio_filter_dir = "/usr/share/retroarch/filters/64bit/audio"' >> ${RAAPPENDCONF}
-	echo 'video_filter_dir = "/usr/share/retroarch/filters/64bit/video"' >> ${RAAPPENDCONF}
-fi
-
-## Rewind
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "rewind"
-(for e in "${NORUNAHEAD[@]}"; do [[ "${e}" == "${PLATFORM}" ]] && exit 0; done) && RA=0 || RA=1
-if [ $RA == 1 ] && [ "${EES}" == "1" ]; then
-	echo 'rewind_enable = "true"' >> ${RAAPPENDCONF}
-else
-	echo 'rewind_enable = "false"' >> ${RAAPPENDCONF}
-fi
-
-## Incrementalsavestates
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "incrementalsavestates"
-if [ "${EES}" == "false" ] || [ "${EES}" == "none" ] || [ "${EES}" == "0" ]; then
-	echo 'savestate_auto_index = "false"' >> ${RAAPPENDCONF}
-	echo 'savestate_max_keep = "50"' >> ${RAAPPENDCONF}
-else
-	echo 'savestate_auto_index = "true"' >> ${RAAPPENDCONF}
-	echo 'savestate_max_keep = "0"' >> ${RAAPPENDCONF}
-fi
-
-## Autosave
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "autosave"
-if [ "${EES}" == "false" ] || [ "${EES}" == "none" ] || [ "${EES}" == "0" ]; then
-	echo 'savestate_auto_save = "false"' >> ${RAAPPENDCONF}
-	echo 'savestate_auto_load = "false"' >> ${RAAPPENDCONF}
-else
-	echo 'savestate_auto_save = "true"' >> ${RAAPPENDCONF}
-	echo 'savestate_auto_load = "true"' >> ${RAAPPENDCONF}
-fi
-
-## Snapshots
-echo 'savestate_directory = "'"${SNAPSHOTS}/${PLATFORM}"'"' >> ${RAAPPENDCONF}
-if [ ! -z ${SNAPSHOT} ]
-then
-		sed -i "/savestate_auto_load =/d" ${RAAPPENDCONF}
-		sed -i "/savestate_auto_save =/d" ${RAAPPENDCONF}
-		if [ ${AUTOSAVE} == "1" ]; then
-			echo 'savestate_auto_load = "true"' >> ${RAAPPENDCONF}
-			echo 'savestate_auto_save = "true"' >> ${RAAPPENDCONF}
-		else
-			echo 'savestate_auto_load = "false"' >> ${RAAPPENDCONF}
-			echo 'savestate_auto_save = "false"' >> ${RAAPPENDCONF}
-                fi
-		echo "state_slot = \"${SNAPSHOT}\"" >> ${RAAPPENDCONF}
-fi
-
-## Runahead
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "runahead"
-(for e in "${NORUNAHEAD[@]}"; do [[ "${e}" == "${PLATFORM}" ]] && exit 0; done) && RA=0 || RA=1
-if [ $RA == 1 ]; then
-	if [ "${EES}" == "false" ] || [ "${EES}" == "none" ] || [ "${EES}" == "0" ]; then
-		echo 'run_ahead_enabled = "false"' >> ${RAAPPENDCONF}
-		echo 'run_ahead_frames = "1"' >> ${RAAPPENDCONF}
-	else
-		echo 'run_ahead_enabled = "true"' >> ${RAAPPENDCONF}
-		echo "run_ahead_frames = \"${EES}\"" >> ${RAAPPENDCONF}
-	fi
-fi
-
-## Secondinstance
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "secondinstance"
-(for e in "${NORUNAHEAD[@]}"; do [[ "${e}" == "${PLATFORM}" ]] && exit 0; done) && RA=0 || RA=1
-if [ $RA == 1 ]; then
-	[ "${EES}" == "1" ] && echo 'run_ahead_secondary_instance = "true"' >> ${RAAPPENDCONF} || echo 'run_ahead_secondary_instance = "false"' >> ${RAAPPENDCONF}
-fi
-
-## Audiolatency
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "audiolatency"
-if [[ "${EES}" =~ ^[0-9]+$ ]] && [[ "${EES}" -gt "0" ]]; then
-	echo "audio_latency = \"${EES}\"" >> ${RAAPPENDCONF}
-fi
-
-## D-Pad to Analogue support, option in ES is missing atm but is managed as global.analogue=1 in system.cfg (that is made by postupdate.sh)
-# Get configuration from system.cfg and set to retroarch.cfg
-get_game_setting "analogue"
-(for e in "${NOANALOGUE[@]}"; do [[ "${e}" == "${PLATFORM}" ]] && exit 0; done) && RA=1 || RA=0
-if [ $RA == 1 ] || [ "${EES}" == "false" ] || [ "${EES}" == "0" ]; then
-        echo 'input_player1_analog_dpad_mode = "0"' >> ${RAAPPENDCONF}
-else
-        echo 'input_player1_analog_dpad_mode = "1"' >> ${RAAPPENDCONF}
-fi
-
-##
-## Tate Mode
-##
-
-get_game_setting "tatemode"
-MAME2003DIR="/storage/.config/retroarch/config/MAME 2003-Plus"
-MAME2003REMAPDIR="/storage/remappings/MAME 2003-Plus"
-if [ "${EES}" == "1" ]
-then
-	if [ ! -d "${MAME2003DIR}" ]
-	then
-		mkdir -p "${MAME2003DIR}"
-	fi
-
-        if [ ! -d "${MAME2003REMAPDIR}" ]
-        then
-                mkdir -p "${MAME2003REMAPDIR}"
-	fi
-
-	cp "/usr/config/retroarch/TATE-MAME 2003-Plus.rmp" "${MAME2003REMAPDIR}/MAME 2003-Plus.rmp"
-
-	if [ "$(grep mame2003-plus_tate_mode "${MAME2003DIR}/MAME 2003-Plus.opt" > /dev/null 2>&1)" ]
-	then
-		sed -i 's#mame2003-plus_tate_mode.*$#mame2003-plus_tate_mode = "enabled"#' "${MAME2003DIR}/MAME 2003-Plus.opt" 2>/dev/null
-	else
-		echo 'mame2003-plus_tate_mode = "enabled"' > "${MAME2003DIR}/MAME 2003-Plus.opt"
-	fi
-else
-	if [ -e "${MAME2003DIR}/MAME 2003-Plus.opt" ]
-	then
-		sed -i 's#mame2003-plus_tate_mode.*$#mame2003-plus_tate_mode = "disabled"#' "${MAME2003DIR}/MAME 2003-Plus.opt" 2>/dev/null
-	fi
-	if [ -e "${MAME2003REMAPDIR}/MAME 2003-Plus.rmp" ]
-	then
-		rm -f "${MAME2003REMAPDIR}/MAME 2003-Plus.rmp"
-	fi
-fi
-
-##
-## Parallel-N64 core options
-##
-
-PARALLELN64DIR="/storage/.config/retroarch/config/ParaLLEl N64"
-
-        if [ ! -d "${PARALLELN64DIR}" ]
-        then
-                mkdir -p "${PARALLELN64DIR}"
+        rm -f /tmp/"${MY_CONTROLLER}.cfg"
         fi
+    fi
+}
 
-        if [ ! -f "${PARALLELN64DIR}/ParaLLEl N64.opt" ]
+function set_ra_menudriver() {
+    add_setting "retroarch.menu_driver" "menu_driver"
+    local MENU_DRIVER=$(game_setting retroarch.menu_driver)
+    case ${MENU_DRIVER} in
+        rgui)
+            add_setting "none" "menu_linear_filter" "true"
+        ;;
+    esac
+}
+
+function set_fps() {
+    add_setting "showFPS" "fps_show"
+}
+
+function set_cheevos() {
+    local USE_CHEEVOS=$(game_setting "retroachievements")
+    local CHECK_CHEEVOS="$(match "${PLATFORM}" "${HAS_CHEEVOS[@]}")"
+    if [ "${USE_CHEEVOS}" = 1 ] && \
+       [ "${CHECK_CHEEVOS}" = 1 ]
+    then
+        add_setting "none" "cheevos_enable" "true"
+        add_setting "retroachievements.username" "cheevos_username"
+        add_setting "retroachievements.password" "cheevos_password"
+        add_setting "retroachievements.hardcore" "cheevos_hardcore_mode_enable"
+        add_setting "retroachievements.leaderboards" "cheevos_leaderboards_enable"
+        add_setting "retroachievements.verbose" "cheevos_verbose_enable"
+        add_setting "retroachievements.screenshot" "cheevos_auto_screenshot"
+        add_setting "retroachievements.richpresence" "cheevos_richpresence_enable"
+        add_setting "retroachievements.challengeindicators" "cheevos_challenge_indicators"
+        add_setting "retroachievements.testunofficial" "cheevos_test_unofficial"
+        add_setting "retroachievements.badges" "cheevos_badges_enable"
+        add_setting "retroachievements.active" "cheevos_start_active"
+        add_setting "retroachievements.soundenable" "cheevos_unlock_sound_enable"
+    else
+        add_setting "none" "cheevos_enable" "false"
+    fi
+}
+
+function set_netplay() {
+    local USE_NETPLAY=$(game_setting "netplay")
+    if [ "${USE_NETPLAY}" = 1 ]
+    then
+        add_setting "retroachievements.hardcore" "cheevos_hardcore_mode_enable" "false"
+        add_setting "netplay.frames" "netplay_delay_frames"
+        add_setting "netplay.nickname" "netplay_nickname"
+        add_setting "netplay.spectator" "netplay_spectator_mode_enable"
+        add_setting "netplay_public_announce" "netplay_public_announce"
+        local NETPLAY_MODE=$(game_setting "netplay.mode")
+        case ${NETPLAY_MODE} in
+            host)
+                add_setting "none" "netplay_mode" "false"
+                add_setting "none" "netplay_client_swap_input" "false"
+                add_setting "netplay.port" "netplay_ip_port"
+            ;;
+            client)
+                add_setting "none" "netplay_mode" "true"
+                add_setting "none" "netplay_client_swap_input" "true"
+                add_setting "netplay.client.ip" "netplay_ip_address"
+                add_setting "netplay.client.port" "netplay_ip_port"
+            ;;
+        esac
+        local NETPLAY_RELAY=$(game_setting netplay.relay)
+        case $(NETPLAY_RELAY) in
+            none|false|0)
+                add_setting "none" "netplay_use_mitm_server" "false"
+            ;;
+            *)
+                add_setting "none" "netplay_use_mitm_server" "true"
+                add_setting "none" "netplay_mitm_server" "${NETPLAY_RELAY}"
+            ;; 
+        esac
+    else
+        add_setting "none" "netplay" "false"
+    fi
+}
+
+function set_translation() {
+    local USE_AI_SERVICE="$(game_setting ai_service_enabled)"
+    case ${USE_AI_SERVICE} in
+        0|false|none)
+            add_setting "none" "ai_service_enable" "false"
+        ;;
+        *)
+            add_setting "none" "ai_service_enable" "true"
+            local AI_LANG="$(game_setting ai_target_lang)"
+            local AI_URL="$(game_setting ai_service_url)"
+            case ${AI_URL} in
+              0|false|none)
+                add_setting "none" "ai_service_url" "http://ztranslate.net/service?api_key=BATOCERA&mode=Fast&output=png&target_lang=${AI_LANG}"
+              ;;
+              *)
+                add_setting "none" "ai_service_url" "${AI_URL}&mode=Fast&output=png&target_lang=${AI_LANG}"
+              ;;
+            esac
+        ;;
+    esac
+}
+
+function set_aspectratio() {
+    local ASPECT_RATIO="$(game_setting ratio)"
+    case ${ASPECT_RATIO} in
+      0|false|none)
+        add_setting "none" "aspect_ratio_index" "22"
+      ;;
+      *)
+        for AR in ${!CORE_RATIOS[@]}
+        do
+            log "Test [${ASPECT_RATIO}] (${CORE_RATIOS[${AR}]}) (${AR})"
+            if [ "${CORE_RATIOS[${AR}]}" = "${ASPECT_RATIO}" ]
+            then
+                log "Find aspect ratio [${ASPECT_RATIO}] (${CORE_RATIOS[${AR}]})"
+                add_setting "none" "aspect_ratio_index" "${AR}"
+                break
+            fi
+        done
+      ;;
+    esac
+}
+
+function set_filtering() {
+    add_setting "smooth" "video_smooth"
+}
+
+function set_integerscale() {
+    add_setting "integerscale" "video_scale_integer"
+}
+
+function set_rgascale() {
+    add_setting "rgascale" "video_ctx_scaling"
+}
+
+function set_shader() {
+    local SHADER="$(game_setting shaderset)"
+    case ${SHADER} in
+        0|false|none)
+            add_setting "none" "video_shader_enable" "false"
+        ;;
+        *)
+            add_setting "none" "video_shader_enable" "true"
+            add_setting "none" "video_shader" "${SHADER}"
+            echo "--set-shader /tmp/shaders/${SHADER}"
+        ;;
+    esac
+}
+
+function set_filter() {
+    local FILTER="$(game_setting filterset)"
+    case ${FILTER} in
+        0|false|none)
+            add_setting "none" "video_filter" ""
+        ;;
+        *)
+            local FILTER_PATH="/usr/share/retroarch/filters"
+            add_setting "none" "video_ctx_scaling" "false"
+            local CHECK_BITNESS="$(match ${CORE} ${IS_32BIT[@]})"
+            if [ "${CHECK_BITNESS}" = 1 ]
+            then
+                BITS="32"
+            else
+                BITS="64"
+            fi
+                add_setting "none" "video_filter" "${FILTER_PATH}/${BITS}bit/video/${FILTER}"
+                add_setting "none" "video_filter_dir" "${FILTER_PATH}/${BITS}bit/video/"
+                add_setting "none" "audio_filter_dir" "${FILTER_PATH}/${BITS}bit/audio"
+        ;;
+    esac
+}
+
+function set_rewind() {
+    local REWIND="$(game_setting rewind)"
+    local HAS_REWIND="$(match ${CORE} ${NO_REWIND[@]})"
+    case ${HAS_REWIND} in
+        0)
+            add_setting "none" "rewind_enable" "false"
+        ;;
+        *)
+            add_setting "none" "rewind_enable" "true"
+        ;;
+    esac
+}
+
+function set_savestates() {
+    local SAVESTATES="$(game_setting incrementalsavestates)"
+    case ${SAVESTATES} in
+        0|false|none)
+            add_setting "none" "savestate_auto_index" "false"
+            add_setting "none" "savestate_max_keep" "50"
+        ;;
+        *)
+            add_setting "none" "savestate_auto_index" "true"
+            add_setting "none" "savestate_max_keep" "0"
+        ;;
+    esac
+}
+
+function set_autosave() {
+    local AUTOSAVE="$(game_setting autosave)"
+    add_setting "none" "savestate_directory" "${SNAPSHOTS}/${PLATFORM}"
+    if [ ! -z "${SNAPSHOT}" ]
+    then
+        case ${AUTOSAVE} in
+            0|false|none)
+                add_setting "none" "savestate_auto_save" "false"
+                add_setting "none" "savestate_auto_load" "false"
+            ;;
+            *)
+                add_setting "none" "savestate_auto_save" "true"
+                add_setting "none" "savestate_auto_load" "true"
+            ;;
+        esac
+    else
+            add_setting "none" "savestate_auto_load" "false"
+            add_setting "none" "savestate_auto_save" "false"
+    fi
+}
+
+function set_runahead() {
+    local RUNAHEAD="$(game_setting runahead)"
+    local HAS_RUNAHEAD="$(match ${PLATFORM} ${NO_RUNAHEAD[@]})"
+    case ${HAS_RUNAHEAD} in
+        0|false|none)
+            add_setting "none" "run_ahead_enabled" "false"
+            add_setting "none" "run_ahead_frames" "1"
+        ;;
+        *)
+            add_setting "none" "run_ahead_enabled" "true"
+            add_setting "none" "run_ahead_frames" "${RUNAHEAD}"
+            add_setting "secondinstance" "run_ahead_secondary_instance"
+        ;;
+    esac
+}
+
+function set_audiolatency() {
+    add_setting "audiolatency" "audio_latency"
+}
+
+function set_analogsupport() {
+    local HAS_ANALOG="$(match ${PLATFORM} ${NO_ANALOG[@]})"
+    case ${HAS_ANALOG} in
+        0|false|none)
+            add_setting "none" "input_player1_analog_dpad_mode" "0"
+        ;;
+        *)
+            add_setting "analogue" "input_player1_analog_dpad_mode"
+        ;;
+    esac
+}
+
+function set_tatemode() {
+    log "Setup tate mode..."
+    local TATEMODE="$(game_setting tatemode)"
+    local MAME2003DIR="/storage/.config/retroarch/config/MAME 2003-Plus"
+    local MAME2003REMAPDIR="/storage/remappings/MAME 2003-Plus"
+    if [ ! -d "${MAME2003DIR}" ]
+    then
+            mkdir -p "${MAME2003DIR}"
+    fi
+    if [ ! -d "${MAME2003REMAPDIR}" ]
+    then
+            mkdir -p "${MAME2003REMAPDIR}"
+    fi
+    case ${TATEMODE} in
+        0|false|none)
+            if [ -e "${MAME2003DIR}/MAME 2003-Plus.opt" ]
+            then
+                sed -i 's#mame2003-plus_tate_mode.*$#mame2003-plus_tate_mode = "disabled"#' "${MAME2003DIR}/MAME 2003-Plus.opt" 2>/dev/null
+            fi
+            if [ -e "${MAME2003REMAPDIR}/MAME 2003-Plus.rmp" ]
+            then
+                rm -f "${MAME2003REMAPDIR}/MAME 2003-Plus.rmp"
+            fi  
+        ;;
+        *)
+            cp "/usr/config/retroarch/TATE-MAME 2003-Plus.rmp" "${MAME2003REMAPDIR}/MAME 2003-Plus.rmp"
+            if [ "$(grep mame2003-plus_tate_mode "${MAME2003DIR}/MAME 2003-Plus.opt" > /dev/null 2>&1)" ]
+            then
+                sed -i 's#mame2003-plus_tate_mode.*$#mame2003-plus_tate_mode = "enabled"#' "${MAME2003DIR}/MAME 2003-Plus.opt" 2>/dev/null
+            else
+                echo 'mame2003-plus_tate_mode = "enabled"' > "${MAME2003DIR}/MAME 2003-Plus.opt"
+            fi
+        ;;
+    esac
+}
+
+function set_n64opts() {
+    log "Set up N64..."
+    local PARALLELN64DIR="/storage/.config/retroarch/config/ParaLLEl N64"
+    if [ ! -d "${PARALLELN64DIR}" ]
+    then
+        mkdir -p "${PARALLELN64DIR}"
+    fi
+
+    if [ ! -f "${PARALLELN64DIR}/ParaLLEl N64.opt" ]
+    then
+        cp "/usr/config/retroarch/ParaLLEl N64.opt" "${PARALLELN64DIR}/ParaLLEl N64.opt"
+    fi
+    local VIDEO_CORE="$(game_setting parallel_n64_video_core)"
+    sed -i '/parallel-n64-gfxplugin = /c\parallel-n64-gfxplugin = "'${VIDEO_CORE}'"' "${PARALLELN64DIR}/ParaLLEl N64.opt"
+    local SCREENSIZE="$(game_setting parallel_n64_internal_resolution)"
+    sed -i '/parallel-n64-screensize = /c\parallel-n64-screensize = "'${SCREENSOZE}'"' "${PARALLELN64DIR}/ParaLLEl N64.opt"
+    local GAMESPEED="$(game_setting parallel_n64_gamespeed)"
+    sed -i '/parallel-n64-framerate = /c\parallel-n64-framerate = "'${GAMESPEED}'"' "${PARALLELN64DIR}/ParaLLEl N64.opt"
+    local ACCURACY="$(game_setting parallel_n64_gfx_accuracy)"
+    sed -i '/parallel-n64-gfxplugin-accuracy = /c\parallel-n64-gfxplugin-accuracy = "'${ACCURACY}'"' "${PARALLELN64DIR}/ParaLLEl N64.opt"
+    local CONTROLLERPAK="$(game_setting parallel_n64_controller_pak)"
+    sed -i '/parallel-n64-pak1 = /c\parallel-n64-pak1 = "'${CONTROLLERPAK}'"' "${PARALLELN64DIR}/ParaLLEl N64.opt"
+}
+
+function set_atari() {
+    log "Set up Atari (FIXME)..."
+    if [ "${CORE}" = "atari800" ]
+    then
+        ATARICONF="/storage/.config/system/configs/atari800.cfg"
+        ATARI800CONF="/storage/.config/retroarch/config/Atari800/Atari800.opt"
+        if [ ! -f "$ATARI800CONF" ]
         then
-                cp "/usr/config/retroarch/ParaLLEl N64.opt" "${PARALLELN64DIR}/ParaLLEl N64.opt"
+            touch "$ATARI800CONF"
         fi
+        sed -i "/RAM_SIZE=/d" ${ATARICONF}
+        sed -i "/STEREO_POKEY=/d" ${ATARICONF}
+        sed -i "/BUILTIN_BASIC=/d" ${ATARICONF}
+        sed -i "/atari800_system =/d" ${ATARI800CONF}
 
-get_game_setting "parallel_n64_video_core"
+        if [ "${PLATFORM}" == "atari5200" ]; then
+            add_setting "none" "atari800_system" "5200"
+            echo "atari800_system = \"5200\"" >> ${ATARI800CONF}
+            echo "RAM_SIZE=16" >> ${ATARICONF}
+            echo "STEREO_POKEY=0" >> ${ATARICONF}
+            echo "BUILTIN_BASIC=0" >> ${ATARICONF}
+        else
+            add_setting "none" "atari800_system" "800XL (64K)"
+            echo "atari800_system = \"800XL (64K)\"" >> ${ATARI800CONF}
+            echo "RAM_SIZE=64" >> ${ATARICONF}
+            echo "STEREO_POKEY=1" >> ${ATARICONF}
+            echo "BUILTIN_BASIC=1" >> ${ATARICONF}
+        fi
+    fi
+}
 
-        if [ "${EES}" == "glide64" ]
+function set_gambatte() {
+    log "Set up Gambatte (FIXME)..."
+    if [ "${CORE}" = "gambatte" ]
+    then
+        GAMBATTECONF="/storage/.config/retroarch/config/Gambatte/Gambatte.opt"
+        if [ ! -f "GAMBATTECONF" ]
         then
-                sed -i '/parallel-n64-gfxplugin = /c\parallel-n64-gfxplugin = "glide64"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
+            echo 'gambatte_gbc_color_correction = "disabled"' > ${GAMBATTECONF}
+        else
+            sed -i "/gambatte_gb_colorization =/d" ${GAMBATTECONF}
+            sed -i "/gambatte_gb_internal_palette =/d" ${GAMBATTECONF}
         fi
+        local RENDERER=$(game_setting renderer.colorization)
+        case ${RENDERER} in
+            0|false|none)
+                echo 'gambatte_gb_colorization = "disabled"' >> ${GAMBATTECONF}
+            ;;
+            "Best Guess")
+                echo 'gambatte_gb_colorization = "auto"' >> ${GAMBATTECONF}
+            ;;
+            GBC|SGB)
+                echo 'gambatte_gb_colorization = "'${RENDERER}'"' >> ${GAMBATTECONF}
+            ;;
+            *)
+                echo 'gambatte_gb_colorization = "internal"' >> ${GAMBATTECONF}
+                echo 'gambatte_gb_internal_palette = "'${RENDERER}'"' >> ${GAMBATTECONF}
+            ;;
+        esac
+    fi
+}
 
-        if [ "${EES}" == "rice" ]
+function set_controllers() {
+    CONTROLLERS="$@"
+    CONTROLLERS="${CONTROLLERS#*--controllers=*}"
+
+    for i in $(seq 1 1 5)
+    do
+        log "Controller setup (${1})"
+        if [[ "$CONTROLLERS" == *p${i}* ]]
         then
-                sed -i '/parallel-n64-gfxplugin = /c\parallel-n64-gfxplugin = "rice"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
+            PINDEX="${CONTROLLERS#*-p${i}index }"
+            PINDEX="${PINDEX%% -p${i}guid*}"
+            add_setting "none" "input_player${i}_joypad_index" "${PINDEX}"
+            case ${PLATFORM} in
+                atari5200)
+                    add_setting "none" "input_libretro_device_p${i}" "513"
+                ;;
+            esac
         fi
+    done
+}
 
-        if [ "${EES}" == "gln64" ]
-        then
-                sed -i '/parallel-n64-gfxplugin = /c\parallel-n64-gfxplugin = "gln64"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
+###
+### Execute functions
+###
 
-get_game_setting "parallel_n64_internal_resolution"
+configure_hotkeys &
+set_ra_menudriver &
+set_fps &
+set_cheevos &
+set_netplay &
+set_translation &
+set_aspectratio &
+set_filtering &
+set_integerscale &
+set_rgascale &
+set_shader &
+set_filter &
+set_rewind &
+set_savestates &
+set_autosave &
+set_runahead &
+set_audiolatency &
+set_analogsupport &
+set_tatemode &
+set_n64opts &
+set_atari &
+set_gambatte &
+set_controllers &
 
-        if [ "${EES}" == "240p" ]
-        then
-                sed -i '/parallel-n64-screensize = /c\parallel-n64-screensize = "320x240"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
+###
+### Wait for functions to complete.
+###
 
-        if [ "${EES}" == "480p" ]
-        then
-                sed -i '/parallel-n64-screensize = /c\parallel-n64-screensize = "640x480"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
+wait
 
-        if [ "${EES}" == "720p" ]
-        then
-                sed -i '/parallel-n64-screensize = /c\parallel-n64-screensize = "960x720"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
-
-        if [ "${EES}" == "1080p" ]
-        then
-                sed -i '/parallel-n64-screensize = /c\parallel-n64-screensize = "1440x1080"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
-
-get_game_setting "parallel_n64_gamespeed"
-
-        if [ "${EES}" == "original" ]
-        then
-                sed -i '/parallel-n64-framerate = /c\parallel-n64-framerate = "original"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
-
-        if [ "${EES}" == "fullspeed" ]
-        then
-                sed -i '/parallel-n64-framerate = /c\parallel-n64-framerate = "fullspeed"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
-
-get_game_setting "parallel_n64_gfx_accuracy"
-
-        if [ "${EES}" == "low" ]
-        then
-                sed -i '/parallel-n64-gfxplugin-accuracy = /c\parallel-n64-gfxplugin-accuracy = "low"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
-
-        if [ "${EES}" == "medium" ]
-        then
-                sed -i '/parallel-n64-gfxplugin-accuracy = /c\parallel-n64-gfxplugin-accuracy = "medium"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
-
-		if [ "${EES}" == "high" ]
-        then
-                sed -i '/parallel-n64-gfxplugin-accuracy = /c\parallel-n64-gfxplugin-accuracy = "high"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
-
-        if [ "${EES}" == "veryhigh" ]
-        then
-                sed -i '/parallel-n64-gfxplugin-accuracy = /c\parallel-n64-gfxplugin-accuracy = "veryhigh"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
-
-get_game_setting "parallel_n64_controller_pak"
-
-        if [ "${EES}" == "none" ]
-        then
-                sed -i '/parallel-n64-pak1 = /c\parallel-n64-pak1 = "none"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
-        if [ "${EES}" == "memory" ]
-        then
-                sed -i '/parallel-n64-pak1 = /c\parallel-n64-pak1 = "memory"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
-        if [ "${EES}" == "rumble" ]
-        then
-                sed -i '/parallel-n64-pak1 = /c\parallel-n64-pak1 = "rumble"' "/storage/.config/retroarch/config/ParaLLEl N64/ParaLLEl N64.opt"
-        fi
-
-##
-## Settings for special cores
-##
-
-## atari800 core needs other settings when emulation atari5200
-if [ "${CORE}" == "atari800" ]; then
-	log $0 "Atari 800 section"
-	ATARICONF="/storage/.config/system/configs/atari800.cfg"
-	ATARI800CONF="/storage/.config/retroarch/config/Atari800/Atari800.opt"
-	[[ ! -f "$ATARI800CONF" ]] && touch "$ATARI800CONF"
-
-	sed -i "/atari800_system =/d" ${RACORECONF}
-	sed -i "/RAM_SIZE=/d" ${ATARICONF}
-	sed -i "/STEREO_POKEY=/d" ${ATARICONF}
-	sed -i "/BUILTIN_BASIC=/d" ${ATARICONF}
-	sed -i "/atari800_system =/d" ${ATARI800CONF}
-
-	if [ "${PLATFORM}" == "atari5200" ]; then
-		echo "atari800_system = \"5200\"" >> ${RACORECONF}
-		echo "atari800_system = \"5200\"" >> ${ATARI800CONF}
-		echo "RAM_SIZE=16" >> ${ATARICONF}
-		echo "STEREO_POKEY=0" >> ${ATARICONF}
-		echo "BUILTIN_BASIC=0" >> ${ATARICONF}
-	else
-		echo "atari800_system = \"800XL (64K)\"" >> ${RACORECONF}
-		echo "atari800_system = \"800XL (64K)\"" >> ${ATARI800CONF}
-		echo "RAM_SIZE=64" >> ${ATARICONF}
-		echo "STEREO_POKEY=1" >> ${ATARICONF}
-		echo "BUILTIN_BASIC=1" >> ${ATARICONF}
- 	fi
-fi
-
-## Gambatte
-if [ "${CORE}" == "gambatte" ]; then
-	log $0 "Gambatte section"
-	GAMBATTECONF="/storage/.config/retroarch/config/Gambatte/Gambatte.opt"
-	if [ ! -f "$GAMBATTECONF" ]; then
-		# set some defaults
-		echo 'gambatte_gbc_color_correction = "disabled"' > ${GAMBATTECONF}
-	else
-		sed -i "/gambatte_gb_colorization =/d" ${GAMBATTECONF}
-		sed -i "/gambatte_gb_internal_palette =/d" ${GAMBATTECONF}
-	fi
-	get_game_setting "renderer.colorization"
-	if [ "${EES}" == "false" ] || [ "${EES}" == "auto" ] || [ "${EES}" == "none" ]; then
-		echo "gambatte_gb_colorization = \"disabled\"" >> ${GAMBATTECONF}
-	elif [ "${EES}" == "Best Guess" ]; then
-		echo "gambatte_gb_colorization = \"auto\"" >> ${GAMBATTECONF}
-	elif [ "${EES}" == "GBC" ] || [ "${EES}" == "SGB" ]; then
-		echo "gambatte_gb_colorization = \"${EES}\"" >> ${GAMBATTECONF}
-	else
-		echo "gambatte_gb_colorization = \"internal\"" >> ${GAMBATTECONF}
-		echo "gambatte_gb_internal_palette = \"${EES}\"" >> ${GAMBATTECONF}
-	fi
-fi
-
-# We set up the controller index
-#sed -i "/input_libretro_device_p1/d" ${RACONF}
-CONTROLLERS="$@"
-CONTROLLERS="${CONTROLLERS#*--controllers=*}"
-
-for i in 1 2 3 4 5; do
-log $0 "Controller section (${1})"
-if [[ "$CONTROLLERS" == *p${i}* ]]; then
-PINDEX="${CONTROLLERS#*-p${i}index }"
-PINDEX="${PINDEX%% -p${i}guid*}"
-#sed -i "/input_player${i}_joypad_index =/d" ${RACONF}
-echo "input_player${i}_joypad_index = \"${PINDEX}\"" >> ${RAAPPENDCONF}
-
-# Setting controller type for different cores
-if [ "${PLATFORM}" == "atari5200" ]; then
-	sed -i "/input_libretro_device_p${i}/d" ${RAAPPENDCONF}
-	echo "input_libretro_device_p${i} = \"513\"" >> ${RAAPPENDCONF}
-fi
-
-fi
-done
-
-##
-## Clean Exit
-##
-doexit
+cleanup

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -428,10 +428,10 @@ set_consolefont() {
   progress "Set console font"
   if [ -e /dev/fb0 ]; then
     hres="$(fbset 2>/dev/null | awk '/geometry/ { print $2 }')"
-    if [ "${hres}" -gt "0" ] && [ "${hres}" -lt "640" ]
+    if [ "${hres}" -gt "0" ] && [ "${hres}" -le "640" ]
     then
       setfont -C /dev/console ter-v12n.psf
-    elif [ "${hres}" -ge "640" ] && [ "${hres}" -lt "720" ]
+    elif [ "${hres}" -ge "641" ] && [ "${hres}" -lt "720" ]
     then
       setfont -C /dev/console ter-v14n.psf
     elif [ "${hres}" -ge "720" ] && [ "${hres}" -lt "1080" ]

--- a/packages/sysutils/systemd/scripts/userconfig-setup
+++ b/packages/sysutils/systemd/scripts/userconfig-setup
@@ -55,7 +55,20 @@ then
       1.76|0.56)
         ASPECT="16:9"
       ;;
+      1.6|0.62)
+        ASPECT="16:10"
+      ;;
     esac
+
+    ### Set the aspect ratio in ES.
+    ES_CONFIG="/storage/.config/emulationstation/es_settings.cfg"
+    ES_ASPECT="${ASPECT/:/-}"
+    if [ "$(grep subset.aspect-ratio ${ES_CONFIG})" ]
+    then
+      sed -i 's|<string name="subset.aspect-ratio".*$|<string name="subset.aspect-ratio" value="'${ES_ASPECT}'"/>|g' ${ES_CONFIG}
+    else
+      sed -i '/<\/config>/i \\t<string name="subset.aspect-ratio" value="'${ES_ASPECT}'"/>' ${ES_CONFIG}
+    fi
 
     if [ -f "/storage/.config/emulationstation/resources/logo.png" ]
     then

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="emulationstation"
-PKG_VERSION="7723ff4"
+PKG_VERSION="6dafa36"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
## Description

* Refactors setsettings to greatly improve performance, fixing regression causing very long delays before starting emulation.
* Fixes the memory and gpu governor function for RK3399 and S922X which prevented the desired state from being configured.
* Automatically set the aspect ratio in EmulationStation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

**Test Configuration**:
* Docker (Y/N): N
* JELOS Branch: Dev
* Any additional information that may be useful:

Tested on x55 and Air Pro.