### PR TITLE
make brightness adjust with inverse log instead of linear

### DIFF
--- a/packages/jelos/sources/scripts/brightness
+++ b/packages/jelos/sources/scripts/brightness
@@ -8,15 +8,16 @@
 
 BRIGHTNESS_DEV="$(find /sys/class/backlight/*/ -name brightness -print -quit)"
 BRIGHTNESS_PATH="${BRIGHTNESS_DEV%/brightness}"
+BRIGHTNESS_TABLE=($(get_setting brightness_table))
+if [ -z $BRIGHTNESS_TABLE ]; then
+  BRIGHTNESS_TABLE="0 0.04 0.08 0.13 0.19 0.25 0.33 0.42 0.54 0.71 1"
+  set_setting brightness_table "$BRIGHTNESS_TABLE"
+fi
+NUM_STEPS=${#BRIGHTNESS_TABLE[@]}
 
-MIN=0
 MAX=$(<$(find /sys/class/backlight/*/ -name max_brightness -print -quit))
-NUM_STEPS=10
-eqn() {
-  echo "(l(1.0+$NUM_STEPS-$NEXT)/l(1.0+$NUM_STEPS))"
-}
 compute() {
-  echo "x=$MAX+0.5-(($MAX-$MIN)*$(eqn$1)); scale=0; x/1" | bc -l
+  echo "${BRIGHTNESS_TABLE[$NEXT]} * $MAX" | bc -l
 }
 
 if [ ! -f "${BRIGHTNESS_DEV}" ]
@@ -37,12 +38,16 @@ setBrightness() {
 stepUp() {
   CURRENT=$(get_setting system.brightness)
   NEXT=$(( ${CURRENT} + 1 ))
-  if (( ${NEXT} > 10 ))
+  if (( ${NEXT} >= $NUM_STEPS ))
   then
-    NEXT=10
+    NEXT=$(( $NUM_STEPS - 1 ))
   fi
 
   BRIGHTNESS=$(printf '%.0f' "$(compute)")
+  if (($BRIGHTNESS > $MAX ))
+  then
+    BRIGHTNESS=$MAX
+  fi
 
   setBrightness ${BRIGHTNESS} ${NEXT}
 }
@@ -75,7 +80,7 @@ case ${1} in
         ;;
         "set")
           NEXT=${2}
-           setBrightness "$(printf '%.0f' "$(compute)")" ${2}
+          setBrightness "$(printf '%.0f' "$(compute)")" ${2}
         ;;
         *)
           echo $(getBrightness)

--- a/packages/jelos/sources/scripts/brightness
+++ b/packages/jelos/sources/scripts/brightness
@@ -11,7 +11,13 @@ BRIGHTNESS_PATH="${BRIGHTNESS_DEV%/brightness}"
 
 MIN=0
 MAX=$(<$(find /sys/class/backlight/*/ -name max_brightness -print -quit))
-STEP="$(echo "scale=1; (${MAX} / 10)" | bc)"
+NUM_STEPS=10
+eqn() {
+  echo "(l(1.0+$NUM_STEPS-$NEXT)/l(1.0+$NUM_STEPS))"
+}
+compute() {
+  echo "x=$MAX+0.5-(($MAX-$MIN)*$(eqn$1)); scale=0; x/1" | bc -l
+}
 
 if [ ! -f "${BRIGHTNESS_DEV}" ]
 then
@@ -36,7 +42,7 @@ stepUp() {
     NEXT=10
   fi
 
-  BRIGHTNESS=$(printf '%.0f' "$(echo "scale=1; ${STEP} * ${NEXT}" | bc)")
+  BRIGHTNESS=$(printf '%.0f' "$(compute)")
 
   setBrightness ${BRIGHTNESS} ${NEXT}
 }
@@ -49,7 +55,7 @@ stepDown() {
     NEXT=0
   fi
 
-  BRIGHTNESS=$(printf '%.0f' "$(echo "scale=1; ${STEP} * ${NEXT}" | bc)")
+  BRIGHTNESS=$(printf '%.0f' "$(compute)")
 
   setBrightness ${BRIGHTNESS} ${NEXT}
 }
@@ -68,7 +74,8 @@ case ${1} in
           echo ${BRIGHTNESS_PATH}
         ;;
         "set")
