### PR TITLE
Update start_pico8.sh

### DIFF
--- a/packages/emulators/standalone/pico-8/sources/start_pico8.sh
+++ b/packages/emulators/standalone/pico-8/sources/start_pico8.sh
@@ -12,7 +12,7 @@ case ${HW_ARCH} in
     STATIC_BIN="pico8_64"
   ;;
   *)
-    STATIC_BIN="pico8"
+    STATIC_BIN="pico8_dyn"
   ;;
 esac
 
@@ -42,17 +42,7 @@ fi
 # store sdl_controllers in root directory so its shared across devices - will look to revisit this with controller refactor work
 cp -f /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt ${GAME_DIR}/sdl_controllers.txt
 
-if [ -e "${LAUNCH_DIR}/pico8_dyn" ]
-then
-  chmod 0755 ${LAUNCH_DIR}/pico8_din
-  jslisten set "-9 pico8_dyn start_pico8.sh"
-  ${LAUNCH_DIR}/pico8_dyn -home -root_path ${GAME_DIR} -joystick 0 ${OPTIONS} "${CART}"
-fi
-
-if [ ! "$?" = 0 ] && [ -e "${LAUNCH_DIR}/${STATIC_BIN}" ]
-then
-  # mark the binary executable to cover cases where the user adding the binaries doesn't know or forgets.
-  chmod 0755 ${LAUNCH_DIR}/${STATIC_BIN}
-  jslisten set "-9 ${STATIC_BIN} start_pico8.sh"
-  ${LAUNCH_DIR}/${STATIC_BIN} -home -root_path ${GAME_DIR} -joystick 0 ${OPTIONS} "${CART}"
-fi
+# mark the binary executable to cover cases where the user adding the binaries doesn't know or forgets.
+chmod 0755 ${LAUNCH_DIR}/${STATIC_BIN}
+jslisten set "-9 ${STATIC_BIN} start_pico8.sh"
+${LAUNCH_DIR}/${STATIC_BIN} -home -root_path ${GAME_DIR} -joystick 0 ${OPTIONS} "${CART}"


### PR DESCRIPTION
from testing on RGB30 and Loki Zero I am seeing the following: 
- aarch64 (which is I think covers all of our arm devices) needs and looks for the pico8_64 + pico8.dat files from the raspberrypi zip 
- x86 works with the pico8_dyn + pico8.dat files from the linux 64 zip

So with that in mind I think the changes in this commit cover those use cases.  I've tested on my RGB30, RG351P and Loki Zero and it looks to work well across each.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

- Created a start_pico8.sh script and added to /storage/bin to act as an override of the source at /usr/bin.  
- Tested on RGB30, RG351P and Loki zero
- Tested booting Splore.png and direct game boots on each device
- Tested with pico8 binaries in both subdirectories (/aarch64 and /x86_64) and in the root of the roms directory

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation