### PR TITLE
Add 1:1 Aspect Ratio Support to Art Book Next

### DIFF
--- a/packages/themes/es-theme-art-book-next/package.mk
+++ b/packages/themes/es-theme-art-book-next/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2021 Fewtarius
 
 PKG_NAME="es-theme-art-book-next"
-PKG_VERSION="f2e1c55547e60f475e416b734aa1effbcf726201"
+PKG_VERSION="f8c18db7824cabda52e762214e6b526835cf92dc"
 PKG_ARCH="any"
 PKG_LICENSE="CUSTOM"
 PKG_SITE="https://github.com/anthonycaccese/art-book-next-jelos"


### PR DESCRIPTION
Adds initial support for 1:1 aspect ratio in Art Book Next

Screenshot:
<img  src="https://github.com/JustEnoughLinuxOS/distribution/assets/1454947/5ed4974c-d4aa-4588-989a-3348aa39d77d">

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Tested in local RetroBat installation using a 480x480 resolution. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
