### PR TITLE
Rgb10max3 deadzone enhancement

### DIFF
--- a/projects/Amlogic/packages/linux/patches/S922X/000-s922x-devices.patch
+++ b/projects/Amlogic/packages/linux/patches/S922X/000-s922x-devices.patch
@@ -3044,34 +3044,34 @@ diff -rupN linux.orig/drivers/input/joystick/odroid-gou-joypad.c linux/drivers/i
 +	int nbtn;
 +
 +	for (nbtn = 0; nbtn < joypad->chan_count; nbtn++) {
-+		struct bt_adc *adc = &joypad->adcs[nbtn];
++		struct bt_adc *adcx = &joypad->adcs[nbtn];
 +
-+		adc->value = joypad_adc_read(joypad, adc);
-+		if (!adc->value) {
++		adcx->value = joypad_adc_read(joypad, adcx);
++		if (!adcx->value) {
 +			dev_err(joypad->dev, "%s : saradc channels[%d]!\n",
 +				__func__, nbtn);
 +			continue;
 +		}
-+		adc->value = adc->value - adc->cal;
++		adcx->value = adcx->value - adcx->cal;
 +
 +		/* Joystick Deadzone check */
 +		if (joypad->bt_adc_deadzone) {
-+			if (abs(adc->value) < joypad->bt_adc_deadzone)
-+				adc->value = 0;
++			if (abs(adcx->value) < joypad->bt_adc_deadzone)
++				adcx->value = 0;
 +		}
 +
 +		/* adc data tuning */
-+		if (adc->tuning_n && adc->value < 0)
-+			adc->value = ADC_DATA_TUNING(adc->value, adc->tuning_n);
-+		if (adc->tuning_p && adc->value > 0)
-+			adc->value = ADC_DATA_TUNING(adc->value, adc->tuning_p);
++		if (adcx->tuning_n && adcx->value < 0)
++			adcx->value = ADC_DATA_TUNING(adcx->value, adcx->tuning_n);
++		if (adcx->tuning_p && adcx->value > 0)
++			adcx->value = ADC_DATA_TUNING(adcx->value, adcx->tuning_p);
 +
-+		adc->value = adc->value > adc->max ? adc->max : adc->value;
-+		adc->value = adc->value < adc->min ? adc->min : adc->value;
++		adcx->value = adcx->value > adcx->max ? adcx->max : adcx->value;
++		adcx->value = adcx->value < adcx->min ? adcx->min : adcx->value;
 +
 +		input_report_abs(poll_dev->input,
-+			adc->report_type,
-+			adc->invert ? adc->value * (-1) : adc->value);
++			adcx->report_type,
++			adcx->invert ? adcx->value * (-1) : adcx->value);
 +	}
 +	input_sync(poll_dev->input);
 +}

--- a/projects/Amlogic/packages/linux/patches/S922X/000-s922x-devices.patch
+++ b/projects/Amlogic/packages/linux/patches/S922X/000-s922x-devices.patch
@@ -2652,7 +2652,7 @@ diff -rupN linux.orig/drivers/input/joystick/amlogic-saradc.h linux/drivers/inpu
 diff -rupN linux.orig/drivers/input/joystick/odroid-gou-joypad.c linux/drivers/input/joystick/odroid-gou-joypad.c
 --- linux.orig/drivers/input/joystick/odroid-gou-joypad.c	1970-01-01 00:00:00.000000000 +0000
 +++ linux/drivers/input/joystick/odroid-gou-joypad.c	2023-09-12 12:03:27.490291628 +0000
-@@ -0,0 +1,959 @@
+@@ -0,0 +1,960 @@
 +/*----------------------------------------------------------------------------*/
 +#include <linux/kernel.h>
 +#include <linux/module.h>
@@ -3078,8 +3078,9 @@ diff -rupN linux.orig/drivers/input/joystick/odroid-gou-joypad.c linux/drivers/i
 +			}
 +			else {
 +				/* Assumes adcx->max == -adcx->min == adcy->max == -adcy->min */
-+				adcx->value = (adcx->max * adcx->value * (mag - joypad->bt_adc_deadzone)) / (mag * (adcx->max - joypad->bt_adc_deadzone));
-+				adcy->value = (adcy->max * adcy->value * (mag - joypad->bt_adc_deadzone)) / (mag * (adcy->max - joypad->bt_adc_deadzone));
++				/* Order of operations is critical to avoid integer overflow */
++				adcx->value = (((adcx->max * adcx->value) / mag) * (mag - joypad->bt_adc_deadzone)) / (adcx->max - joypad->bt_adc_deadzone);
++				adcy->value = (((adcy->max * adcy->value) / mag) * (mag - joypad->bt_adc_deadzone)) / (adcy->max - joypad->bt_adc_deadzone);
 +			}
 +		}
 +

--- a/projects/Amlogic/packages/linux/patches/S922X/000-s922x-devices.patch
+++ b/projects/Amlogic/packages/linux/patches/S922X/000-s922x-devices.patch
@@ -2652,7 +2652,7 @@ diff -rupN linux.orig/drivers/input/joystick/amlogic-saradc.h linux/drivers/inpu
 diff -rupN linux.orig/drivers/input/joystick/odroid-gou-joypad.c linux/drivers/input/joystick/odroid-gou-joypad.c
 --- linux.orig/drivers/input/joystick/odroid-gou-joypad.c	1970-01-01 00:00:00.000000000 +0000
 +++ linux/drivers/input/joystick/odroid-gou-joypad.c	2023-09-12 12:03:27.490291628 +0000
-@@ -0,0 +1,950 @@
+@@ -0,0 +1,959 @@
 +/*----------------------------------------------------------------------------*/
 +#include <linux/kernel.h>
 +#include <linux/module.h>
@@ -3042,6 +3042,7 @@ diff -rupN linux.orig/drivers/input/joystick/odroid-gou-joypad.c linux/drivers/i
 +{
 +	struct joypad *joypad = poll_dev->private;
 +	int nbtn;
++	int mag;
 +
 +	/* Assumes an even number of axes and that joystick axis pairs are sequential */
 +	/* e.g. left stick Y immediately follows left stick X */
@@ -3067,12 +3068,19 @@ diff -rupN linux.orig/drivers/input/joystick/odroid-gou-joypad.c linux/drivers/i
 +		}
 +		adcy->value = adcy->value - adcy->cal;
 +
-+		/* Joystick Deadzone check */
++		/* Scaled Radial Deadzone */
++		/* https://web.archive.org/web/20190129113357/http://www.third-helix.com/2013/04/12/doing-thumbstick-dead-zones-right.html */
++		mag = int_sqrt((adcx->value * adcx->value) + (adcy->value * adcy->value));
 +		if (joypad->bt_adc_deadzone) {
-+			if (abs(adcx->value) < joypad->bt_adc_deadzone)
++			if (mag <= joypad->bt_adc_deadzone) {
 +				adcx->value = 0;
-+			if (abs(adcy->value) < joypad->bt_adc_deadzone)
 +				adcy->value = 0;
++			}
++			else {
++				/* Assumes adcx->max == -adcx->min == adcy->max == -adcy->min */
++				adcx->value = (adcx->max * adcx->value * (mag - joypad->bt_adc_deadzone)) / (mag * (adcx->max - joypad->bt_adc_deadzone));
++				adcy->value = (adcy->max * adcy->value * (mag - joypad->bt_adc_deadzone)) / (mag * (adcy->max - joypad->bt_adc_deadzone));
++			}
 +		}
 +
 +		/* adc data tuning */
@@ -3085,6 +3093,7 @@ diff -rupN linux.orig/drivers/input/joystick/odroid-gou-joypad.c linux/drivers/i
 +		if (adcy->tuning_p && adcy->value > 0)
 +			adcy->value = ADC_DATA_TUNING(adcy->value, adcy->tuning_p);
 +
++		/* Clamp to [min, max] */
 +		adcx->value = adcx->value > adcx->max ? adcx->max : adcx->value;
 +		adcx->value = adcx->value < adcx->min ? adcx->min : adcx->value;
 +		adcy->value = adcy->value > adcy->max ? adcy->max : adcy->value;

--- a/projects/Amlogic/packages/linux/patches/S922X/000-s922x-devices.patch
+++ b/projects/Amlogic/packages/linux/patches/S922X/000-s922x-devices.patch
@@ -2652,7 +2652,7 @@ diff -rupN linux.orig/drivers/input/joystick/amlogic-saradc.h linux/drivers/inpu
 diff -rupN linux.orig/drivers/input/joystick/odroid-gou-joypad.c linux/drivers/input/joystick/odroid-gou-joypad.c
 --- linux.orig/drivers/input/joystick/odroid-gou-joypad.c	1970-01-01 00:00:00.000000000 +0000
 +++ linux/drivers/input/joystick/odroid-gou-joypad.c	2023-09-12 12:03:27.490291628 +0000
-@@ -0,0 +1,926 @@
+@@ -0,0 +1,950 @@
 +/*----------------------------------------------------------------------------*/
 +#include <linux/kernel.h>
 +#include <linux/module.h>
@@ -3043,9 +3043,13 @@ diff -rupN linux.orig/drivers/input/joystick/odroid-gou-joypad.c linux/drivers/i
 +	struct joypad *joypad = poll_dev->private;
 +	int nbtn;
 +
