### PR TITLE
AYN Loki Max Display & Audio Support

### DIFF
--- a/packages/hardware/quirks/devices/ayn Loki Max/001-audio
+++ b/packages/hardware/quirks/devices/ayn Loki Max/001-audio
@@ -1,0 +1,14 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
+
+. /etc/profile
+
+
+MYDEVICE=$(get_setting system.audiodevice)
+if [ -z "${MYDEVICE}" ]
+then
+  ### Set the audio device.
+  set-audio set "ALC269VB (1:0)"
+  set-audio esset "Master"
+fi

--- a/packages/kernel/linux/patches/AMD64/002-display-quirks.patch
+++ b/packages/kernel/linux/patches/AMD64/002-display-quirks.patch
@@ -2,7 +2,7 @@ diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/dr
 index 0cb646cb04ee..1045ffe447ad 100644
 --- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
 +++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
-@@ -133,6 +133,12 @@ static const struct drm_dmi_panel_orientation_data lcd1600x2560_rightside_up = {
+@@ -133,6 +133,12 @@ static const struct drm_dmi_panel_orient
  	.orientation = DRM_MODE_PANEL_ORIENTATION_RIGHT_UP,
  };
  
@@ -15,7 +15,7 @@ index 0cb646cb04ee..1045ffe447ad 100644
  static const struct dmi_system_id orientation_data[] = {
  	{	/* Acer One 10 (S1003) */
  		.matches = {
-@@ -170,13 +176,13 @@ static const struct dmi_system_id orientation_data[] = {
+@@ -170,13 +176,13 @@ static const struct dmi_system_id orient
  		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "T103HAF"),
  		},
  		.driver_data = (void *)&lcd800x1280_rightside_up,
@@ -32,7 +32,7 @@ index 0cb646cb04ee..1045ffe447ad 100644
  		.matches = {
  		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "AYANEO"),
  		  DMI_MATCH(DMI_PRODUCT_NAME, "AIR"),
-@@ -188,6 +194,24 @@ static const struct dmi_system_id orientation_data[] = {
+@@ -188,6 +194,30 @@ static const struct dmi_system_id orient
  		  DMI_MATCH(DMI_BOARD_NAME, "NEXT"),
  		},
  		.driver_data = (void *)&lcd800x1280_rightside_up,
@@ -54,6 +54,12 @@ index 0cb646cb04ee..1045ffe447ad 100644
 +                  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "AOKZOE A1 Pro"),
 +                },
 +		.driver_data = (void *)&lcd1200x1920_leftside_up,
++        }, {    /* AYN Loki Max */
++                .matches = {
++                  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ayn"),
++                  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Loki Max"),
++                },
++		.driver_data = (void *)&lcd1080x1920_leftside_up,
  	}, {	/* Chuwi HiBook (CWI514) */
  		.matches = {
  			DMI_MATCH(DMI_BOARD_VENDOR, "Hampoo"),


### PR DESCRIPTION
Provides support to rotate the display and add set up the correct default audio for AYN Loki Max.  Games can be installed and played with audio, controls and proper display rotation.  Full support for the AYN Loki Max is not yet available with this PR (specifically that the system menu item does not currently open in EmulationStation).  

![IMG_1915](https://github.com/JustEnoughLinuxOS/distribution/assets/1454947/8d229641-1eb5-4165-953d-41770a127572)

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Flashed fresh to SD card and initiallized on an AYN Loki Max directly.  Tested in GPDWin 4 to validate on another device.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas