### PR TITLE
Search in  /sbin & /usr/sbin to find the parted command

### DIFF
--- a/projects/Rockchip/bootloader/install
+++ b/projects/Rockchip/bootloader/install
@@ -12,14 +12,16 @@ RKSPI_LOADER=${INSTALL}/usr/share/bootloader/rkspi_loader.img
 generate_rkspi_loader() {
         echo "spi: create rkspi_loader.img..."
         dd if=/dev/zero of=$RKSPI_LOADER bs=1M count=0 seek=16
-        parted -s $RKSPI_LOADER mklabel gpt
-        parted -s $RKSPI_LOADER unit s mkpart idbloader 64 7167
-        parted -s $RKSPI_LOADER unit s mkpart vnvm 7168 7679
-        parted -s $RKSPI_LOADER unit s mkpart reserved_space 7680 8063
-        parted -s $RKSPI_LOADER unit s mkpart reserved1 8064 8127
-        parted -s $RKSPI_LOADER unit s mkpart uboot_env 8128 8191
-        parted -s $RKSPI_LOADER unit s mkpart reserved2 8192 16383
-        parted -s $RKSPI_LOADER unit s mkpart uboot 16384 32734
+        # When running as a non-root user, /sbin & /usr/sbin are excluded from $PATH
+        PATH=/sbin:/usr/sbin:$PATH PARTED_CMD="$(which parted)"
+        ${PARTED_CMD} -s $RKSPI_LOADER mklabel gpt
+        ${PARTED_CMD} -s $RKSPI_LOADER unit s mkpart idbloader 64 7167
+        ${PARTED_CMD} -s $RKSPI_LOADER unit s mkpart vnvm 7168 7679
+        ${PARTED_CMD} -s $RKSPI_LOADER unit s mkpart reserved_space 7680 8063
+        ${PARTED_CMD} -s $RKSPI_LOADER unit s mkpart reserved1 8064 8127
+        ${PARTED_CMD} -s $RKSPI_LOADER unit s mkpart uboot_env 8128 8191
+        ${PARTED_CMD} -s $RKSPI_LOADER unit s mkpart reserved2 8192 16383
+        ${PARTED_CMD} -s $RKSPI_LOADER unit s mkpart uboot 16384 32734
         echo "spi: write idbloader.img to rkspi_loader.img..."
         dd if=${PKG_BUILD}/idbloader.img of=$RKSPI_LOADER seek=64 conv=notrunc
         echo "spi: write uboot.itb to rkspi_loader.img..."


### PR DESCRIPTION
# Pull Request Template

## Description

In debian, /sbin is not in $PATH when uid is not 0. This results in the booatloader/install script to fail & idboader.img not being generated correctly.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested Locally?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run make RK3566 and make sure that build.JELOS-RK3566.aarch64/image/system/usr/share/bootloader/idbloader.img is built.

**Test Configuration**:
* Build OS name and version: Debian Sid
* Docker (Y/N): N
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
