### PR TITLE
Update opus version to 1.4

### DIFF
--- a/packages/multimedia/opus/package.mk
+++ b/packages/multimedia/opus/package.mk
@@ -18,6 +18,12 @@ PKG_BUILD_FLAGS="+pic"
 #  PKG_FIXED_POINT="--disable-fixed-point"
 #fi
 
+#if [ "${TARGET_ARCH}" = "x86_64" ]; then
+  PKG_SHARED_LIBRARY="--enable-shared"
+#else
+#  PKG_SHARED_LIBRARY="--disable-shared"
+#fi
+
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
-                           --disable-shared \
+                           $PKG_SHARED_LIBRARY \
                            $PKG_FIXED_POINT"

--- a/packages/multimedia/opus/package.mk
+++ b/packages/multimedia/opus/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="opus"
-PKG_VERSION="1.3.1"
-PKG_SHA256="65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d"
+PKG_VERSION="1.4"
+PKG_SHA256="c9b32b4253be5ae63d1ff16eea06b94b5f0f2951b7a02aceef58e3a3ce49c51f"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.opus-codec.org"
-PKG_URL="https://archive.mozilla.org/pub/opus/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_URL="https://downloads.xiph.org/releases/opus/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Codec designed for interactive speech and audio transmission over the Internet."
 PKG_TOOLCHAIN="configure"


### PR DESCRIPTION
## Description

Change opus package.mk URL to xiph.org for more up to date package and bump version to 1.4 to fix audio decode in moonlight.

Fixes # opus_multistream_decode segfault on opus 1.3.1

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested audio decode with a moonlight-qt on JELOS by playing a youtube video over a desktop stream.
- [X] Tested audio decode on JELOS/dev using default moonlight-embedded package and streaming a youtube video over a desktop stream.
- Notably have not tested any emulators that might rely on opus.

**Test Configuration**:
* Build OS name and version: AMD64
* Docker (Y/N): Y
* JELOS Branch: dev
* Any additional information that may be useful: Maybe consider switching to moonlight-qt for AMD64 builds to support hardware video decode as well?

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
