### PR TITLE
Fix parallel-n64-screensize option not being set.

### DIFF
--- a/packages/jelos/sources/scripts/setsettings.sh
+++ b/packages/jelos/sources/scripts/setsettings.sh
@@ -676,7 +676,7 @@ function set_n64opts() {
         local VIDEO_CORE="$(game_setting parallel_n64_video_core)"
         sed -i '/parallel-n64-gfxplugin = /c\parallel-n64-gfxplugin = "'${VIDEO_CORE}'"' "${PARALLELN64DIR}/ParaLLEl N64.opt"
         local SCREENSIZE="$(game_setting parallel_n64_internal_resolution)"
-        sed -i '/parallel-n64-screensize = /c\parallel-n64-screensize = "'${SCREENSOZE}'"' "${PARALLELN64DIR}/ParaLLEl N64.opt"
+        sed -i '/parallel-n64-screensize = /c\parallel-n64-screensize = "'${SCREENSIZE}'"' "${PARALLELN64DIR}/ParaLLEl N64.opt"
         local GAMESPEED="$(game_setting parallel_n64_gamespeed)"
         sed -i '/parallel-n64-framerate = /c\parallel-n64-framerate = "'${GAMESPEED}'"' "${PARALLELN64DIR}/ParaLLEl N64.opt"
         local ACCURACY="$(game_setting parallel_n64_gfx_accuracy)"


### PR DESCRIPTION
# Fix parallel n64 screensize

## Description

Small typo in setsettings.sh was preventing a ParaLLEl-N64 option from being set.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Not tested (still working out kinks in my dev environment).  Just thought this one was pretty obvious on inspection.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