-           setBrightness "$(printf '%.0f' "$(echo "scale=1; ${STEP} * ${2}" | bc)")" ${2}
+          NEXT=${2}
+           setBrightness "$(printf '%.0f' "$(compute)")" ${2}
         ;;
         *)
           echo $(getBrightness)

--- a/packages/ui/emulationstation/patches/001-tweak-brightness.patch
+++ b/packages/ui/emulationstation/patches/001-tweak-brightness.patch
@@ -12,15 +12,17 @@ index e37b6c9..8b75358 100644
  
  	if (mLoadingNext)
 diff --git a/es-app/src/guis/GuiMenu.cpp b/es-app/src/guis/GuiMenu.cpp
-index a327ea0..c67dc02 100644
+index a327ea0..2181ddc 100644
 --- a/es-app/src/guis/GuiMenu.cpp
 +++ b/es-app/src/guis/GuiMenu.cpp
-@@ -1180,11 +1180,11 @@ void GuiMenu::openSystemSettings_batocera()
+@@ -1180,11 +1180,13 @@ void GuiMenu::openSystemSettings_batocera()
  	{
  		// brightness
  		int brightness = BrightnessControl::getInstance()->getBrightness();
 -		auto brightnessComponent = std::make_shared<SliderComponent>(mWindow, 0.f, 100.f, 10.f, "%");
-+		auto brightnessComponent = std::make_shared<SliderComponent>(mWindow, 0.f, 10.f, 1.f, "/10");
++    float brightness_count = BrightnessControl::getInstance()->getNumBrightness() - 1;
++    std::string brightness_count_str = "/" + std::to_string((int)brightness_count) + "  ";
++		auto brightnessComponent = std::make_shared<SliderComponent>(mWindow, 0.f, brightness_count, 1.f, brightness_count_str);
  		brightnessComponent->setValue(brightness);
  		brightnessComponent->setOnValueChanged([](const float &newVal) {
  			BrightnessControl::getInstance()->setBrightness((int)Math::round(newVal));
@@ -30,10 +32,14 @@ index a327ea0..c67dc02 100644
  
  		s->addWithLabel(_("BRIGHTNESS"), brightnessComponent);
 diff --git a/es-core/src/BrightnessControl.cpp b/es-core/src/BrightnessControl.cpp
-index 706358f..6f98c9a 100644
+index 706358f..2373fbb 100644
 --- a/es-core/src/BrightnessControl.cpp
 +++ b/es-core/src/BrightnessControl.cpp
-@@ -7,6 +7,7 @@
+@@ -4,13 +4,16 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <string.h>
++#include <sstream>
  #include <SystemConf.h>
  #include <unistd.h>
  #include "platform.h"
@@ -41,7 +47,24 @@ index 706358f..6f98c9a 100644
  
  std::string BACKLIGHT_PATH = std::string(getShOutput(R"(/usr/bin/brightness path)"));
  std::string BACKLIGHT_BRIGHTNESS_NAME = BACKLIGHT_PATH + "/brightness";
-@@ -57,19 +58,9 @@ int BrightnessControl::getBrightness() const
+ std::string BACKLIGHT_BRIGHTNESS_MAX_NAME = BACKLIGHT_PATH + "/max_brightness";
++std::vector<float> brightness_table = {0, 1};
+ #define BACKLIGHT_BUFFER_SIZE 127
+ 
+ std::weak_ptr<BrightnessControl> BrightnessControl::sInstance;
+@@ -29,6 +32,11 @@ std::shared_ptr<BrightnessControl> &BrightnessControl::getInstance()
+ 
+ BrightnessControl::BrightnessControl() {}
+ 
++int BrightnessControl::getNumBrightness() const
++{
++  return brightness_table.size();
++}
++
+ int BrightnessControl::getBrightness() const
+ {
+ #ifdef WIN32
+@@ -57,19 +65,21 @@ int BrightnessControl::getBrightness() const
      if (max == 0)
          return 0;
  
@@ -50,39 +73,63 @@ index 706358f..6f98c9a 100644
 -        return false;
 -
 -    memset(buffer, 0, BACKLIGHT_BUFFER_SIZE + 1);
--
++    SystemConf::getInstance()->loadSystemConf();
+ 
 -    count = read(fd, buffer, BACKLIGHT_BUFFER_SIZE);
 -    if (count > 0)
 -        value = atoi(buffer);
 -
 -    close(fd);
--
++    std::stringstream ss(SystemConf::getInstance()->get("brightness_table"));
++    brightness_table.clear();
++    float b_val;
++    while (ss >> b_val) {
++      brightness_table.push_back(b_val);
++    }
++    //TODO: need to make a rational initial condition -- this should always be populated by the brightness script on boot??
++    if (brightness_table.empty()) {
++      brightness_table = {0, 0.04, 0.08, 0.13, 0.19, 0.25, 0.33, 0.42, 0.54, 0.71, 1};
++    }
+ 
 -    value = (uint32_t)((value / (float)max * 100.0f) + 0.5f);
-+    SystemConf::getInstance()->loadSystemConf();
 +		auto sysbright = SystemConf::getInstance()->get("system.brightness");
 +    value = stoi(sysbright);
      return value;
  }
  
-@@ -82,8 +73,8 @@ void BrightnessControl::setBrightness(int value)
+@@ -82,8 +92,8 @@ void BrightnessControl::setBrightness(int value)
      if (value < 0)
          value = 0;
  
 -    if (value > 100)
 -        value = 100;
-+    if (value > 10)
-+        value = 10;
++    if (value >= brightness_table.size())
++        value = brightness_table.size() - 1;
  
      int fd;
      int max = 100;
-@@ -109,8 +100,8 @@ void BrightnessControl::setBrightness(int value)
+@@ -109,8 +119,10 @@ void BrightnessControl::setBrightness(int value)
      if (fd < 0)
          return;
  
 -    float percent = (value / 100.0f * (float)max) + 0.5f;
 -    sprintf(buffer, "%d\n", (uint32_t)percent);
-+    float val = (max - (max * (log(11-value)/log(11)))) + 0.5f;
++    float val = max * brightness_table[value] ;
++    if (val > max)
++        val = max;
 +    sprintf(buffer, "%d\n", (uint32_t)val);
  
      count = write(fd, buffer, strlen(buffer));
      if (count < 0)
+diff --git a/es-core/src/BrightnessControl.h b/es-core/src/BrightnessControl.h
+index b527b31..6ad3559 100644
+--- a/es-core/src/BrightnessControl.h
++++ b/es-core/src/BrightnessControl.h
+@@ -21,6 +21,7 @@ public:
+     bool isAvailable();
+ 
+     int getBrightness() const;
++    int getNumBrightness() const;
+     void setBrightness(int Brightness);
+ };
+ 

--- a/packages/ui/emulationstation/patches/001-tweak-brightness.patch
+++ b/packages/ui/emulationstation/patches/001-tweak-brightness.patch
@@ -30,7 +30,7 @@ index a327ea0..c67dc02 100644
  
  		s->addWithLabel(_("BRIGHTNESS"), brightnessComponent);
 diff --git a/es-core/src/BrightnessControl.cpp b/es-core/src/BrightnessControl.cpp
-index 706358f..ea38de1 100644
+index 706358f..6f98c9a 100644
 --- a/es-core/src/BrightnessControl.cpp
 +++ b/es-core/src/BrightnessControl.cpp
 @@ -7,6 +7,7 @@
@@ -41,10 +41,22 @@ index 706358f..ea38de1 100644
  
  std::string BACKLIGHT_PATH = std::string(getShOutput(R"(/usr/bin/brightness path)"));
  std::string BACKLIGHT_BRIGHTNESS_NAME = BACKLIGHT_PATH + "/brightness";
-@@ -69,7 +70,9 @@ int BrightnessControl::getBrightness() const
+@@ -57,19 +58,9 @@ int BrightnessControl::getBrightness() const
+     if (max == 0)
+         return 0;
  
-     close(fd);
- 
+-    fd = open(BACKLIGHT_BRIGHTNESS_NAME.c_str(), O_RDONLY);
+-    if (fd < 0)
+-        return false;
+-
+-    memset(buffer, 0, BACKLIGHT_BUFFER_SIZE + 1);
+-
+-    count = read(fd, buffer, BACKLIGHT_BUFFER_SIZE);
+-    if (count > 0)
+-        value = atoi(buffer);
+-
+-    close(fd);
+-
 -    value = (uint32_t)((value / (float)max * 100.0f) + 0.5f);
 +    SystemConf::getInstance()->loadSystemConf();
 +		auto sysbright = SystemConf::getInstance()->get("system.brightness");
@@ -52,7 +64,7 @@ index 706358f..ea38de1 100644
      return value;
  }
  
-@@ -82,8 +85,8 @@ void BrightnessControl::setBrightness(int value)
+@@ -82,8 +73,8 @@ void BrightnessControl::setBrightness(int value)
      if (value < 0)
          value = 0;
  
@@ -63,7 +75,7 @@ index 706358f..ea38de1 100644
  
      int fd;
      int max = 100;
-@@ -109,8 +112,8 @@ void BrightnessControl::setBrightness(int value)
+@@ -109,8 +100,8 @@ void BrightnessControl::setBrightness(int value)
      if (fd < 0)
          return;
  

--- a/packages/ui/emulationstation/patches/001-tweak-brightness.patch
+++ b/packages/ui/emulationstation/patches/001-tweak-brightness.patch
@@ -1,3 +1,16 @@
+diff --git a/es-app/src/SystemScreenSaver.cpp b/es-app/src/SystemScreenSaver.cpp
+index e37b6c9..8b75358 100644
+--- a/es-app/src/SystemScreenSaver.cpp
++++ b/es-app/src/SystemScreenSaver.cpp
+@@ -184,7 +184,7 @@ void SystemScreenSaver::stopScreenSaver()
+ 	if ( screensaver_behavior == "black" )
+ 	{
+ 		auto sysbright = SystemConf::getInstance()->get("system.brightness");
+-		BrightnessControl::getInstance()->setBrightness(stoi(sysbright) * 10);
++		BrightnessControl::getInstance()->setBrightness(stoi(sysbright));
+ 	}
+ 
+ 	if (mLoadingNext)
 diff --git a/es-app/src/guis/GuiMenu.cpp b/es-app/src/guis/GuiMenu.cpp
 index a327ea0..c67dc02 100644
 --- a/es-app/src/guis/GuiMenu.cpp
@@ -17,7 +30,7 @@ index a327ea0..c67dc02 100644
  
  		s->addWithLabel(_("BRIGHTNESS"), brightnessComponent);
 diff --git a/es-core/src/BrightnessControl.cpp b/es-core/src/BrightnessControl.cpp
-index 706358f..5dd2995 100644
+index 706358f..ea38de1 100644
 --- a/es-core/src/BrightnessControl.cpp
 +++ b/es-core/src/BrightnessControl.cpp
 @@ -7,6 +7,7 @@
@@ -28,16 +41,18 @@ index 706358f..5dd2995 100644
  
  std::string BACKLIGHT_PATH = std::string(getShOutput(R"(/usr/bin/brightness path)"));
  std::string BACKLIGHT_BRIGHTNESS_NAME = BACKLIGHT_PATH + "/brightness";
-@@ -69,7 +70,7 @@ int BrightnessControl::getBrightness() const
+@@ -69,7 +70,9 @@ int BrightnessControl::getBrightness() const
  
      close(fd);
  
 -    value = (uint32_t)((value / (float)max * 100.0f) + 0.5f);
-+    value = (uint32_t)(11-exp(((max+0.5-value)/max)*log(11)) + 0.5f);
++    SystemConf::getInstance()->loadSystemConf();
++		auto sysbright = SystemConf::getInstance()->get("system.brightness");
++    value = stoi(sysbright);
      return value;
  }
  
-@@ -82,8 +83,8 @@ void BrightnessControl::setBrightness(int value)
+@@ -82,8 +85,8 @@ void BrightnessControl::setBrightness(int value)
      if (value < 0)
          value = 0;
  
@@ -48,7 +63,7 @@ index 706358f..5dd2995 100644
  
      int fd;
      int max = 100;
-@@ -109,8 +110,8 @@ void BrightnessControl::setBrightness(int value)
+@@ -109,8 +112,8 @@ void BrightnessControl::setBrightness(int value)
      if (fd < 0)
          return;
  

--- a/packages/ui/emulationstation/patches/001-tweak-brightness.patch
+++ b/packages/ui/emulationstation/patches/001-tweak-brightness.patch
@@ -1,0 +1,61 @@
+diff --git a/es-app/src/guis/GuiMenu.cpp b/es-app/src/guis/GuiMenu.cpp
+index a327ea0..c67dc02 100644
+--- a/es-app/src/guis/GuiMenu.cpp
++++ b/es-app/src/guis/GuiMenu.cpp
+@@ -1180,11 +1180,11 @@ void GuiMenu::openSystemSettings_batocera()
+ 	{
+ 		// brightness
+ 		int brightness = BrightnessControl::getInstance()->getBrightness();
+-		auto brightnessComponent = std::make_shared<SliderComponent>(mWindow, 0.f, 100.f, 10.f, "%");
++		auto brightnessComponent = std::make_shared<SliderComponent>(mWindow, 0.f, 10.f, 1.f, "/10");
+ 		brightnessComponent->setValue(brightness);
+ 		brightnessComponent->setOnValueChanged([](const float &newVal) {
+ 			BrightnessControl::getInstance()->setBrightness((int)Math::round(newVal));
+-                        SystemConf::getInstance()->set("system.brightness", std::to_string((int)Math::round(newVal) / 10));
++                        SystemConf::getInstance()->set("system.brightness", std::to_string((int)newVal));
+ 		});
+ 
+ 		s->addWithLabel(_("BRIGHTNESS"), brightnessComponent);
+diff --git a/es-core/src/BrightnessControl.cpp b/es-core/src/BrightnessControl.cpp
+index 706358f..5dd2995 100644
+--- a/es-core/src/BrightnessControl.cpp
++++ b/es-core/src/BrightnessControl.cpp
+@@ -7,6 +7,7 @@
+ #include <SystemConf.h>
+ #include <unistd.h>
+ #include "platform.h"
++#include <math.h>
+ 
+ std::string BACKLIGHT_PATH = std::string(getShOutput(R"(/usr/bin/brightness path)"));
+ std::string BACKLIGHT_BRIGHTNESS_NAME = BACKLIGHT_PATH + "/brightness";
+@@ -69,7 +70,7 @@ int BrightnessControl::getBrightness() const
+ 
+     close(fd);
+ 
+-    value = (uint32_t)((value / (float)max * 100.0f) + 0.5f);
++    value = (uint32_t)(11-exp(((max+0.5-value)/max)*log(11)) + 0.5f);
+     return value;
+ }
+ 
+@@ -82,8 +83,8 @@ void BrightnessControl::setBrightness(int value)
+     if (value < 0)
+         value = 0;
+ 
+-    if (value > 100)
+-        value = 100;
++    if (value > 10)
++        value = 10;
+ 
+     int fd;
+     int max = 100;
+@@ -109,8 +110,8 @@ void BrightnessControl::setBrightness(int value)
+     if (fd < 0)
+         return;
+ 
+-    float percent = (value / 100.0f * (float)max) + 0.5f;
+-    sprintf(buffer, "%d\n", (uint32_t)percent);
++    float val = (max - (max * (log(11-value)/log(11)))) + 0.5f;
++    sprintf(buffer, "%d\n", (uint32_t)val);
+ 
+     count = write(fd, buffer, strlen(buffer));
+     if (count < 0)


### PR DESCRIPTION
# Pull Request Template

## Description

This code changes the brightness to weight the lower end of the brightness range more heavily than the upper end of the range. There are two main new functions added for possible future tweaks if a different ratio was found to be desirable:
eqn() - an equation that calculates the size of any given step
compute() - takes eqn() and scales it into the functional brightness range (MAX - MIN), then performs a ceiling operation

If the original behavior were desired, for instance, you could just change eqn to 1-(STEP/MAX).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

I built dev with and without my change and flashed to 2 separate sd cards and booted a RG353V with each. The minimum brightness appeared ~50% as bright as the existing dev. I only have one device so it was a very subjective test.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
