### PR TITLE
Respect aspect ratio setting in mupen64plus-sa, and tidy launch script

### DIFF
--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -10,6 +10,8 @@ jslisten set "-9 mupen64plus"
 
 # Emulation Station Features
 GAME=$(echo "${1}"| sed "s#^/.*/##")
+SCREENWIDTH=$(fbwidth)
+SCREENHEIGHT=$(fbheight)
 ASPECT=$(get_setting game_aspect_ratio n64 "${GAME}")
 IRES=$(get_setting internal_resolution n64 "${GAME}")
 RSP=$(get_setting rsp_plugin n64 "${GAME}")
@@ -18,27 +20,26 @@ FPS=$(get_setting show_fps n64 "${GAME}")
 PAK=$(get_setting controller_pak n64 "${GAME}")
 CON=$(get_setting input_configuration n64 "${GAME}")
 VPLUGIN=$(get_setting video_plugin n64 "${GAME}")
+
 SHARE="/usr/local/share/mupen64plus"
 GAMEDATA="/storage/.config/mupen64plus"
 M64PCONF="${GAMEDATA}/mupen64plus.cfg"
 CUSTOMINP="${GAMEDATA}/custominput.ini"
 TMP="/tmp/mupen64plus"
 
-SCREENWIDTH=$(fbwidth)
-SCREENHEIGHT=$(fbheight)
-
-if [[ ! -f "${CUSTOMINP}" ]]; then
-    mkdir -p ${GAMEDATA}
-    cp ${SHARE}/default.ini ${CUSTOMINP}
-fi
+rm -rf ${TMP}
+mkdir -p ${TMP}
+mkdir -p ${GAMEDATA}
 
 if [[ ! -f "${M64PCONF}" ]]; then
-    mkdir -p ${GAMEDATA}
     cp ${SHARE}/mupen64plus.cfg* ${M64PCONF}
 fi
 
-rm -rf ${TMP}
-mkdir -p ${TMP}
+if [[ ! -f "${CUSTOMINP}" ]]; then
+    cp ${SHARE}/default.ini ${CUSTOMINP}
+fi
+
+cp ${M64PCONF} ${TMP}
 
 # Input Config
 if [ "${CON}" = "custom" ]; then
@@ -58,8 +59,6 @@ else
     cp "$1" ${TMP}
     ROM="${GAME}"
 fi
-
-cp ${M64PCONF} ${TMP}
 
 # Set the cores to use
 CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -101,7 +101,7 @@ if [ "${ASPECT}" = "fullscreen" ]; then
     SET_PARAMS+=" --set Video-GLideN64[AspectRatio]=3"
     SET_PARAMS+=" --set Video-Glide64mk2[aspect]=2"
 else
-    if [ "${VPLUGIN}" = "rice" ]; then
+    if [ -z "${VPLUGIN}" ] || [ "${VPLUGIN}" = "rice" ]; then
         GAMEWIDTH=$(((SCREENHEIGHT * 4) / 3))
         SET_PARAMS+=" --set Video-General[ScreenWidth]=${GAMEWIDTH}"
     else

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -19,20 +19,21 @@ PAK=$(get_setting controller_pak n64 "${GAME}")
 CON=$(get_setting input_configuration n64 "${GAME}")
 VPLUGIN=$(get_setting video_plugin n64 "${GAME}")
 SHARE="/usr/local/share/mupen64plus"
-M64PCONF="/storage/.config/mupen64plus/mupen64plus.cfg"
-TMP="/tmp/mupen64plus"
 GAMEDATA="/storage/.config/mupen64plus"
+M64PCONF="${GAMEDATA}/mupen64plus.cfg"
+CUSTOMINP="${GAMEDATA}/custominput.ini"
+TMP="/tmp/mupen64plus"
 
 SCREENWIDTH=$(fbwidth)
 SCREENHEIGHT=$(fbheight)
 
-if [[ ! -f "${GAMEDATA}/custominput.ini" ]]; then
+if [[ ! -f "${CUSTOMINP}" ]]; then
     mkdir -p ${GAMEDATA}
-    cp ${SHARE}/default.ini ${GAMEDATA}/custominput.ini
+    cp ${SHARE}/default.ini ${CUSTOMINP}
 fi
 
 if [[ ! -f "${M64PCONF}" ]]; then
-    mkdir -p /storage/.config/mupen64plus
+    mkdir -p ${GAMEDATA}
     cp ${SHARE}/mupen64plus.cfg* ${M64PCONF}
 fi
 
@@ -41,7 +42,7 @@ mkdir -p ${TMP}
 
 # Input Config
 if [ "${CON}" = "custom" ]; then
-    cp ${GAMEDATA}/custominput.ini ${TMP}/InputAutoCfg.ini
+    cp ${CUSTOMINP} ${TMP}/InputAutoCfg.ini
 elif [ "${CON}" = "standard" ]; then
     cp ${SHARE}/default.ini ${TMP}/InputAutoCfg.ini
 else

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -8,7 +8,7 @@
 
 jslisten set "-9 mupen64plus"
 
-#Emulation Station Features
+# Emulation Station Features
 GAME=$(echo "${1}"| sed "s#^/.*/##")
 ASPECT=$(get_setting game_aspect_ratio n64 "${GAME}")
 IRES=$(get_setting internal_resolution n64 "${GAME}")
@@ -27,13 +27,13 @@ SCREENWIDTH=$(fbwidth)
 SCREENHEIGHT=$(fbheight)
 
 if [[ ! -f "$GAMEDATA/custominput.ini" ]]; then
-	mkdir -p $GAMEDATA
-	cp $SHARE/default.ini $GAMEDATA/custominput.ini
+    mkdir -p $GAMEDATA
+    cp $SHARE/default.ini $GAMEDATA/custominput.ini
 fi
 
 if [[ ! -f "$M64PCONF" ]]; then
-	mkdir -p /storage/.config/mupen64plus
-	cp $SHARE/mupen64plus.cfg* $M64PCONF
+    mkdir -p /storage/.config/mupen64plus
+    cp $SHARE/mupen64plus.cfg* $M64PCONF
 fi
 
 rm -rf $TMP
@@ -41,120 +41,119 @@ mkdir -p $TMP
 
 # Unzip or copy the rom to the working directory
 if [ $(echo $1 | grep -i .zip | wc -l) -eq 1 ]; then
-	#unpack the zip file
-  	unzip -q -o "$1" -d $TMP
-	ROM=$(unzip -Zl -1 "$1")
+    #unpack the zip file
+    unzip -q -o "$1" -d $TMP
+    ROM=$(unzip -Zl -1 "$1")
 else
-	cp "$1" $TMP
-	ROM="$GAME"
+    cp "$1" $TMP
+    ROM="$GAME"
 fi
 
 cp $M64PCONF $TMP
 SET_PARAMS="--set Core[SharedDataPath]=$TMP --set Video-Rice[ResolutionWidth]=${SCREENWIDTH}"
 
-#Set the cores to use
+# Set the cores to use
 CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
 if [ "${CORES}" = "little" ]
 then
-  EMUPERF="${SLOW_CORES}"
+    EMUPERF="${SLOW_CORES}"
 elif [ "${CORES}" = "big" ]
 then
-  EMUPERF="${FAST_CORES}"
+    EMUPERF="${FAST_CORES}"
 else
-  ### All..
-  unset EMUPERF
+    ### All..
+    unset EMUPERF
 fi
 
-#Aspect Ratio
-	if [ "${ASPECT}" = "fullscreen" ]; then
-		# TODO: Set aspect ratio to fullscreen
-		SET_PARAMS="$SET_PARAMS --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Glide64mk2[aspect]=2 --set Video-GLideN64[AspectRatio]=3 --set Video-Parallel[WidescreenStretch]=False"
-	else
-		# TODO: Set aspect ratio to 4:3
-		if [ "${VPLUGIN}" = "rice" ]; then
-			GAMEWIDTH=$(((SCREENHEIGHT * 4) / 3))
-			SET_PARAMS="$SET_PARAMS --set Video-General[ScreenWidth]=${GAMEWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
-		else
-			SET_PARAMS="$SET_PARAMS --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[WidescreenStretch]=False --set Video-Glide64mk2[aspect]=0 --set Video-GLideN64[AspectRatio]=1"
-		fi
-	fi
+# Aspect Ratio
+if [ "${ASPECT}" = "fullscreen" ]; then
+    # TODO: Set aspect ratio to fullscreen
+    SET_PARAMS="$SET_PARAMS --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Glide64mk2[aspect]=2 --set Video-GLideN64[AspectRatio]=3 --set Video-Parallel[WidescreenStretch]=False"
+else
+    # TODO: Set aspect ratio to 4:3
+    if [ "${VPLUGIN}" = "rice" ]; then
+        GAMEWIDTH=$(((SCREENHEIGHT * 4) / 3))
+        SET_PARAMS="$SET_PARAMS --set Video-General[ScreenWidth]=${GAMEWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
+    else
+        SET_PARAMS="$SET_PARAMS --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[WidescreenStretch]=False --set Video-Glide64mk2[aspect]=0 --set Video-GLideN64[AspectRatio]=1"
+    fi
+fi
 
 # Native Res Factor (Upscaling)
-	if [ "${VPLUGIN}" = "gliden64" ]; then
-		sed -i "/UseNativeResolutionFactor/c\UseNativeResolutionFactor = $IRES" $TMP/mupen64plus.cfg
-	elif [ "${VPLUGIN}" = "rmg_parallel" ]; then
-		sed -i "/Upscaling/c\Upscaling = $IRES" $TMP/mupen64plus.cfg
-	fi
-
+if [ "${VPLUGIN}" = "gliden64" ]; then
+    sed -i "/UseNativeResolutionFactor/c\UseNativeResolutionFactor = $IRES" $TMP/mupen64plus.cfg
+elif [ "${VPLUGIN}" = "rmg_parallel" ]; then
+    sed -i "/Upscaling/c\Upscaling = $IRES" $TMP/mupen64plus.cfg
+fi
 
 # Input Config
-	if [ "${CON}" = "custom" ]; then
-		cp $GAMEDATA/custominput.ini $TMP/InputAutoCfg.ini
-	elif [ "${CON}" = "standard" ]; then
-                cp $SHARE/default.ini $TMP/InputAutoCfg.ini
-	else
-		cp $SHARE/default.ini $TMP/InputAutoCfg.ini
-	fi
+if [ "${CON}" = "custom" ]; then
+    cp $GAMEDATA/custominput.ini $TMP/InputAutoCfg.ini
+elif [ "${CON}" = "standard" ]; then
+    cp $SHARE/default.ini $TMP/InputAutoCfg.ini
+else
+    cp $SHARE/default.ini $TMP/InputAutoCfg.ini
+fi
 
 # Controller Pak
-	sed -i "0,/plugin =/c\plugin = $PAK" $TMP/mupen64plus.cfg
+sed -i "0,/plugin =/c\plugin = $PAK" $TMP/mupen64plus.cfg
 
 # Show FPS
 # Get configuration from system.cfg
-	if [ "${FPS}" = "true" ]; then
-		export LIBGL_SHOW_FPS="1"
-		export GALLIUM_HUD="cpu+GPU-load+fps"
-		SET_PARAMS="$SET_PARAMS --set Video-GLideN64[ShowFPS]=True"
-		#SET_PARAMS="$SET_PARAMS --set Video-Glide64mk2[show_fps]=1"
-		#SET_PARAMS="$SET_PARAMS --set Video-Rice[ShowFPS]=True"
-	else
-		export LIBGL_SHOW_FPS="0"
-		export GALLIUM_HUD="off"
-		SET_PARAMS="$SET_PARAMS --set Video-GLideN64[ShowFPS]=False"
-		#SET_PARAMS="$SET_PARAMS --set Video-Glide64mk2[show_fps]=0"
-		#SET_PARAMS="$SET_PARAMS --set Video-Rice[ShowFPS]=False"
-	fi
+if [ "${FPS}" = "true" ]; then
+    export LIBGL_SHOW_FPS="1"
+    export GALLIUM_HUD="cpu+GPU-load+fps"
+    SET_PARAMS="$SET_PARAMS --set Video-GLideN64[ShowFPS]=True"
+    #SET_PARAMS="$SET_PARAMS --set Video-Glide64mk2[show_fps]=1"
+    #SET_PARAMS="$SET_PARAMS --set Video-Rice[ShowFPS]=True"
+else
+    export LIBGL_SHOW_FPS="0"
+    export GALLIUM_HUD="off"
+    SET_PARAMS="$SET_PARAMS --set Video-GLideN64[ShowFPS]=False"
+    #SET_PARAMS="$SET_PARAMS --set Video-Glide64mk2[show_fps]=0"
+    #SET_PARAMS="$SET_PARAMS --set Video-Rice[ShowFPS]=False"
+fi
 
 # SIMPLECORE, decide which executable to use for simple64
- if [ "${SIMPLECORE}" = "simple" ]; then
-	SIMPLESUFFIX="-simple"
-	SET_PARAMS="$SET_PARAMS --set Core[R4300Emulator]=1"
+if [ "${SIMPLECORE}" = "simple" ]; then
+    SIMPLESUFFIX="-simple"
+    SET_PARAMS="$SET_PARAMS --set Core[R4300Emulator]=1"
 else
-	SIMPLESUFFIX=""
-	SET_PARAMS="$SET_PARAMS --set Core[R4300Emulator]=2"
+    SIMPLESUFFIX=""
+    SET_PARAMS="$SET_PARAMS --set Core[R4300Emulator]=2"
 fi
 
 # Set the video plugin
 case ${VPLUGIN} in
-	"rmg_parallel")
-		SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-parallel${SIMPLESUFFIX}.so"
-		RSP="parallel"
-	;;
-	"gliden64")
-		SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-GLideN64${SIMPLESUFFIX}.so"
-	;;
-	"gl64mk2")
-		SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-glide64mk2${SIMPLESUFFIX}.so"
-	;;
-	"rice")
-		SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-rice${SIMPLESUFFIX}.so"
-	;;
-	*)
-		SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-rice${SIMPLESUFFIX}.so"
-	;;
+    "rmg_parallel")
+        SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-parallel${SIMPLESUFFIX}.so"
+        RSP="parallel"
+    ;;
+    "gliden64")
+        SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-GLideN64${SIMPLESUFFIX}.so"
+    ;;
+    "gl64mk2")
+        SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-glide64mk2${SIMPLESUFFIX}.so"
+    ;;
+    "rice")
+        SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-rice${SIMPLESUFFIX}.so"
+    ;;
+    *)
+        SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-rice${SIMPLESUFFIX}.so"
+    ;;
 esac
 
 # Set the RSP plugin
 case "${RSP}" in
-	"parallel")
-		SET_PARAMS="$SET_PARAMS --rsp mupen64plus-rsp-parallel$SIMPLESUFFIX.so"
-	;;
-	"hle")
-		SET_PARAMS="$SET_PARAMS --rsp mupen64plus-rsp-hle$SIMPLESUFFIX.so"
-	;;
-	*)
-    	SET_PARAMS="$SET_PARAMS --rsp mupen64plus-rsp-cxd4$SIMPLESUFFIX.so"
-  	;;
+    "parallel")
+        SET_PARAMS="$SET_PARAMS --rsp mupen64plus-rsp-parallel$SIMPLESUFFIX.so"
+    ;;
+    "hle")
+        SET_PARAMS="$SET_PARAMS --rsp mupen64plus-rsp-hle$SIMPLESUFFIX.so"
+    ;;
+    *)
+        SET_PARAMS="$SET_PARAMS --rsp mupen64plus-rsp-cxd4$SIMPLESUFFIX.so"
+    ;;
 esac
 
 # Set the remaining plugins

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -26,31 +26,31 @@ GAMEDATA="/storage/.config/mupen64plus"
 SCREENWIDTH=$(fbwidth)
 SCREENHEIGHT=$(fbheight)
 
-if [[ ! -f "$GAMEDATA/custominput.ini" ]]; then
-    mkdir -p $GAMEDATA
-    cp $SHARE/default.ini $GAMEDATA/custominput.ini
+if [[ ! -f "${GAMEDATA}/custominput.ini" ]]; then
+    mkdir -p ${GAMEDATA}
+    cp ${SHARE}/default.ini ${GAMEDATA}/custominput.ini
 fi
 
-if [[ ! -f "$M64PCONF" ]]; then
+if [[ ! -f "${M64PCONF}" ]]; then
     mkdir -p /storage/.config/mupen64plus
-    cp $SHARE/mupen64plus.cfg* $M64PCONF
+    cp ${SHARE}/mupen64plus.cfg* ${M64PCONF}
 fi
 
-rm -rf $TMP
-mkdir -p $TMP
+rm -rf ${TMP}
+mkdir -p ${TMP}
 
 # Unzip or copy the rom to the working directory
 if [ $(echo $1 | grep -i .zip | wc -l) -eq 1 ]; then
     #unpack the zip file
-    unzip -q -o "$1" -d $TMP
+    unzip -q -o "$1" -d ${TMP}
     ROM=$(unzip -Zl -1 "$1")
 else
-    cp "$1" $TMP
-    ROM="$GAME"
+    cp "$1" ${TMP}
+    ROM="${GAME}"
 fi
 
-cp $M64PCONF $TMP
-SET_PARAMS="--set Core[SharedDataPath]=$TMP --set Video-Rice[ResolutionWidth]=${SCREENWIDTH}"
+cp ${M64PCONF} ${TMP}
+SET_PARAMS="--set Core[SharedDataPath]=${TMP} --set Video-Rice[ResolutionWidth]=${SCREENWIDTH}"
 
 # Set the cores to use
 CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
@@ -68,98 +68,98 @@ fi
 # Aspect Ratio
 if [ "${ASPECT}" = "fullscreen" ]; then
     # TODO: Set aspect ratio to fullscreen
-    SET_PARAMS="$SET_PARAMS --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Glide64mk2[aspect]=2 --set Video-GLideN64[AspectRatio]=3 --set Video-Parallel[WidescreenStretch]=False"
+    SET_PARAMS="${SET_PARAMS} --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Glide64mk2[aspect]=2 --set Video-GLideN64[AspectRatio]=3 --set Video-Parallel[WidescreenStretch]=False"
 else
     # TODO: Set aspect ratio to 4:3
     if [ "${VPLUGIN}" = "rice" ]; then
         GAMEWIDTH=$(((SCREENHEIGHT * 4) / 3))
-        SET_PARAMS="$SET_PARAMS --set Video-General[ScreenWidth]=${GAMEWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
+        SET_PARAMS="${SET_PARAMS} --set Video-General[ScreenWidth]=${GAMEWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
     else
-        SET_PARAMS="$SET_PARAMS --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[WidescreenStretch]=False --set Video-Glide64mk2[aspect]=0 --set Video-GLideN64[AspectRatio]=1"
+        SET_PARAMS="${SET_PARAMS} --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[WidescreenStretch]=False --set Video-Glide64mk2[aspect]=0 --set Video-GLideN64[AspectRatio]=1"
     fi
 fi
 
 # Native Res Factor (Upscaling)
 if [ "${VPLUGIN}" = "gliden64" ]; then
-    sed -i "/UseNativeResolutionFactor/c\UseNativeResolutionFactor = $IRES" $TMP/mupen64plus.cfg
+    sed -i "/UseNativeResolutionFactor/c\UseNativeResolutionFactor = ${IRES}" ${TMP}/mupen64plus.cfg
 elif [ "${VPLUGIN}" = "rmg_parallel" ]; then
-    sed -i "/Upscaling/c\Upscaling = $IRES" $TMP/mupen64plus.cfg
+    sed -i "/Upscaling/c\Upscaling = ${IRES}" ${TMP}/mupen64plus.cfg
 fi
 
 # Input Config
 if [ "${CON}" = "custom" ]; then
-    cp $GAMEDATA/custominput.ini $TMP/InputAutoCfg.ini
+    cp ${GAMEDATA}/custominput.ini ${TMP}/InputAutoCfg.ini
 elif [ "${CON}" = "standard" ]; then
-    cp $SHARE/default.ini $TMP/InputAutoCfg.ini
+    cp ${SHARE}/default.ini ${TMP}/InputAutoCfg.ini
 else
-    cp $SHARE/default.ini $TMP/InputAutoCfg.ini
+    cp ${SHARE}/default.ini ${TMP}/InputAutoCfg.ini
 fi
 
 # Controller Pak
-sed -i "0,/plugin =/c\plugin = $PAK" $TMP/mupen64plus.cfg
+sed -i "0,/plugin =/c\plugin = ${PAK}" ${TMP}/mupen64plus.cfg
 
 # Show FPS
 # Get configuration from system.cfg
 if [ "${FPS}" = "true" ]; then
     export LIBGL_SHOW_FPS="1"
     export GALLIUM_HUD="cpu+GPU-load+fps"
-    SET_PARAMS="$SET_PARAMS --set Video-GLideN64[ShowFPS]=True"
-    #SET_PARAMS="$SET_PARAMS --set Video-Glide64mk2[show_fps]=1"
-    #SET_PARAMS="$SET_PARAMS --set Video-Rice[ShowFPS]=True"
+    SET_PARAMS="${SET_PARAMS} --set Video-GLideN64[ShowFPS]=True"
+    #SET_PARAMS="${SET_PARAMS} --set Video-Glide64mk2[show_fps]=1"
+    #SET_PARAMS="${SET_PARAMS} --set Video-Rice[ShowFPS]=True"
 else
     export LIBGL_SHOW_FPS="0"
     export GALLIUM_HUD="off"
-    SET_PARAMS="$SET_PARAMS --set Video-GLideN64[ShowFPS]=False"
-    #SET_PARAMS="$SET_PARAMS --set Video-Glide64mk2[show_fps]=0"
-    #SET_PARAMS="$SET_PARAMS --set Video-Rice[ShowFPS]=False"
+    SET_PARAMS="${SET_PARAMS} --set Video-GLideN64[ShowFPS]=False"
+    #SET_PARAMS="${SET_PARAMS} --set Video-Glide64mk2[show_fps]=0"
+    #SET_PARAMS="${SET_PARAMS} --set Video-Rice[ShowFPS]=False"
 fi
 
 # SIMPLECORE, decide which executable to use for simple64
 if [ "${SIMPLECORE}" = "simple" ]; then
     SIMPLESUFFIX="-simple"
-    SET_PARAMS="$SET_PARAMS --set Core[R4300Emulator]=1"
+    SET_PARAMS="${SET_PARAMS} --set Core[R4300Emulator]=1"
 else
     SIMPLESUFFIX=""
-    SET_PARAMS="$SET_PARAMS --set Core[R4300Emulator]=2"
+    SET_PARAMS="${SET_PARAMS} --set Core[R4300Emulator]=2"
 fi
 
 # Set the video plugin
 case ${VPLUGIN} in
     "rmg_parallel")
-        SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-parallel${SIMPLESUFFIX}.so"
+        SET_PARAMS="${SET_PARAMS} --gfx mupen64plus-video-parallel${SIMPLESUFFIX}.so"
         RSP="parallel"
     ;;
     "gliden64")
-        SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-GLideN64${SIMPLESUFFIX}.so"
+        SET_PARAMS="${SET_PARAMS} --gfx mupen64plus-video-GLideN64${SIMPLESUFFIX}.so"
     ;;
     "gl64mk2")
-        SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-glide64mk2${SIMPLESUFFIX}.so"
+        SET_PARAMS="${SET_PARAMS} --gfx mupen64plus-video-glide64mk2${SIMPLESUFFIX}.so"
     ;;
     "rice")
-        SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-rice${SIMPLESUFFIX}.so"
+        SET_PARAMS="${SET_PARAMS} --gfx mupen64plus-video-rice${SIMPLESUFFIX}.so"
     ;;
     *)
-        SET_PARAMS="$SET_PARAMS --gfx mupen64plus-video-rice${SIMPLESUFFIX}.so"
+        SET_PARAMS="${SET_PARAMS} --gfx mupen64plus-video-rice${SIMPLESUFFIX}.so"
     ;;
 esac
 
 # Set the RSP plugin
 case "${RSP}" in
     "parallel")
-        SET_PARAMS="$SET_PARAMS --rsp mupen64plus-rsp-parallel$SIMPLESUFFIX.so"
+        SET_PARAMS="${SET_PARAMS} --rsp mupen64plus-rsp-parallel${SIMPLESUFFIX}.so"
     ;;
     "hle")
-        SET_PARAMS="$SET_PARAMS --rsp mupen64plus-rsp-hle$SIMPLESUFFIX.so"
+        SET_PARAMS="${SET_PARAMS} --rsp mupen64plus-rsp-hle${SIMPLESUFFIX}.so"
     ;;
     *)
-        SET_PARAMS="$SET_PARAMS --rsp mupen64plus-rsp-cxd4$SIMPLESUFFIX.so"
+        SET_PARAMS="${SET_PARAMS} --rsp mupen64plus-rsp-cxd4${SIMPLESUFFIX}.so"
     ;;
 esac
 
 # Set the remaining plugins
-SET_PARAMS="$SET_PARAMS --input mupen64plus-input-sdl$SIMPLESUFFIX.so"
-SET_PARAMS="$SET_PARAMS --audio mupen64plus-audio-sdl$SIMPLESUFFIX.so"
+SET_PARAMS="${SET_PARAMS} --input mupen64plus-input-sdl${SIMPLESUFFIX}.so"
+SET_PARAMS="${SET_PARAMS} --audio mupen64plus-audio-sdl${SIMPLESUFFIX}.so"
 
 echo ${SET_PARAMS}
 
-${EMUPERF} /usr/local/bin/mupen64plus${SIMPLESUFFIX} --configdir $TMP $SET_PARAMS "$TMP/$ROM"
+${EMUPERF} /usr/local/bin/mupen64plus${SIMPLESUFFIX} --configdir ${TMP} ${SET_PARAMS} "${TMP}/${ROM}"

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -81,9 +81,9 @@ fi
 
 # Native Res Factor (Upscaling)
 if [ "${VPLUGIN}" = "gliden64" ]; then
-    sed -i "/UseNativeResolutionFactor/c\UseNativeResolutionFactor = ${IRES}" ${TMP}/mupen64plus.cfg
+    SET_PARAMS+=" --set Video-GLideN64[UseNativeResolutionFactor]=${IRES}"
 elif [ "${VPLUGIN}" = "rmg_parallel" ]; then
-    sed -i "/Upscaling/c\Upscaling = ${IRES}" ${TMP}/mupen64plus.cfg
+    SET_PARAMS+=" --set Video-Parallel[Upscaling]=${IRES}"
 fi
 
 # Input Config
@@ -96,7 +96,10 @@ else
 fi
 
 # Controller Pak
-sed -i "0,/plugin =/c\plugin = ${PAK}" ${TMP}/mupen64plus.cfg
+SET_PARAMS+=" --set Input-SDL-Control1[plugin]=${PAK}"
+SET_PARAMS+=" --set Input-SDL-Control2[plugin]=${PAK}"
+SET_PARAMS+=" --set Input-SDL-Control3[plugin]=${PAK}"
+SET_PARAMS+=" --set Input-SDL-Control4[plugin]=${PAK}"
 
 # Show FPS
 # Get configuration from system.cfg

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -68,12 +68,12 @@ else
 fi
 
 # Aspect Ratio
+SET_PARAMS+=" --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
+SET_PARAMS+=" --set Video-Parallel[ScreenWidth]=${SCREENWIDTH}"
+SET_PARAMS+=" --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT}"
 if [ "${ASPECT}" = "fullscreen" ]; then
     # TODO: Set aspect ratio to fullscreen
     SET_PARAMS+=" --set Video-General[ScreenWidth]=${SCREENWIDTH}"
-    SET_PARAMS+=" --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
-    SET_PARAMS+=" --set Video-Parallel[ScreenWidth]=${SCREENWIDTH}"
-    SET_PARAMS+=" --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT}"
     SET_PARAMS+=" --set Video-Glide64mk2[aspect]=2"
     SET_PARAMS+=" --set Video-GLideN64[AspectRatio]=3"
     SET_PARAMS+=" --set Video-Parallel[WidescreenStretch]=False"
@@ -82,24 +82,17 @@ else
     if [ "${VPLUGIN}" = "rice" ]; then
         GAMEWIDTH=$(((SCREENHEIGHT * 4) / 3))
         SET_PARAMS+=" --set Video-General[ScreenWidth]=${GAMEWIDTH}"
