### PR TITLE
Add FPS option to ES for PCSX2.

### DIFF
--- a/packages/emulators/standalone/pcsx2-sa/sources/start_pcsx2.sh
+++ b/packages/emulators/standalone/pcsx2-sa/sources/start_pcsx2.sh
@@ -4,15 +4,30 @@
 
 . /etc/profile
 
-ARG=${1//[\\]/}
+GAME=${1//[\\]/}
 
 jslisten set "-9 pcsx2-qt"
+
+FPS=$(get_setting show_fps ps2 "${GAME}")
 
 if [ ! -d "/storage/.config/PCSX2" ]
 then
   cp -rf /usr/config/PCSX2 /storage/.config
 fi
-@APPIMAGE@ -fastboot -nogui -- "${ARG}"
+
+for OSDPROPERTY in OsdShowSpeed OsdShowFPS OsdShowCPU OsdShowGPU OsdShowResolution OsdShowGSStats OsdShowIndicators
+do
+  case ${FPS} in
+    true)
+      sed -i '/'${OSDPROPERTY}'/c\'${OSDPROPERTY}' = true' /storage/.config/PCSX2/inis/PCSX2.ini
+    ;;
+    *)
+      sed -i '/'${OSDPROPERTY}'/c\'${OSDPROPERTY}' = false' /storage/.config/PCSX2/inis/PCSX2.ini
+    ;;
+  esac
+done
+
+@APPIMAGE@ -fastboot -nogui -- "${GAME}"
 
 #Workaround until we can learn why it doesn't exit cleanly when asked.
 killall -9 pcsx2-qt

--- a/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/packages/ui/emulationstation/config/common/es_features.cfg
@@ -488,6 +488,18 @@
     </core>
    </cores>
   </emulator>
+  <emulator name="pcsx2">
+   <cores>
+    <core name="pcsx2-sa">
+     <features>
+      <feature name="show fps">
+        <choice name="yes" value="true"/>
+        <choice name="no" value="false"/>
+      </feature>
+    </features>
+    </core>
+   </cores>
+  </emulator>
   <emulator name="ryujinx">
    <cores>
     <core name="ryujinx-sa">


### PR DESCRIPTION
## Description

This update adds an FPS enable / disable option for the PS2 emulator PCSX2.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Installed on Air Pro, tested enabling and disabling via system.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
