### PR TITLE
Add a quick check that RK3566 is built before attempting RK3566-X55

### DIFF
--- a/scripts/build_distro
+++ b/scripts/build_distro
@@ -43,6 +43,14 @@ then
       make ${DEVICE_ROOT}
     fi
 
+    # Ensure the DEVICE_ROOT is built before DEVICE
+    if [ ! -d "build.${DISTRO}-${DEVICE_ROOT}.${ARCH}" ]
+    then
+        echo "ERROR: Can't find build root build.${DISTRO}-${DEVICE_ROOT}.${ARCH}"
+        echo "You need to build ${DEVICE_ROOT} before ${DEVICE}"
+        exit 1
+    fi
+
     # Link back to the DEVICE_ROOT so we can re-use the build directory to save space.
     if [ ! -L "build.${DISTRO}-${DEVICE}.${ARCH}" ]
     then
@@ -54,14 +62,6 @@ then
        [ ! -L "sources-${DEVICE}" ]
     then
       ln -sf sources-${DEVICE_ROOT} sources-${DEVICE}
-    fi
-  else
-    # Ensure the DEVICE_ROOT is built before DEVICE
-    if [ ! -d "build.${DISTRO}-${DEVICE_ROOT}.${ARCH}" ]
-    then
-        echo "ERROR: Can't find build root build.${DISTRO}-${DEVICE_ROOT}.${ARCH}"
-        echo "You need to build ${DEVICE_ROOT} before ${DEVICE}"
-        exit 1
     fi
   fi
 

--- a/scripts/build_distro
+++ b/scripts/build_distro
@@ -22,17 +22,6 @@ then
   PKG_CLEAN+=" ${CLEAN_EMU_32BIT}"
 fi
 
-# Device RK3566-X55 needs a built RK3466 root
-if [ "${DEVICE}" = "RK3566-X55" ]
-then
-    if [ ! -d "build.${DISTRO}-RK3566.${ARCH}" ]
-    then
-        echo "ERROR: Can't find build root build.${DISTRO}-RK3566.${ARCH}"
-        echo "You need to build RK3566 before RK3566-X55"
-        exit 1
-    fi
-fi
-
 # If DEVICE_ROOT is defined and not the device being built, make sure that the
 # build folder is a link to root rather than a folder.
 
@@ -65,6 +54,14 @@ then
        [ ! -L "sources-${DEVICE}" ]
     then
       ln -sf sources-${DEVICE_ROOT} sources-${DEVICE}
+    fi
+  else
+    # Ensure the DEVICE_ROOT is built before DEVICE
+    if [ ! -d "build.${DISTRO}-${DEVICE_ROOT}.${ARCH}" ]
+    then
+        echo "ERROR: Can't find build root build.${DISTRO}-${DEVICE_ROOT}.${ARCH}"
+        echo "You need to build ${DEVICE_ROOT} before ${DEVICE}"
+        exit 1
     fi
   fi
 

--- a/scripts/build_distro
+++ b/scripts/build_distro
@@ -22,6 +22,17 @@ then
   PKG_CLEAN+=" ${CLEAN_EMU_32BIT}"
 fi
 
+# Device RK3566-X55 needs a built RK3466 root
+if [ "${DEVICE}" = "RK3566-X55" ]
+then
+    if [ ! -d "build.${DISTRO}-RK3566.${ARCH}" ]
+    then
+        echo "ERROR: Can't find build root build.${DISTRO}-RK3566.${ARCH}"
+        echo "You need to build RK3566 before RK3566-X55"
+        exit 1
+    fi
+fi
+
 # If DEVICE_ROOT is defined and not the device being built, make sure that the
 # build folder is a link to root rather than a folder.
 


### PR DESCRIPTION
# Pull Request Template

## Description

When building for the powkiddy-x55, it is implied that RK3566 needs to be built before RK3566-X55, but it is not checked early, and the build will fail in mysterious ways.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested Locally?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran `make RK3566-X55` without the RK3566, and expected fail + error message

**Test Configuration**:
* Build OS name and version: debian unstable
* Docker (Y/N):  N
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


