### PR TITLE
Update Art Book Next theme

### DIFF
--- a/packages/themes/es-theme-art-book-next/package.mk
+++ b/packages/themes/es-theme-art-book-next/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2021 Fewtarius
 
 PKG_NAME="es-theme-art-book-next"
-PKG_VERSION="28e21fda755e45be6701f56f78d2416282f5711c"
+PKG_VERSION="b5b5312a42060bd05d4dee8b14e750159c471374"
 PKG_ARCH="any"
 PKG_LICENSE="CUSTOM"
 PKG_SITE="https://github.com/anthonycaccese/art-book-next-jelos"


### PR DESCRIPTION
Changes:
- fixes system logos (atarijaguar, pcenginecd)
- adds/updates system art (auto-neverplayed, auto-lightgun, supergrafx, now-playing, 3do, 3ds, amiga, amigacd32, atari5200, atari7800, intellivision
- adds "now-playing" collection 

Details on "Now Playing"
---
A collection that enables a user to specifically add games they are currently playing.   Its meant to be hand curated and to focus on games a user is looking to finish in their library.

In larger library I look for a way to curate a specific set of games at any given time that I am trying to play through to the end (or at least until I decide I am done with them) I think of this list differently than 'last played' because as a user I may pick up a random game to try but am not actively going to play it after that.  I also think of this list differently than 'favorites' because I look at that list as a curated list of long time favorites - not necessarily games I am actively playing.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Installed on my local devices and tested in Retrobat on my local PC

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
