### PR TITLE
setsettings should ensure that overlays are used correctly.

### DIFF
--- a/packages/jelos/sources/scripts/setsettings.sh
+++ b/packages/jelos/sources/scripts/setsettings.sh
@@ -564,6 +564,10 @@ function set_autosave() {
         [1-3])
             log "Autosave enabled (${CHKAUTOSAVE})"
             add_setting "none" "savestate_directory" "${SNAPSHOTS}/${PLATFORM}"
+            if [ ! -d "${SNAPSHOTS}/${PLATFORM}" ]
+            then
+                mkdir "${SNAPSHOTS}/${PLATFORM}"
+            fi
             case ${AUTOSAVE} in
                 1)
                     log "Autosave active (${AUTOSAVE})"

--- a/packages/jelos/sources/scripts/setsettings.sh
+++ b/packages/jelos/sources/scripts/setsettings.sh
@@ -304,6 +304,30 @@ function match() {
 ### Game data functions
 ###
 
+### Configure retroarch paths
+function set_retroarch_paths() {
+  for RETROARCH_PATH in assets_directory cache_directory            \
+                        cheat_database_path content_database_path   \
+                        content_database_path joypad_autoconfig_dir \
+                        libretro_directory libretro_info_path       \
+                        overlay_directory video_shader_dir
+  do
+    clear_setting "${RETROARCH_PATH}"
+  done
+  flush_settings
+  cat <<EOF >>${RETROARCH_CONFIG}
+assets_directory = "/tmp/assets"
+cache_directory = "/tmp/cache"
+cheat_database_path = "/tmp/database/cht"
+content_database_path = "/tmp/database/rdb"
+joypad_autoconfig_dir = "/tmp/joypads"
+libretro_directory = "/tmp/cores"
+libretro_info_path = "/tmp/cores"
+overlay_directory = "/tmp/overlays"
+video_shader_dir = "/tmp/shaders"
+EOF
+}
+
 ### Configure retroarch hotkeys
 function configure_hotkeys() {
     log "Configure hotkeys..."
@@ -744,6 +768,7 @@ function set_controllers() {
 ### Functions that cannot be parallelized
 ###
 
+set_retroarch_paths
 configure_hotkeys
 
 ###

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="emulationstation"
-PKG_VERSION="1dacd77"
+PKG_VERSION="1d085bc"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
This fixes an issue in the last release and possibly earlier releases where overlay directories aren't being set correctly.