-        SET_PARAMS+=" --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
     else
         SET_PARAMS+=" --set Video-General[ScreenWidth]=${SCREENWIDTH}"
-        SET_PARAMS+=" --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
-        SET_PARAMS+=" --set Video-Parallel[ScreenWidth]=${SCREENWIDTH}"
-        SET_PARAMS+=" --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT}"
-        SET_PARAMS+=" --set Video-Parallel[WidescreenStretch]=False"
-        SET_PARAMS+=" --set Video-Glide64mk2[aspect]=0"
-        SET_PARAMS+=" --set Video-GLideN64[AspectRatio]=1"
     fi
+    SET_PARAMS+=" --set Video-Parallel[WidescreenStretch]=False"
+    SET_PARAMS+=" --set Video-Glide64mk2[aspect]=0"
+    SET_PARAMS+=" --set Video-GLideN64[AspectRatio]=1"
 fi
 
 # Native Res Factor (Upscaling)
-if [ "${VPLUGIN}" = "gliden64" ]; then
-    SET_PARAMS+=" --set Video-GLideN64[UseNativeResolutionFactor]=${IRES}"
-elif [ "${VPLUGIN}" = "rmg_parallel" ]; then
-    SET_PARAMS+=" --set Video-Parallel[Upscaling]=${IRES}"
-fi
+SET_PARAMS+=" --set Video-GLideN64[UseNativeResolutionFactor]=${IRES}"
+SET_PARAMS+=" --set Video-Parallel[Upscaling]=${IRES}"
 
 # Input Config
 if [ "${CON}" = "custom" ]; then

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -68,14 +68,14 @@ fi
 # Aspect Ratio
 if [ "${ASPECT}" = "fullscreen" ]; then
     # TODO: Set aspect ratio to fullscreen
-    SET_PARAMS="${SET_PARAMS} --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Glide64mk2[aspect]=2 --set Video-GLideN64[AspectRatio]=3 --set Video-Parallel[WidescreenStretch]=False"
+    SET_PARAMS+=" --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Glide64mk2[aspect]=2 --set Video-GLideN64[AspectRatio]=3 --set Video-Parallel[WidescreenStretch]=False"
 else
     # TODO: Set aspect ratio to 4:3
     if [ "${VPLUGIN}" = "rice" ]; then
         GAMEWIDTH=$(((SCREENHEIGHT * 4) / 3))
-        SET_PARAMS="${SET_PARAMS} --set Video-General[ScreenWidth]=${GAMEWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
+        SET_PARAMS+=" --set Video-General[ScreenWidth]=${GAMEWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
     else
-        SET_PARAMS="${SET_PARAMS} --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[WidescreenStretch]=False --set Video-Glide64mk2[aspect]=0 --set Video-GLideN64[AspectRatio]=1"
+        SET_PARAMS+=" --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[WidescreenStretch]=False --set Video-Glide64mk2[aspect]=0 --set Video-GLideN64[AspectRatio]=1"
     fi
 fi
 
@@ -103,62 +103,62 @@ sed -i "0,/plugin =/c\plugin = ${PAK}" ${TMP}/mupen64plus.cfg
 if [ "${FPS}" = "true" ]; then
     export LIBGL_SHOW_FPS="1"
     export GALLIUM_HUD="cpu+GPU-load+fps"
-    SET_PARAMS="${SET_PARAMS} --set Video-GLideN64[ShowFPS]=True"
-    #SET_PARAMS="${SET_PARAMS} --set Video-Glide64mk2[show_fps]=1"
-    #SET_PARAMS="${SET_PARAMS} --set Video-Rice[ShowFPS]=True"
+    SET_PARAMS+=" --set Video-GLideN64[ShowFPS]=True"
+    #SET_PARAMS+=" --set Video-Glide64mk2[show_fps]=1"
+    #SET_PARAMS+=" --set Video-Rice[ShowFPS]=True"
 else
     export LIBGL_SHOW_FPS="0"
     export GALLIUM_HUD="off"
-    SET_PARAMS="${SET_PARAMS} --set Video-GLideN64[ShowFPS]=False"
-    #SET_PARAMS="${SET_PARAMS} --set Video-Glide64mk2[show_fps]=0"
-    #SET_PARAMS="${SET_PARAMS} --set Video-Rice[ShowFPS]=False"
+    SET_PARAMS+=" --set Video-GLideN64[ShowFPS]=False"
+    #SET_PARAMS+=" --set Video-Glide64mk2[show_fps]=0"
+    #SET_PARAMS+=" --set Video-Rice[ShowFPS]=False"
 fi
 
 # SIMPLECORE, decide which executable to use for simple64
 if [ "${SIMPLECORE}" = "simple" ]; then
     SIMPLESUFFIX="-simple"
-    SET_PARAMS="${SET_PARAMS} --set Core[R4300Emulator]=1"
+    SET_PARAMS+=" --set Core[R4300Emulator]=1"
 else
     SIMPLESUFFIX=""
-    SET_PARAMS="${SET_PARAMS} --set Core[R4300Emulator]=2"
+    SET_PARAMS+=" --set Core[R4300Emulator]=2"
 fi
 
 # Set the video plugin
 case ${VPLUGIN} in
     "rmg_parallel")
-        SET_PARAMS="${SET_PARAMS} --gfx mupen64plus-video-parallel${SIMPLESUFFIX}.so"
+        SET_PARAMS+=" --gfx mupen64plus-video-parallel${SIMPLESUFFIX}.so"
         RSP="parallel"
     ;;
     "gliden64")
-        SET_PARAMS="${SET_PARAMS} --gfx mupen64plus-video-GLideN64${SIMPLESUFFIX}.so"
+        SET_PARAMS+=" --gfx mupen64plus-video-GLideN64${SIMPLESUFFIX}.so"
     ;;
     "gl64mk2")
