### PR TITLE
puae2021 core added

### DIFF
--- a/packages/emulators/libretro/puae2021-lr/package.mk
+++ b/packages/emulators/libretro/puae2021-lr/package.mk
@@ -1,0 +1,46 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#      Copyright (C) 2020      351ELEC team (https://github.com/fewtarius/351ELEC)
+#      Copyright (C) 2023-present Fewtarius
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+PKG_NAME="puae2021-lr"
+PKG_VERSION="94b2edfbb5949bc361862fd518cd7f36a16e0b45"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/libretro/libretro-uae"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="libretro"
+PKG_SHORTDESC="PUAE 2021 libretro port of UAE"
+PKG_LONGDESC="PUAE 2021 libretro port of UAE"
+PKG_TOOLCHAIN="make"
+
+pre_configure_target() {
+  if [ "${ARCH}" == "arm" ]; then
+    CFLAGS="${CFLAGS} -DARM -marm"
+  fi
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+  cp puae2021_libretro.so ${INSTALL}/usr/lib/libretro/
+}

--- a/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/packages/ui/emulationstation/config/common/es_features.cfg
@@ -632,6 +632,7 @@
       <core name="prboom" features="netplay, rewind, autosave" />
       <core name="prosystem" features="netplay, rewind, autosave, cheevos" />
       <core name="puae" features="netplay, rewind, autosave" />
+      <core name="puae2021" features="netplay, rewind, autosave" />
       <core name="px68k" features="netplay, rewind, autosave" />
       <core name="potator" features="decoration, cheevos" />
       <core name="quasi88" features="netplay, rewind, autosave, cheevos" />

--- a/packages/virtual/emulators/package.mk
+++ b/packages/virtual/emulators/package.mk
@@ -23,7 +23,7 @@ LIBRETRO_CORES="81-lr a5200-lr arduous-lr atari800-lr beetle-gba-lr beetle-lynx-
                 gw-lr handy-lr hatari-lr mame2000-lr mame2003-plus-lr mame2010-lr mame2015-lr melonds-lr meowpc98-lr      \
                 mesen-lr mgba-lr mojozork-lr mrboom-lr mupen64plus-lr mupen64plus-nx-lr neocd_lr nestopia-lr np2kai-lr    \
                 nxengine-lr o2em-lr opera-lr parallel-n64-lr pcsx_rearmed-lr picodrive-lr pokemini-lr potator-lr          \
-                prboom-lr prosystem-lr ppsspp-lr puae-lr px68k-lr quasi88-lr quicknes-lr race-lr reminiscence-lr          \
+                prboom-lr prosystem-lr ppsspp-lr puae-lr puae2021-lr px68k-lr quasi88-lr quicknes-lr race-lr reminiscence-lr          \
                 sameboy-lr sameduck-lr scummvm-lr smsplus-gx-lr snes9x-lr snes9x2002-lr snes9x2005_plus-lr snes9x2010-lr  \
                 stella-lr stella-2014-lr swanstation-lr tic80-lr tgbdual-lr tyrquake-lr uzem-lr vba-next-lr               \
                 vbam-lr vecx-lr vice-lr yabasanshiro-lr virtualjaguar-lr xmil-lr xrick-lr"
@@ -128,7 +128,16 @@ makeinstall_target() {
   esac
 
   ### Commodore Amiga
-  add_emu_core amiga retroarch puae true
+  case ${DEVICE} in
+    RK35*|RK3326|RK3399)
+      add_emu_core amiga retroarch puae2021 true
+      add_emu_core amiga retroarch puae false
+    ;;
+    *)
+      add_emu_core amiga retroarch puae true
+      add_emu_core amiga retroarch puae2021 false
+    ;;
+  esac
   case ${TARGET_ARCH} in
     aarch64)
       add_emu_core amiga amiberry amiberry false
@@ -138,7 +147,16 @@ makeinstall_target() {
   add_es_system amiga
 
   ### Commodore Amiga CD32
-  add_emu_core amigacd32 retroarch puae true
+  case ${DEVICE} in
+    RK35*|RK3326|RK3399)
+      add_emu_core amigacd32 retroarch puae2021 true
+      add_emu_core amigacd32 retroarch puae false
+    ;;
+    *)
+      add_emu_core amigacd32 retroarch puae true
+      add_emu_core amigacd32 retroarch puae2021 false
+    ;;
+  esac
   case ${TARGET_ARCH} in
     aarch64)
       add_emu_core amigacd32 retroarch uae4arm false


### PR DESCRIPTION
puae2021 core added for Amiga emulation to be a default one for older Jelos devices. From testing it's improving performance in demanding and AGA games from 35fps to 50fps (PAL)

# Pull Request Template

## Description

The new puae2021 package has been added, a libretro core of good compatibility with majority of games but much better performance for older devices than the current puae core. No extra dependencies are needed.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A

I made a build using Docker which ended in creation of a new Jelos image, I flashed the image to Micro SD. I run the installation of Jelos on RG503, then I tested different Amiga games from compatibility and performance perspective. No issues were found.

**Test Configuration**:
* Build OS name and version: Ubuntu 22.04.03, as VM running in VMWare Workstation on Windows host.
* Docker (Y/N): Y
* JELOS Branch: dev

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

The documentation seems to be auto-generated for the cores, so I didn't make changes to the documentation.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)