### PR TITLE
xemu workaround

### DIFF
--- a/packages/emulators/standalone/xemu-sa/scripts/start_xemu.sh
+++ b/packages/emulators/standalone/xemu-sa/scripts/start_xemu.sh
@@ -39,3 +39,6 @@ fi
 CONFIG=/storage/.config/xemu/xemu.toml
 
 @APPIMAGE@ -full-screen -config_path $CONFIG -dvd_path "${1}"
+
+#Workaround until we can learn why it doesn't exit cleanly when asked.
+killall -9 xemu-sa


### PR DESCRIPTION
## Description

xemu doesn't seem to exit cleanly when requested from the UI, it remains running in the background preventing the device from rebooting and hindering performance until it's killed.  This works around that until it can be properly resolved.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
