### PR TITLE
Enable intel_hasvk on crocus devices

### DIFF
--- a/config/graphic
+++ b/config/graphic
@@ -40,6 +40,7 @@ get_graphicdrivers() {
   if listcontains "${GRAPHIC_DRIVERS}" "crocus"; then
     GALLIUM_DRIVERS+=" crocus"
     XORG_DRIVERS+=" intel"
+    VULKAN_DRIVERS_MESA+=" intel_hasvk"
     COMPOSITE_SUPPORT="yes"
     VAAPI_SUPPORT="yes"
   fi


### PR DESCRIPTION
Tested on Intel Celeron n3000, codename Braswell.

Could be tested on other platforms which I don't own, e.g. Haswell, Broadwell...

But since they are anyway not officially supported we may just see if any reports come in after it has been merged and more folks can test easy.
