### PR TITLE
Adds support for the Powkiddy RGB30.

### DIFF
--- a/projects/Rockchip/devices/RK3566/options
+++ b/projects/Rockchip/devices/RK3566/options
@@ -32,7 +32,7 @@
     PARTITION_TABLE="gpt"
     UBOOT_LABEL="uboot"
     TRUST_LABEL="resource"
-    DEVICE_DTB=("rk3566-rg353p-linux" "rk3566-rg353v-linux" "rk3566-rg353m-linux" "rk3566-rg503-linux" "rk3566-rk2023-linux")
+    DEVICE_DTB=("rk3566-rg353p-linux" "rk3566-rg353v-linux" "rk3566-rg353m-linux" "rk3566-rg503-linux" "rk3566-rk2023-linux" "rk3566-rgb30-linux")
     UBOOT_DTB="rk3566"
     UBOOT_CONFIG="rk3568_defconfig"
     PKG_SOC="rk356x"

--- a/projects/Rockchip/packages/linux/package.mk
+++ b/projects/Rockchip/packages/linux/package.mk
@@ -26,7 +26,7 @@ case ${DEVICE} in
   ;;
   RK3566)
     PKG_URL="${PKG_SITE}/rk356x-kernel.git"
-    PKG_VERSION="692dc405f"
+    PKG_VERSION="9d98ce7b4"
     GET_HANDLER_SUPPORT="git"
     PKG_GIT_CLONE_BRANCH="main"
   ;;


### PR DESCRIPTION
## Description

This PR implements support for the new Powkiddy RGB30.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

* Booted 08012023 from my local dev branch on the RGB30.
* Verified the following:
  * The correct device tree was loaded.
  * The aspect ratio is correctly configured (1:1).
  * Validated that controls work.
  * Verified audio output, headphone jack, and volume work.