### PR TITLE
N64 enhancements

### DIFF
--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -104,15 +104,15 @@ fi
 	if [ "${FPS}" = "true" ]; then
 		export LIBGL_SHOW_FPS="1"
 		export GALLIUM_HUD="cpu+GPU-load+fps"
-		# sed -i '/ShowFPS = (False|True)/c\ShowFPS = True' $TMP/mupen64plus.cfg
-		# sed -i '/ShowFPS = (0|1)/c\ShowFPS = 1' $TMP/mupen64plus.cfg
-		# sed -i '/show_fps/c\show_fps = 1' $TMP/mupen64plus.cfg
+		SET_PARAMS="$SET_PARAMS --set Video-GLideN64[ShowFPS]=True"
+		#SET_PARAMS="$SET_PARAMS --set Video-Glide64mk2[show_fps]=1"
+		#SET_PARAMS="$SET_PARAMS --set Video-Rice[ShowFPS]=True"
 	else
 		export LIBGL_SHOW_FPS="0"
 		export GALLIUM_HUD="off"
-		# sed -i '/ShowFPS = (False|True)/c\ShowFPS = False' $TMP/mupen64plus.cfg
-		# sed -i '/ShowFPS = (0|1)/c\ShowFPS = 0' $TMP/mupen64plus.cfg
-		# sed -i '/show_fps/c\show_fps = 0' $TMP/mupen64plus.cfg
+		SET_PARAMS="$SET_PARAMS --set Video-GLideN64[ShowFPS]=False"
+		#SET_PARAMS="$SET_PARAMS --set Video-Glide64mk2[show_fps]=0"
+		#SET_PARAMS="$SET_PARAMS --set Video-Rice[ShowFPS]=False"
 	fi
 
 # SIMPLECORE, decide which executable to use for simple64


### PR DESCRIPTION
## Description

This adds FPS display to Mupen64Plus-SA, for the GLideN64 video plugin only.  I have not yet got it working for the Rice and Glide64mk2 plugins.

If you'd rather wait until FPS is working for all three plugins, feel free to decline this PR.  I'm only submitting this now in case I get sidetracked with something else (e.g. dev docs).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Built for RK3566.  Verified on the (unsupported) RG353PS device.  I can test on X55 this weekend if you need me to.

Choose Mupen64plus-SA, GLideN64 video plugin, and Show FPS to on.  FPS shows up in the bottom left corner for me.

**Test Configuration**:
* Build OS name and version: Xubuntu 22.04 in VMware VM
* Docker (Y/N): Y
* JELOS Branch: dev

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
