### PR TITLE
Fix resize reboot failure bug.

### DIFF
--- a/packages/sysutils/busybox/config/busybox-init.conf
+++ b/packages/sysutils/busybox/config/busybox-init.conf
@@ -573,12 +573,12 @@ CONFIG_CHATTR=y
 # CONFIG_MODPROBE_SMALL is not set
 # CONFIG_DEPMOD is not set
 CONFIG_INSMOD=y
-# CONFIG_LSMOD is not set
+CONFIG_LSMOD=y
 # CONFIG_FEATURE_LSMOD_PRETTY_2_6_OUTPUT is not set
-# CONFIG_MODINFO is not set
-# CONFIG_MODPROBE is not set
+CONFIG_MODINFO=y
+CONFIG_MODPROBE=y
 # CONFIG_FEATURE_MODPROBE_BLACKLIST is not set
-# CONFIG_RMMOD is not set
+CONFIG_RMMOD=y
 
 #
 # Options common to multiple modutils
@@ -1056,10 +1056,10 @@ CONFIG_FEATURE_FAST_TOP=y
 # CONFIG_FREE is not set
 # CONFIG_FUSER is not set
 # CONFIG_IOSTAT is not set
-# CONFIG_KILL is not set
-# CONFIG_KILLALL is not set
+CONFIG_KILL=y
+CONFIG_KILLALL=y
 # CONFIG_KILLALL5 is not set
-# CONFIG_LSOF is not set
+CONFIG_LSOF=y
 # CONFIG_MPSTAT is not set
 # CONFIG_NMETER is not set
 # CONFIG_PGREP is not set

--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -55,14 +55,10 @@ if [ -e /storage/.please_resize_me ] ; then
     StartProgress spinner "Resizing storage partition...   " "parted -s -a optimal -m ${DISK} resizepart ${PARTNUM} 100% &>/dev/null"
     StartProgress spinner "Checking storage file system... " "e2fsck -f -p ${PART} &>/dev/null"
     StartProgress spinner "Resizing storage file system... " "resize2fs ${PART} &>/dev/null"
+    StartProgress spinner "Checking storage file system... " "e2fsck -f -p ${PART} &>/dev/null"
+
     StartProgress countdown "Rebooting in 5s...     " 5 "NOW"
   fi
 fi
-
-# Remove all of the modules that may be loaded to see if /flash will cleanly unmount.
-for module in $(lsmod | awk '{print $1}')
-do
-  modprobe -r --remove-dependencies ${module} &>/dev/null
-done
-
-shutdown -r now &>/dev/null
+sync &>/dev/null
+reboot &>/dev/null

--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -62,7 +62,7 @@ fi
 # Remove all of the modules that may be loaded to see if /flash will cleanly unmount.
 for module in $(lsmod | awk '{print $1}')
 do
-  rmmod ${module} 2>/dev/null
+  modprobe -r --remove-dependencies ${module} &>/dev/null
 done
 
 shutdown -r now &>/dev/null

--- a/packages/sysutils/systemd/system.d/userconfig.service
+++ b/packages/sysutils/systemd/system.d/userconfig.service
@@ -7,7 +7,7 @@ After=systemd-tmpfiles-setup.service
 Type=oneshot
 ExecStart=/usr/bin/userconfig-setup
 RemainAfterExit=yes
-StandardOutput=syslog+console
+StandardOutput=journal+console
 
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
We should do a filesystem check before rebooting, otherwise the resized partition may not be marked clean.