### PR TITLE
Updates

### DIFF
--- a/documentation/GENERAL_HOTKEYS_AND_BUTTON_CODES.md
+++ b/documentation/GENERAL_HOTKEYS_AND_BUTTON_CODES.md
@@ -24,10 +24,7 @@ By default JELOS will detect your controller and configure RetroArch hotkeys aut
   * Back 5s: L1
   * Skip 60s: R2
   * Back 60s: L2
-  * Battery Status: L2+Vol-Up
-  * WIFI Toggle: L2+Vol-Down
-  * Brightness Up: R2+Vol-Up
-  * Brightness Down: R2+Vol-Down
+> Note: Force-Close is R1+Start+Select on some devices, this is normal behavior.
 
 # Per Device Hotkeys
 |Device|Brightness Up|Brightness Down|Battery Status|WIFI Toggle|

--- a/packages/jelos/sources/scripts/setsettings.sh
+++ b/packages/jelos/sources/scripts/setsettings.sh
@@ -344,7 +344,8 @@ function configure_hotkeys() {
             for HKEYSETTING in input_enable_hotkey_btn input_bind_hold      \
                                input_exit_emulator_btn input_fps_toggle_btn \
                                input_menu_toggle_btn input_save_state_btn   \
-                               input_load_state_btn
+                               input_load_state_btn input_hold_fast_forward \
+                               input_toggle_fast_forward_btn
             do
                 clear_setting "${HKEYSETTING}"
             done
@@ -357,6 +358,7 @@ input_fps_toggle_btn = "${input_y_btn}"
 input_menu_toggle_btn = "${input_x_btn}"
 input_save_state_btn = "${input_r_btn}"
 input_load_state_btn = "${input_l_btn}"
+input_hold_fast_forward_btn = "${input_r2_btn}"
 EOF
             rm -f /tmp/"${MY_CONTROLLER}.cfg"
         fi

--- a/packages/kernel/linux/package.mk
+++ b/packages/kernel/linux/package.mk
@@ -4,7 +4,7 @@
 
 PKG_NAME="linux"
 PKG_LICENSE="GPL"
-PKG_VERSION="6.4.7"
+PKG_VERSION="6.4.8"
 PKG_URL="https://www.kernel.org/pub/linux/kernel/v6.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_SITE="http://www.kernel.org"
 PKG_DEPENDS_HOST="ccache:host rsync:host openssl:host"

--- a/projects/Amlogic/packages/linux/package.mk
+++ b/projects/Amlogic/packages/linux/package.mk
@@ -19,7 +19,7 @@ PKG_PATCH_DIRS+="${DEVICE}"
 
 case ${DEVICE} in
   S922X*)
-    PKG_VERSION="6.1.42"
+    PKG_VERSION="6.1.43"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v6.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
   ;;
 esac

--- a/projects/Rockchip/packages/linux/package.mk
+++ b/projects/Rockchip/packages/linux/package.mk
@@ -37,7 +37,7 @@ case ${DEVICE} in
     PKG_GIT_CLONE_BRANCH="main"
   ;;
   RK33*)
-    PKG_VERSION="6.1.42"
+    PKG_VERSION="6.1.43"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v6.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
   ;;
 esac


### PR DESCRIPTION
## Description

* Update Linux kernel to 6.4.8 (AMD64), and 6.1.43 (RK3326, RK3399, S922X)
* Setsettings should configure the fastforward button per our documentation.