-        SET_PARAMS="${SET_PARAMS} --gfx mupen64plus-video-glide64mk2${SIMPLESUFFIX}.so"
+        SET_PARAMS+=" --gfx mupen64plus-video-glide64mk2${SIMPLESUFFIX}.so"
     ;;
     "rice")
-        SET_PARAMS="${SET_PARAMS} --gfx mupen64plus-video-rice${SIMPLESUFFIX}.so"
+        SET_PARAMS+=" --gfx mupen64plus-video-rice${SIMPLESUFFIX}.so"
     ;;
     *)
-        SET_PARAMS="${SET_PARAMS} --gfx mupen64plus-video-rice${SIMPLESUFFIX}.so"
+        SET_PARAMS+=" --gfx mupen64plus-video-rice${SIMPLESUFFIX}.so"
     ;;
 esac
 
 # Set the RSP plugin
 case "${RSP}" in
     "parallel")
-        SET_PARAMS="${SET_PARAMS} --rsp mupen64plus-rsp-parallel${SIMPLESUFFIX}.so"
+        SET_PARAMS+=" --rsp mupen64plus-rsp-parallel${SIMPLESUFFIX}.so"
     ;;
     "hle")
-        SET_PARAMS="${SET_PARAMS} --rsp mupen64plus-rsp-hle${SIMPLESUFFIX}.so"
+        SET_PARAMS+=" --rsp mupen64plus-rsp-hle${SIMPLESUFFIX}.so"
     ;;
     *)
-        SET_PARAMS="${SET_PARAMS} --rsp mupen64plus-rsp-cxd4${SIMPLESUFFIX}.so"
+        SET_PARAMS+=" --rsp mupen64plus-rsp-cxd4${SIMPLESUFFIX}.so"
     ;;
 esac
 
 # Set the remaining plugins
-SET_PARAMS="${SET_PARAMS} --input mupen64plus-input-sdl${SIMPLESUFFIX}.so"
-SET_PARAMS="${SET_PARAMS} --audio mupen64plus-audio-sdl${SIMPLESUFFIX}.so"
+SET_PARAMS+=" --input mupen64plus-input-sdl${SIMPLESUFFIX}.so"
+SET_PARAMS+=" --audio mupen64plus-audio-sdl${SIMPLESUFFIX}.so"
 
 echo ${SET_PARAMS}
 

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -39,6 +39,15 @@ fi
 rm -rf ${TMP}
 mkdir -p ${TMP}
 
+# Input Config
+if [ "${CON}" = "custom" ]; then
+    cp ${GAMEDATA}/custominput.ini ${TMP}/InputAutoCfg.ini
+elif [ "${CON}" = "standard" ]; then
+    cp ${SHARE}/default.ini ${TMP}/InputAutoCfg.ini
+else
+    cp ${SHARE}/default.ini ${TMP}/InputAutoCfg.ini
+fi
+
 # Unzip or copy the rom to the working directory
 if [ $(echo $1 | grep -i .zip | wc -l) -eq 1 ]; then
     #unpack the zip file
@@ -50,9 +59,6 @@ else
 fi
 
 cp ${M64PCONF} ${TMP}
-SET_PARAMS=""
-SET_PARAMS+=" --set Core[SharedDataPath]=${TMP}"
-SET_PARAMS+=" --set Video-Rice[ResolutionWidth]=${SCREENWIDTH}"
 
 # Set the cores to use
 CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
@@ -67,10 +73,29 @@ else
     unset EMUPERF
 fi
 
+SET_PARAMS=""
+SET_PARAMS+=" --set Core[SharedDataPath]=${TMP}"
+
+# SIMPLECORE, decide which executable to use for simple64
+if [ "${SIMPLECORE}" = "simple" ]; then
+    SIMPLESUFFIX="-simple"
+    SET_PARAMS+=" --set Core[R4300Emulator]=1"
+else
+    SIMPLESUFFIX=""
+    SET_PARAMS+=" --set Core[R4300Emulator]=2"
+fi
+
+# Controller Pak
+SET_PARAMS+=" --set Input-SDL-Control1[plugin]=${PAK}"
+SET_PARAMS+=" --set Input-SDL-Control2[plugin]=${PAK}"
+SET_PARAMS+=" --set Input-SDL-Control3[plugin]=${PAK}"
+SET_PARAMS+=" --set Input-SDL-Control4[plugin]=${PAK}"
+
 # Aspect Ratio
 SET_PARAMS+=" --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
 SET_PARAMS+=" --set Video-Parallel[ScreenWidth]=${SCREENWIDTH}"
 SET_PARAMS+=" --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT}"
+SET_PARAMS+=" --set Video-Rice[ResolutionWidth]=${SCREENWIDTH}"
 if [ "${ASPECT}" = "fullscreen" ]; then
     # TODO: Set aspect ratio to fullscreen
     SET_PARAMS+=" --set Video-General[ScreenWidth]=${SCREENWIDTH}"
@@ -94,21 +119,6 @@ fi
 SET_PARAMS+=" --set Video-GLideN64[UseNativeResolutionFactor]=${IRES}"
 SET_PARAMS+=" --set Video-Parallel[Upscaling]=${IRES}"
 
-# Input Config
-if [ "${CON}" = "custom" ]; then
-    cp ${GAMEDATA}/custominput.ini ${TMP}/InputAutoCfg.ini
-elif [ "${CON}" = "standard" ]; then
-    cp ${SHARE}/default.ini ${TMP}/InputAutoCfg.ini
-else
-    cp ${SHARE}/default.ini ${TMP}/InputAutoCfg.ini
-fi
-
-# Controller Pak
-SET_PARAMS+=" --set Input-SDL-Control1[plugin]=${PAK}"
-SET_PARAMS+=" --set Input-SDL-Control2[plugin]=${PAK}"
-SET_PARAMS+=" --set Input-SDL-Control3[plugin]=${PAK}"
-SET_PARAMS+=" --set Input-SDL-Control4[plugin]=${PAK}"
-
 # Show FPS
 # Get configuration from system.cfg
 if [ "${FPS}" = "true" ]; then
