### PR TITLE
Honor Fast HLE (Mupen) choice for RSP plugin in mupen64plus-sa.

### DIFF
--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -149,7 +149,7 @@ case "${RSP}" in
 	"parallel")
 		SET_PARAMS="$SET_PARAMS --rsp mupen64plus-rsp-parallel$SIMPLESUFFIX.so"
 	;;
-	"cxd4")
+	"hle")
 		SET_PARAMS="$SET_PARAMS --rsp mupen64plus-rsp-hle$SIMPLESUFFIX.so"
 	;;
 	*)


### PR DESCRIPTION
# Pull Request Template

## Description

Fix a typo in the Mupen64 standalone startup script.  Prior to this, it was impossible to select "Fast HLE (Mupen)" for the RSP plugin in the N64 settings for standalone.  The default remains "Accurate HLE (CXD4)", which is what everyone is accustomed to.

Minutiae described in the git commit message for interested readers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Go to Mupen64Plus Standalone settings.  Select Fast HLE (Mupen) for the RSP Plugin.  Launch a game, then quit to Emulation Station.  Then SSH to the device and issue the commands
```
cd /var/log/
less exec.log
```

- [x] On dev, you will see the emulator was launched incorrectly with arguments `--rsp mupen64plus-rsp-cxd4.so`
- [x] On this branch, you will see it was launched correctly with arguments `--rsp mupen64plus-rsp-hle.so`

**Test Configuration**:
* Build OS name and version: Ubuntu 22.04 in VM
* Docker: Yes
* JELOS Branch: `dev`
* Device: PowKiddy X55


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
