### PR TITLE
Fix vim defaults file

### DIFF
--- a/packages/tools/vim/package.mk
+++ b/packages/tools/vim/package.mk
@@ -49,6 +49,7 @@ pre_makeinstall_target() {
 post_makeinstall_target() {
   (
   mv ${INSTALL}/storage/.config/vim/vim/vimrc_example.vim ${INSTALL}/usr/config/vim/vimrc
+  mv ${INSTALL}/storage/.config/vim/vim/defaults.vim ${INSTALL}/usr/config/vim/defaults.vim
   rm -r ${INSTALL}/storage/
   )
 }


### PR DESCRIPTION
# Pull Request Template

## Description

When running vim from JELOS, I always get the warning `E1187: Failed to source defaults.vim`.
This is because `/storage/.config/vim/vimrc` has the lines:

```
" Get the defaults that most users want.
source $VIMRUNTIME/defaults.vim
```
But the file isn't copied in the package file.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested Locally?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Built the package, made sure sysroot/storage/.config/vim/vim/defaults.vim was present


**Test Configuration**:
* Build OS name and version: Debian testing
* Docker (Y/N): N
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
