### PR TITLE
Put config files back to where they are expected

### DIFF
--- a/packages/tools/vim/package.mk
+++ b/packages/tools/vim/package.mk
@@ -21,7 +21,6 @@ PKG_CONFIGURE_OPTS_TARGET="vim_cv_getcwd_broken=no \
                            vim_cv_tty_mode=0620 \
                            ac_cv_sizeof_int=4 \
                            ac_cv_small_wchar_t=no \
-                           --datarootdir=/storage/.config/vim \
                            --disable-canberra \
                            --disable-nls \
                            --enable-selinux=no \
@@ -48,8 +47,6 @@ pre_makeinstall_target() {
 
 post_makeinstall_target() {
   (
-  mv ${INSTALL}/storage/.config/vim/vim/vimrc_example.vim ${INSTALL}/usr/config/vim/vimrc
-  mv ${INSTALL}/storage/.config/vim/vim/defaults.vim ${INSTALL}/usr/config/vim/defaults.vim
-  rm -r ${INSTALL}/storage/
+  mv ${INSTALL}/usr/share/vim/vimrc_example.vim ${INSTALL}/usr/share/vim/vimrc
   )
 }


### PR DESCRIPTION
# Pull Request Template

## Description

While trying to debug another issue with vim, I realized the package.mk file is for some reason changing "datarootdir", which on a Debian based machine, will point to "/usr/share".
It is strange to want to replace it with something stored in the "user directory".

With this change, all vim warnings disappear finally, the user can still add their own config to "/storage/.vimrc" or "/storage/.vim/vimrc", and we finally get syntax highlighting!


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested Locally?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Rebuilt Image with rebuilt package, ssh'ed the ran vim on a shell script and saw the pretty colors and no warnings

**Test Configuration**:
* Build OS name and version: Debian unstable
* Docker (Y/N): N
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

