### PR TITLE
Misc updates (Fan/Temp readings, PCSX2 defaults)

### DIFF
--- a/documentation/PER_DEVICE_DOCUMENTATION/AMD64/SUPPORTED_EMULATORS_AND_CORES.md
+++ b/documentation/PER_DEVICE_DOCUMENTATION/AMD64/SUPPORTED_EMULATORS_AND_CORES.md
@@ -112,7 +112,7 @@ This document describes all available systems emulators and cores available for 
 |SNK|Neo Geo Pocket (ngp)|1998|`ngp`|.ngc .ngp .zip .7z|**retroarch:** beetle_ngp (default)<br>**retroarch:** race<br>|
 |SNK|Neo Geo Pocket Color (ngpc)|1999|`ngpc`|.ngc .zip .7z|**retroarch:** beetle_ngp (default)<br>**retroarch:** race<br>|
 |Sony|PlayStation (psx)|1994|`psx`|.bin .cue .img .mdf .pbp .toc .cbn .m3u .ccd .chd .iso|**retroarch:** beetle_psx (default)<br>**Duckstation:** duckstation-sa<br>**retroarch:** duckstation<br>**retroarch:** swanstation<br>|
-|Sony|PlayStation 2 (ps2)|2000|`ps2`|.iso .mdf .nrg .bin .img .dump .gz .cso .chd|**retroarch:** pcsx2 (default)<br>**pcsx2:** pcsx2-sa<br>|
+|Sony|PlayStation 2 (ps2)|2000|`ps2`|.iso .mdf .nrg .bin .img .dump .gz .cso .chd|**pcsx2:** pcsx2-sa (default)<br>**retroarch:** pcsx2<br>|
 |Sony|PlayStation 3 (ps3)|2006|`ps3`|.ps3 .bin|**rpcs3:** rpcs3-sa (default)<br>|
 |Sony|PlayStation Portable (psp)|2004|`psp`|.iso .cso .pbp|**ppsspp:** ppsspp-sa (default)<br>**retroarch:** ppsspp<br>|
 |Sony|PlayStation Vita (psvita)|2011|`launcher`|.sh|**vita3k:** vita3k-sa (default)<br>|

--- a/packages/hardware/quirks/devices/AYANEO AIR Plus/020-fan_control
+++ b/packages/hardware/quirks/devices/AYANEO AIR Plus/020-fan_control
@@ -3,9 +3,7 @@
 # Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
 
 cat <<EOF >/storage/.config/profile.d/020-fan_control
-DEVICE_HAS_FAN="true"
-DEVICE_PWM_FAN="$(find /sys/devices/platform/ayn-platform -name pwm1)"
-DEVICE_FAN_INPUT="$(find /sys/devices/platform/ayn-platform -name fan*_input)"
+DEVICE_HAS_FAN="false"
 DEVICE_TEMP_SENSOR="$(find /sys/devices/pci*/* -path "*/nvme" -prune -o -name temp1_input -print)"
 EOF
 

--- a/packages/hardware/quirks/devices/AYANEO AIR/020-fan_control
+++ b/packages/hardware/quirks/devices/AYANEO AIR/020-fan_control
@@ -5,6 +5,7 @@
 cat <<EOF >/storage/.config/profile.d/020-fan_control
 DEVICE_HAS_FAN="true"
 DEVICE_PWM_FAN="$(find /sys/devices/platform/oxp-platform -name pwm1)"
+DEVICE_FAN_INPUT="$(find /sys/devices/platform/oxp-platform -name fan*_input)"
 DEVICE_TEMP_SENSOR="$(find /sys/devices/pci*/* -path "*/nvme" -prune -o -name temp1_input -print)"
 EOF
 

--- a/packages/jelos/sources/scripts/jelos-info
+++ b/packages/jelos/sources/scripts/jelos-info
@@ -74,12 +74,6 @@ case ${HW_ARCH} in
   ;;
 esac
 
-# temperature
-# Unit: millidegree Celsius
-if [ -e "${DEVICE_TEMP_SENSOR}" ]
-then
-  TEMPE=$(cat ${DEVICE_TEMP_SENSOR} 2>/dev/null | sort -rn | head -1 | sed -e s+"[0-9][0-9][0-9]$"++)
-fi
 echo "SYSTEM INFORMATION:"
 echo "DEVICE: ${QUIRK_DEVICE}"
 echo "OPERATING SYSTEM: ${OS_NAME}"
@@ -106,13 +100,18 @@ then
 fi
 echo "CPU INFORMATION:"
 echo "CPU: ${V_CPUMODEL1} (${V_CPUNB} Cores)"
-if test -n "${TEMPE}"
+
+# temperature
+# Unit: millidegree Celsius
+TEMPE=$(printf "%.0f" $(awk '{ total += $1; count++ } END { print total/count }' ${DEVICE_TEMP_SENSOR} 2>/dev/null) 2>/dev/null | sed -e s+"[0-9][0-9][0-9]$"++)
+if [ -n "${TEMPE}" ]
 then
-    echo "CPU TEMPERATURE: ${TEMPE}°"
+  echo "CPU TEMPERATURE: ${TEMPE}°"
 fi
+
 if [ "${DEVICE_HAS_FAN}" = "true" ]
 then
-  FANSPEED=$(cat ${DEVICE_PWM_FAN} 2>/dev/null)
+  FANSPEED=$(cat ${DEVICE_FAN_INPUT} 2>/dev/null)
   if [ "${FANSPEED}" = "0" ]
   then
     FANSPEED="OFF"

--- a/packages/kernel/linux-drivers/ayn-platform/package.mk
+++ b/packages/kernel/linux-drivers/ayn-platform/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present Fewtarius
 
 PKG_NAME="ayn-platform"
-PKG_VERSION="7a9b0ee47143a268cc62553551dd8886f6aa4ae8"
+PKG_VERSION="7f0c88d70be3e69c866e1284c9488c1044b4edce"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ShadowBlip/ayn-platform"
 PKG_URL="${PKG_SITE}.git"


### PR DESCRIPTION
* Documentation update, AMD64 PS2 now defaults to pcsx2-sa on fresh flashes.
* JELOS Information now displays fan speed and CPU temp correctly on supported AYANEO and ayn Loki devices.
