### PR TITLE
Reintroduce network play, options in ES (game settings, X over a game).

### DIFF
--- a/packages/compress/p7zip/package.mk
+++ b/packages/compress/p7zip/package.mk
@@ -34,13 +34,11 @@ pre_build_target() {
 }
 
 make_target() {
-  make CXX=${CXX} CC=${CC} -C ${PKG_BUILD}/.${TARGET_NAME} 7z 7za
+  make CXX=${CXX} CC=${CC} -C ${PKG_BUILD}/.${TARGET_NAME} all3
 }
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin
-    cp -p ${PKG_BUILD}/.${TARGET_NAME}/bin/7z.so ${INSTALL}/usr/bin
     cp -pr ${PKG_BUILD}/.${TARGET_NAME}/bin/Codecs ${INSTALL}/usr/bin
-    cp -p ${PKG_BUILD}/.${TARGET_NAME}/bin/7z ${INSTALL}/usr/bin
-    cp -p ${PKG_BUILD}/.${TARGET_NAME}/bin/7za ${INSTALL}/usr/bin
+    cp -p ${PKG_BUILD}/.${TARGET_NAME}/bin/7z* ${INSTALL}/usr/bin
 }

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="emulationstation"
-PKG_VERSION="211b537"
+PKG_VERSION="f74057e"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
## Description

This PR corrects issues preventing RetroArch netplay EmulationStation from appearing and working correctly.  Functionality includes configuring netplay for local play, as well as playing via RetroArch lobby.  To use, select and configure via Games Settings, and launch the lobby browser by pressing X or host/connect a local session by pressing X over any game and selecting Netplay Options.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
