### PR TITLE
Theme update

### DIFF
--- a/packages/themes/es-theme-art-book-next/package.mk
+++ b/packages/themes/es-theme-art-book-next/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2021 Fewtarius
 
 PKG_NAME="es-theme-art-book-next"
-PKG_VERSION="4659285a01d1e30150cb008ae6ef0e9db2c60935"
+PKG_VERSION="86369b3cc7c76a2b6921d5ec7010e0b363471754"
 PKG_ARCH="any"
 PKG_LICENSE="CUSTOM"
 PKG_SITE="https://github.com/anthonycaccese/art-book-next-jelos"


### PR DESCRIPTION
Simplified helpsystem toggle
on 16:9, 16:10 and 5:3 the helpsystem can be turned off from one setting now (previously it required two settings).

Main Menu > UI Settings > On-Screen Help

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Local theme update on RGB30 and Loki Zero

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