@@ -123,15 +133,6 @@ else
     SET_PARAMS+=" --set Video-GLideN64[ShowFPS]=False"
     #SET_PARAMS+=" --set Video-Glide64mk2[show_fps]=0"
     #SET_PARAMS+=" --set Video-Rice[ShowFPS]=False"
-fi
-
-# SIMPLECORE, decide which executable to use for simple64
-if [ "${SIMPLECORE}" = "simple" ]; then
-    SIMPLESUFFIX="-simple"
-    SET_PARAMS+=" --set Core[R4300Emulator]=1"
-else
-    SIMPLESUFFIX=""
-    SET_PARAMS+=" --set Core[R4300Emulator]=2"
 fi
 
 # Set the video plugin

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -115,14 +115,14 @@ if [ "${FPS}" = "true" ]; then
     export LIBGL_SHOW_FPS="1"
     export GALLIUM_HUD="cpu+GPU-load+fps"
     SET_PARAMS+=" --set Video-GLideN64[ShowFPS]=True"
-    #SET_PARAMS+=" --set Video-Glide64mk2[show_fps]=1"
-    #SET_PARAMS+=" --set Video-Rice[ShowFPS]=True"
+    SET_PARAMS+=" --set Video-Glide64mk2[show_fps]=1"
+    SET_PARAMS+=" --set Video-Rice[ShowFPS]=True"
 else
     export LIBGL_SHOW_FPS="0"
     export GALLIUM_HUD="off"
     SET_PARAMS+=" --set Video-GLideN64[ShowFPS]=False"
-    #SET_PARAMS+=" --set Video-Glide64mk2[show_fps]=0"
-    #SET_PARAMS+=" --set Video-Rice[ShowFPS]=False"
+    SET_PARAMS+=" --set Video-Glide64mk2[show_fps]=0"
+    SET_PARAMS+=" --set Video-Rice[ShowFPS]=False"
 fi
 
 # Set the video plugin

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -50,7 +50,9 @@ else
 fi
 
 cp ${M64PCONF} ${TMP}
-SET_PARAMS="--set Core[SharedDataPath]=${TMP} --set Video-Rice[ResolutionWidth]=${SCREENWIDTH}"
+SET_PARAMS=""
+SET_PARAMS+=" --set Core[SharedDataPath]=${TMP}"
+SET_PARAMS+=" --set Video-Rice[ResolutionWidth]=${SCREENWIDTH}"
 
 # Set the cores to use
 CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
@@ -68,14 +70,27 @@ fi
 # Aspect Ratio
 if [ "${ASPECT}" = "fullscreen" ]; then
     # TODO: Set aspect ratio to fullscreen
-    SET_PARAMS+=" --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Glide64mk2[aspect]=2 --set Video-GLideN64[AspectRatio]=3 --set Video-Parallel[WidescreenStretch]=False"
+    SET_PARAMS+=" --set Video-General[ScreenWidth]=${SCREENWIDTH}"
+    SET_PARAMS+=" --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
+    SET_PARAMS+=" --set Video-Parallel[ScreenWidth]=${SCREENWIDTH}"
+    SET_PARAMS+=" --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT}"
+    SET_PARAMS+=" --set Video-Glide64mk2[aspect]=2"
+    SET_PARAMS+=" --set Video-GLideN64[AspectRatio]=3"
+    SET_PARAMS+=" --set Video-Parallel[WidescreenStretch]=False"
 else
     # TODO: Set aspect ratio to 4:3
     if [ "${VPLUGIN}" = "rice" ]; then
         GAMEWIDTH=$(((SCREENHEIGHT * 4) / 3))
-        SET_PARAMS+=" --set Video-General[ScreenWidth]=${GAMEWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
+        SET_PARAMS+=" --set Video-General[ScreenWidth]=${GAMEWIDTH}"
+        SET_PARAMS+=" --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
     else
-        SET_PARAMS+=" --set Video-General[ScreenWidth]=${SCREENWIDTH} --set Video-General[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[ScreenWidth]=${SCREENWIDTH} --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT} --set Video-Parallel[WidescreenStretch]=False --set Video-Glide64mk2[aspect]=0 --set Video-GLideN64[AspectRatio]=1"
+        SET_PARAMS+=" --set Video-General[ScreenWidth]=${SCREENWIDTH}"
+        SET_PARAMS+=" --set Video-General[ScreenHeight]=${SCREENHEIGHT}"
+        SET_PARAMS+=" --set Video-Parallel[ScreenWidth]=${SCREENWIDTH}"
+        SET_PARAMS+=" --set Video-Parallel[ScreenHeight]=${SCREENHEIGHT}"
+        SET_PARAMS+=" --set Video-Parallel[WidescreenStretch]=False"
+        SET_PARAMS+=" --set Video-Glide64mk2[aspect]=0"
+        SET_PARAMS+=" --set Video-GLideN64[AspectRatio]=1"
     fi
 fi
 


### PR DESCRIPTION
## Description

Mupen64plus-sa was not respecting the aspect ratio setting, when using the default video plugin.  The render was always being stretched to fullscreen.  Which did not make a good first impression to anyone trying mupen-sa.

With this fix, mupen64plus-sa now maintains 4:3 or fullscreen as the user requests, for the default video plugin.

I also tidied the mupen64plus-sa launch script.  I believe the script is more readable and easier to maintain now.  Commits broken down for reviewability.  Rationale is given in the commit messages.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Built and tested on my own device.  Verified all three aspect ratio settings, using the default video plugin, and when explicitly using Rice.

**Test Configuration**:
* Build OS name and version: RK3566-X55
* Docker (Y/N): Y
* JELOS Branch: dev

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
