### PR TITLE
Allow empty PSK in order to connect to open wifi networks

### DIFF
--- a/packages/jelos/sources/scripts/wifictl
+++ b/packages/jelos/sources/scripts/wifictl
@@ -8,6 +8,9 @@
 ###
 ### Basic WIFI properties used across the tool.
 ###
+### Usage:
+###     wifictl command [ssid] [psk]
+###
 
 CFG_ROOT="/storage/.cache"
 WIFI_CFG="${CFG_ROOT}/connman/wifi.config"
@@ -45,7 +48,7 @@ then
   PSK="${GENERATED[0]: -10}"
 fi
 
-if [ ! -d "" ]
+if [ ! -d "${CFG_ROOT}/connman" ]
 then
   mkdir -p "${CFG_ROOT}/connman"
 fi
@@ -142,8 +145,15 @@ AutoConnect = true
 [service_${OS_NAME}_default]
 Type = wifi
 Name = ${SSID}
+EOF
+
+  # Only add a PSK if one is provided, in order to connect to
+  # open networks.
+  if [ ! -z "${PSK}" ] ; then
+    cat >> "${WIFI_CFG}" <<EOF
 Passphrase = ${PSK}
 EOF
+  fi
 
   if [ "${WIFI_TYPE}" = "1" ]
   then


### PR DESCRIPTION
# Pull Request Template

## Description

For connman to be able to connect to open network (with no PSK), we need to not add the Passphrase config line, or it will try to connect to the network and authenticate with a PSK that is the empty string.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested Locally?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Rebuilt the image, dropped on my X55, checked that the connman cache files had the expected content and that I could connect to an open network as well as one with a PSK

**Test Configuration**:
* Build OS name and version: Debian untable
* Docker (Y/N): N
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