-+	for (nbtn = 0; nbtn < joypad->chan_count; nbtn++) {
++	/* Assumes an even number of axes and that joystick axis pairs are sequential */
++	/* e.g. left stick Y immediately follows left stick X */
++	for (nbtn = 0; nbtn < joypad->chan_count; nbtn += 2) {
 +		struct bt_adc *adcx = &joypad->adcs[nbtn];
++		struct bt_adc *adcy = &joypad->adcs[nbtn + 1];
 +
++		/* Read first joystick axis */
 +		adcx->value = joypad_adc_read(joypad, adcx);
 +		if (!adcx->value) {
 +			dev_err(joypad->dev, "%s : saradc channels[%d]!\n",
@@ -3054,10 +3058,21 @@ diff -rupN linux.orig/drivers/input/joystick/odroid-gou-joypad.c linux/drivers/i
 +		}
 +		adcx->value = adcx->value - adcx->cal;
 +
++		/* Read second joystick axis */
++		adcy->value = joypad_adc_read(joypad, adcy);
++		if (!adcy->value) {
++			dev_err(joypad->dev, "%s : saradc channels[%d]!\n",
++				__func__, nbtn + 1);
++			continue;
++		}
++		adcy->value = adcy->value - adcy->cal;
++
 +		/* Joystick Deadzone check */
 +		if (joypad->bt_adc_deadzone) {
 +			if (abs(adcx->value) < joypad->bt_adc_deadzone)
 +				adcx->value = 0;
++			if (abs(adcy->value) < joypad->bt_adc_deadzone)
++				adcy->value = 0;
 +		}
 +
 +		/* adc data tuning */
@@ -3065,13 +3080,22 @@ diff -rupN linux.orig/drivers/input/joystick/odroid-gou-joypad.c linux/drivers/i
 +			adcx->value = ADC_DATA_TUNING(adcx->value, adcx->tuning_n);
 +		if (adcx->tuning_p && adcx->value > 0)
 +			adcx->value = ADC_DATA_TUNING(adcx->value, adcx->tuning_p);
++		if (adcy->tuning_n && adcy->value < 0)
++			adcy->value = ADC_DATA_TUNING(adcy->value, adcy->tuning_n);
++		if (adcy->tuning_p && adcy->value > 0)
++			adcy->value = ADC_DATA_TUNING(adcy->value, adcy->tuning_p);
 +
 +		adcx->value = adcx->value > adcx->max ? adcx->max : adcx->value;
 +		adcx->value = adcx->value < adcx->min ? adcx->min : adcx->value;
++		adcy->value = adcy->value > adcy->max ? adcy->max : adcy->value;
++		adcy->value = adcy->value < adcy->min ? adcy->min : adcy->value;
 +
 +		input_report_abs(poll_dev->input,
 +			adcx->report_type,
 +			adcx->invert ? adcx->value * (-1) : adcx->value);
++		input_report_abs(poll_dev->input,
++			adcy->report_type,
++			adcy->invert ? adcy->value * (-1) : adcy->value);
 +	}
 +	input_sync(poll_dev->input);
 +}


### PR DESCRIPTION
## Description

This should enhance the "smoothness" of the analog sticks for S922X devices.  This work was spurred by observations of these two discord posts:
https://discord.com/channels/948029830325235753/1035228339952160878/1150892704704762006
https://discord.com/channels/948029830325235753/1035228339952160878/1150983965285568592

I do not have ~~any of these devices~~ the OGU to test on, so **_I would appreciate if other(s) in the community could verify the improvement_** before this is merged.  I recommend using the PPSSPP calibration tool (or similar) to verify the before/after behavior.  If I understand correctly, this impacts all S922X devices.

The problem is that the HK OGU joystick driver uses an overly simple algorithm to implement deadzone.  Here is how it originally remaps analog inputs before they are ingested by the kernel input handling:
![remap0](https://github.com/JustEnoughLinuxOS/distribution/assets/2266445/4e638e82-e097-42af-8221-363a0327354f)
This leads to a few problems.
- strong snapping (loss of precision/accuracy) in the cardinal directions
- step change in signal when stick crosses deadzone boundary
- no guarantee that corners can be reached

I updated the algorithm to use "scaled radial deadzone", which addresses all three problems.  Code comments contain a reference link for posterity.
![remap3](https://github.com/JustEnoughLinuxOS/distribution/assets/2266445/c1d9607b-62da-4332-9c6e-10458a43968b)

I should mention that I stuck with integer math only (e.g. `int_sqrt`) because that's all I saw in the mainline kernel source for all these joystick drivers.  No floats or doubles...

I also had to make some assumptions about the number and order of analog axes.  I listed those assumptions directly in the code comments.  If someone ever needed to port this to another device tree, hopefully they'd notice the assumptions and make sure they apply to the new device.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

I was only able to test the mathematics in theory using Matlab.  I also verified the patch builds (no typos).

Update: I have since obtained an RGB10Max3 Pro and verified behavior on that device.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas