### PR TITLE
Update opus to version 1.4 and Add support for/switch to moonlight-qt on x86_64

### DIFF
--- a/packages/apps/moonlight/package.mk
+++ b/packages/apps/moonlight/package.mk
@@ -2,16 +2,44 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="moonlight"
-PKG_VERSION="36c1636f3c77345e6439f848def9a4f917e25834"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
-PKG_SITE="https://github.com/moonlight-stream/moonlight-embedded"
 PKG_URL="${PKG_SITE}.git"
 PKG_DEPENDS_TARGET="toolchain opus SDL2 libevdev alsa curl enet avahi libvdpau libcec ffmpeg"
-PKG_SHORTDESC="Moonlight Embedded is an open source implementation of NVIDIA's GameStream, as used by the NVIDIA Shield, but built for Linux."
-PKG_TOOLCHAIN="cmake"
+PKG_SHORTDESC="Moonlight is an open source implementation of NVIDIA's GameStream, as used by the NVIDIA Shield, but built for Linux."
 GET_HANDLER_SUPPORT="git"
 PKG_PATCH_DIRS+="${DEVICE}"
+
+if [ "${TARGET_ARCH}" = "x86_64" ] 
+then
+  PKG_SITE="https://github.com/moonlight-stream/moonlight-qt"
+  PKG_VERSION="18130fd8de19de90dad5542d66dbe8904a1acea7"
+  PKG_DEPENDS_TARGET+=" qt5"
+  PKG_TOOLCHAIN="manual"
+  make_target() {
+    git submodule update --init --recursive
+    qmake "CONFIG+=embedded" moonlight-qt.pro
+    make release
+  }
+  post_makeinstall_target() {
+    mkdir -p ${INSTALL}/usr/bin
+    mkdir -p ${INSTALL}/usr/config/modules
+    cp ${PKG_BUILD}/app/moonlight ${INSTALL}/usr/bin/
+    cp ${PKG_BUILD}/start_moonlight.sh ${INSTALL}/usr/bin/
+    chmod +x ${INSTALL}/usr/bin/*
+    mv ${INSTALL}/usr/bin/start_moonlight.sh ${INSTALL}/usr/config/modules/Start\ Moonlight.sh
+  }
+else
+  PKG_SITE="https://github.com/moonlight-stream/moonlight-embedded"
+  PKG_VERSION="36c1636f3c77345e6439f848def9a4f917e25834"
+  PKG_TOOLCHAIN="cmake"
+  post_makeinstall_target() {
+    mkdir -p ${INSTALL}/usr/config/moonlight
+    cp -R ${PKG_BUILD}/moonlight.conf ${INSTALL}/usr/config/moonlight
+    rm ${INSTALL}/usr/etc/moonlight.conf 
+    rm ${INSTALL}/usr/share/moonlight/gamecontrollerdb.txt 
+  }
+fi
 
 if [ "${PROJECT}" = "Rockchip" ]
 then
@@ -30,10 +58,3 @@ if [ "${VULKAN_SUPPORT}" = "yes" ]
   then
   PKG_DEPENDS_TARGET+=" vulkan-loader vulkan-headers"
 fi
-
-post_makeinstall_target() {
-  mkdir -p ${INSTALL}/usr/config/moonlight
-    cp -R ${PKG_BUILD}/moonlight.conf ${INSTALL}/usr/config/moonlight
-    rm ${INSTALL}/usr/etc/moonlight.conf 
-    rm ${INSTALL}/usr/share/moonlight/gamecontrollerdb.txt 
-}

--- a/packages/apps/moonlight/package.mk
+++ b/packages/apps/moonlight/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="moonlight"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
-PKG_URL="${PKG_SITE}.git"
+PKG_SITE="https://github.com/moonlight-stream/moonlight-"
 PKG_DEPENDS_TARGET="toolchain opus SDL2 libevdev alsa curl enet avahi libvdpau libcec ffmpeg"
 PKG_SHORTDESC="Moonlight is an open source implementation of NVIDIA's GameStream, as used by the NVIDIA Shield, but built for Linux."
 GET_HANDLER_SUPPORT="git"
@@ -12,12 +12,12 @@ PKG_PATCH_DIRS+="${DEVICE}"
 
 if [ "${TARGET_ARCH}" = "x86_64" ] 
 then
-  PKG_SITE="https://github.com/moonlight-stream/moonlight-qt"
-  PKG_VERSION="18130fd8de19de90dad5542d66dbe8904a1acea7"
+  PKG_SITE+="qt"
+  PKG_URL="${PKG_SITE}.git"
+  PKG_VERSION="49e06798642e2fcbf1b3c74b040b2ec1bc8a85e0"
   PKG_DEPENDS_TARGET+=" qt5"
   PKG_TOOLCHAIN="manual"
   make_target() {
-    git submodule update --init --recursive
     qmake "CONFIG+=embedded" moonlight-qt.pro
     make release
   }
@@ -30,7 +30,8 @@ then
     mv ${INSTALL}/usr/bin/start_moonlight.sh ${INSTALL}/usr/config/modules/Start\ Moonlight.sh
   }
 else
-  PKG_SITE="https://github.com/moonlight-stream/moonlight-embedded"
+  PKG_SITE+="embedded"
+  PKG_URL="${PKG_SITE}.git"
   PKG_VERSION="36c1636f3c77345e6439f848def9a4f917e25834"
   PKG_TOOLCHAIN="cmake"
   post_makeinstall_target() {

--- a/packages/apps/moonlight/sources/start_moonlight.sh
+++ b/packages/apps/moonlight/sources/start_moonlight.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. /etc/profile
+jslisten set "moonlight"
+QT_QPA_PLATFORM=wayland moonlight

--- a/packages/multimedia/opus/package.mk
+++ b/packages/multimedia/opus/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="opus"
-PKG_VERSION="1.3.1"
-PKG_SHA256="65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d"
+PKG_VERSION="1.4"
+PKG_SHA256="c9b32b4253be5ae63d1ff16eea06b94b5f0f2951b7a02aceef58e3a3ce49c51f"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.opus-codec.org"
-PKG_URL="https://archive.mozilla.org/pub/opus/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_URL="https://downloads.xiph.org/releases/opus/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Codec designed for interactive speech and audio transmission over the Internet."
 PKG_TOOLCHAIN="configure"
@@ -18,6 +18,12 @@ PKG_BUILD_FLAGS="+pic"
 #  PKG_FIXED_POINT="--disable-fixed-point"
 #fi
 
+if [ "${TARGET_ARCH}" = "x86_64" ]; then
+  PKG_SHARED_LIBRARY="--enable-shared"
+else
+  PKG_SHARED_LIBRARY="--disable-shared"
+fi
+
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
-                           --disable-shared \
+                           $PKG_SHARED_LIBRARY \
                            $PKG_FIXED_POINT"


### PR DESCRIPTION
# Update opus to 1.4 / Add support for moonlight-qt

## Description

Bumps opus version to 1.4 and changes its site to xiph.org to get current updates
Adds support for building moonlight-qt and sets it as the version we use when the arch is x86_64
Adds support for launching moonlight-qt on its own from the Tools menu for those who want to tweak streaming settings
Fixes opus_multistream_decode segfault on moonlight-embedded via opus update

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [?] This change requires a documentation update

## How Has This Been Tested Locally?

- [x] Tested moonlight-qt on Loki Zero by pairing, updating gamelist, streaming, and unpairing via the emualtionstation menus

**Test Configuration**:
* Build OS name and version: x86_64 AMD64
* Docker (Y/N): Y
* JELOS Branch: dev
* Any additional information that may be useful: May need to inform users on how to use standalone launch of moonlight-qt via the Tools menu. Currently you either need a touch screen or to use your devices Start button to enter settings after launching.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
