### PR TITLE
pico-8 launch updates

### DIFF
--- a/packages/emulators/standalone/pico-8/sources/autostart/common/010-pico8
+++ b/packages/emulators/standalone/pico-8/sources/autostart/common/010-pico8
@@ -8,5 +8,6 @@ then
   mkdir "${PICO_DIR}"
 fi
 
-cp -f  "/usr/bin/start_pico8.sh" "${PICO_DIR}/Start Pico-8.sh"
-
+# Suggest removing this and replacing it with a file called Splore.png
+# cp -f  "/usr/bin/start_pico8.sh" "${PICO_DIR}/Start Pico-8.sh"
+touch "${PICO_DIR}/Splore.png"


### PR DESCRIPTION
## Description

Aims to simply the launch scripts for pico-8 by:
- consolidating all launch details into usr/bin/start_pico8.sh.  Instead of copying the .sh file to the roms directory it instead creates a Splore.png which is used to launch splore.  This should enable us to make updates in one place without needing to update roms in the future.
- Updates the static_bin for x86_64 to `pico8_dyn` which enables the script to be simplified further.  pico8_dyn is the binary that works for x86 devices so thought it would be best to just call that directly and remove the extra condition later in the script

I'll make changes to pico-8 wiki documentation if these changes look good to go.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested Locally?

Built dev with these changes and tested an upgrade and fresh install on x86_64 loki zero.  Also tested the script changes directly on RGB30.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation