### PR TITLE
Update Citra-sa

### DIFF
--- a/packages/emulators/standalone/citra-sa/package.mk
+++ b/packages/emulators/standalone/citra-sa/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present BrooksyTech (https://github.com/brooksytech)
 
 PKG_NAME="citra-sa"
-PKG_VERSION="e52b7e655c4263ebee887b9a7f1900c6d4d5c1c9"
+PKG_VERSION="64f26948fe2c2076857731621934be82a6ea3e93"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://github.com/JustEnoughLinuxOS/citra-canary"
 PKG_URL="${PKG_SITE}.git"
@@ -29,6 +29,7 @@ pre_configure_target() {
 PKG_CMAKE_OPTS_TARGET+="        -DENABLE_QT=OFF \
                                 -DENABLE_QT_TRANSLATION=OFF \
                                 -DENABLE_SDL2=ON \
+                                -DCITRA_WARNINGS_AS_ERRORS=OFF \
                                 -DUSE_DISCORD_PRESENCE=OFF"
 
 }


### PR DESCRIPTION
Looks like touchscreen input via mouse broken on the Vulkan backend. 

Will need to research. 