### PR TITLE
Fix wget 403 Forbidden error

### DIFF
--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -22,7 +22,7 @@ pkg_lock_status "GETPKG" "${PKG_NAME}" "unpack" "downloading package..."
 
 PACKAGE_MIRROR="${DISTRO_MIRROR}/${PKG_NAME}/${PKG_SOURCE_NAME}"
 [ "${VERBOSE}" != "yes" ] && WGET_OPT=-q
-WGET_CMD="wget --output-file=- --timeout=30 --tries=3 --passive-ftp --no-check-certificate -c ${WGET_OPT} --progress=bar:force --show-progress -O ${PACKAGE}"
+WGET_CMD="wget --secure-protocol=TLSv1_2 --output-file=- --timeout=30 --tries=3 --passive-ftp --no-check-certificate -c ${WGET_OPT} --progress=bar:force --show-progress -O ${PACKAGE}"
 
 # unset LD_LIBRARY_PATH to stop wget from using toolchain/lib and loading libssl.so/libcrypto.so instead of host libraries
 unset LD_LIBRARY_PATH


### PR DESCRIPTION
## Description

Force wget to use TLS 1.2 to resolve 403 Forbidden error.  Thanks to @AndreMiras @ https://github.com/orgs/community/discussions/65227#discussioncomment-6846790

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

```
rm -rf sources-AMD64/pipewire
./scripts/get pipewire
<snip>
    INFO      Calculated checksum: 7e405d84cf3535d1f1a5fff01c13b2cb7f420b1a9242469d56ac8fd5b2f36139
```