### PR TITLE
glfw: source wayland.xml from the buildroot and rebuild if wayland gets updated

### DIFF
--- a/packages/graphics/glfw/package.mk
+++ b/packages/graphics/glfw/package.mk
@@ -26,8 +26,13 @@ fi
 
 if [ "${DISPLAYSERVER}" = "wl" ]; then
 	PKG_DEPENDS_TARGET+=" wayland wayland-protocols libglvnd"
+	PKG_NEED_UNPACK="$(get_pkg_directory wayland)"
 	PKG_CMAKE_OPTS_TARGET+=" -DGLFW_BUILD_WAYLAND=ON"
 fi
+
+post_unpack() {
+  sed -i "s|\${WAYLAND_CLIENT_PKGDATADIR}|${TOOLCHAIN}/share/wayland|" ${PKG_BUILD}/src/CMakeLists.txt
+}
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/


### PR DESCRIPTION
glfw was sourcing wayland.xml from outside of the buildroot, this PR sources the file from the buildroot and also rebuilds glfw if wayland is updated