### PR TITLE
Amlogic: fix debug tty and enable debug shell over uart

### DIFF
--- a/projects/Amlogic/devices/S922X/options
+++ b/projects/Amlogic/devices/S922X/options
@@ -69,7 +69,7 @@
     WINDOWMANAGER="weston11"
   
   # kernel serial console
-    EXTRA_CMDLINE="rootwait quiet console=ttyAML0,115200 console=tty0 no_console_suspend net.ifnames=0 consoleblank=0 fbcon=rotate:3"
+    EXTRA_CMDLINE="rootwait quiet systemd.debug_shell=ttyAML0 console=ttyAML0,115200n8 console=tty0 no_console_suspend net.ifnames=0 consoleblank=0 fbcon=rotate:3"
 
   # additional packages to install
   #  ADDITIONAL_PACKAGES=""
@@ -94,7 +94,7 @@
     DRIVER_ADDONS=""
 
   # debug tty path
-    DEBUG_TTY="/dev/ttyFIQ0"
+    DEBUG_TTY="/dev/ttyAML0"
 
   # Disable 32BIT support
     ENABLE_32BIT="false"

--- a/projects/Amlogic/devices/S922X/options
+++ b/projects/Amlogic/devices/S922X/options
@@ -69,7 +69,7 @@
     WINDOWMANAGER="weston11"
   
   # kernel serial console
-    EXTRA_CMDLINE="rootwait quiet systemd.debug_shell=ttyAML0 console=ttyAML0,115200n8 console=tty0 no_console_suspend net.ifnames=0 consoleblank=0 fbcon=rotate:3"
+    EXTRA_CMDLINE="rootwait quiet systemd.debug_shell=ttyAML0 console=ttyAML0,115200n8 console=tty0 no_console_suspend net.ifnames=0 consoleblank=0"
 
   # additional packages to install
   #  ADDITIONAL_PACKAGES=""

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -64,4 +64,4 @@
     DRIVER_ADDONS_SUPPORT="no"
 
   # debug tty path
-    DEBUG_TTY="/dev/ttyS2"
+    DEBUG_TTY="/dev/ttyAML0"


### PR DESCRIPTION
This PR fixes the TTY path in the project options and enables debug shell over UART