### PR TITLE
Fix brightness on new flashes, bump SDL2.

### DIFF
--- a/packages/graphics/SDL2/package.mk
+++ b/packages/graphics/SDL2/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2022-present Fewtarius
 
 PKG_NAME="SDL2"
-PKG_VERSION="2.28.2"
+PKG_VERSION="2.28.4"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libsdl.org/"
 PKG_URL="https://www.libsdl.org/release/SDL2-${PKG_VERSION}.tar.gz"

--- a/packages/jelos/sources/scripts/brightness
+++ b/packages/jelos/sources/scripts/brightness
@@ -8,16 +8,18 @@
 
 BRIGHTNESS_DEV="$(find /sys/class/backlight/*/ -name brightness -print -quit)"
 BRIGHTNESS_PATH="${BRIGHTNESS_DEV%/brightness}"
+
+declare -a BRIGHTNESS_TABLE
 BRIGHTNESS_TABLE=($(get_setting brightness_table))
-if [ -z $BRIGHTNESS_TABLE ]; then
-  BRIGHTNESS_TABLE="0 0.04 0.08 0.13 0.19 0.25 0.33 0.42 0.54 0.71 1"
-  set_setting brightness_table "$BRIGHTNESS_TABLE"
+if [ -z ${BRIGHTNESS_TABLE} ]; then
+  BRIGHTNESS_TABLE=(0 0.04 0.08 0.13 0.19 0.25 0.33 0.42 0.54 0.71 1)
+  set_setting brightness_table "${BRIGHTNESS_TABLE[*]}"
 fi
 NUM_STEPS=${#BRIGHTNESS_TABLE[@]}
 
 MAX=$(<$(find /sys/class/backlight/*/ -name max_brightness -print -quit))
-compute() {
-  echo "${BRIGHTNESS_TABLE[$NEXT]} * $MAX" | bc -l
+function compute() {
+  echo "${BRIGHTNESS_TABLE[$NEXT]} * ${MAX}" | bc -l
 }
 
 if [ ! -f "${BRIGHTNESS_DEV}" ]


### PR DESCRIPTION
## Description

* Fix brightness set bug on new flashes.
* Bump SDL to 2.28.4

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Found that brightness was set to 0 on new flashes due to a bug in the brightness script that failed to set the brightness table as an array if it was not already defined.  Corrected the bug, and tested on an x55 by deleting the table and setting the brightness multiple times.  Prior to correcting, the first time it was set it would fail to set.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
