### PR TITLE
Drop s2idle, revert battery fixes.

### DIFF
--- a/packages/hardware/quirks/devices/Anbernic RG353P/001-hardwareinit
+++ b/packages/hardware/quirks/devices/Anbernic RG353P/001-hardwareinit
@@ -16,4 +16,3 @@ then
   /usr/bin/setsuspendmode freeze
 fi
 
-echo s2idle >/sys/power/mem_sleep

--- a/packages/hardware/quirks/devices/Anbernic RG353V/001-hardwareinit
+++ b/packages/hardware/quirks/devices/Anbernic RG353V/001-hardwareinit
@@ -16,4 +16,3 @@ then
   /usr/bin/setsuspendmode freeze
 fi
 
-echo s2idle >/sys/power/mem_sleep

--- a/packages/hardware/quirks/devices/Anbernic RG503/001-hardwareinit
+++ b/packages/hardware/quirks/devices/Anbernic RG503/001-hardwareinit
@@ -16,4 +16,3 @@ then
   /usr/bin/setsuspendmode freeze
 fi
 
-echo s2idle >/sys/power/mem_sleep

--- a/packages/hardware/quirks/devices/Anbernic RG552/001-hardwareinit
+++ b/packages/hardware/quirks/devices/Anbernic RG552/001-hardwareinit
@@ -10,4 +10,3 @@ then
   /usr/bin/setsuspendmode freeze
 fi
 
-echo s2idle >/sys/power/mem_sleep

--- a/packages/hardware/quirks/devices/Powkiddy RK2023/001-hardwareinit
+++ b/packages/hardware/quirks/devices/Powkiddy RK2023/001-hardwareinit
@@ -10,4 +10,3 @@ then
   /usr/bin/setsuspendmode freeze
 fi
 
-echo s2idle >/sys/power/mem_sleep

--- a/projects/Rockchip/packages/linux/package.mk
+++ b/projects/Rockchip/packages/linux/package.mk
@@ -26,13 +26,13 @@ case ${DEVICE} in
   ;;
   RK3566)
     PKG_URL="${PKG_SITE}/rk356x-kernel.git"
-    PKG_VERSION="800e3a4a5"
+    PKG_VERSION="692dc405f"
     GET_HANDLER_SUPPORT="git"
     PKG_GIT_CLONE_BRANCH="main"
   ;;
   *X55)
     PKG_URL="${PKG_SITE}/rk3566-x55-kernel.git"
-    PKG_VERSION="a514c4665"
+    PKG_VERSION="ab0743108"
     GET_HANDLER_SUPPORT="git"
     PKG_GIT_CLONE_BRANCH="main"
   ;;


### PR DESCRIPTION
## Description

There have been a lot of complaints that JELOS sleep uses more battery on RK3566 devices which was implemented to reduce the kernel bugs that cause low FPS, choppy audio, etc on some devices.  This PR drops use of s2idle which prevented those issues and allows devices to use less power while sleeping.

Additionally reverts changes implemented to work around and greatly reduce issues with RK3566 devices sometimes needing a battery disconnect in hardware due to complaints.  The resulting outcome of this change will require more users to disconnect and reconnect the battery when the issue occurs and their battery is stuck at 0% or somewhere below 100%.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
