### PR TITLE
projects: enable entware

### DIFF
--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -65,3 +65,7 @@
 
   # debug tty path
     DEBUG_TTY="/dev/ttyS2"
+
+  # build with entware installer
+    ENTWARE_SUPPORT="yes"
+    ENTWARE_ARCH="aarch64-k3.10"

--- a/projects/PC/options
+++ b/projects/PC/options
@@ -70,3 +70,7 @@
 
   # Installation support
     INSTALLER_SUPPORT="yes"
+
+  # build with entware installer
+    ENTWARE_SUPPORT="yes"
+    ENTWARE_ARCH="x64-k3.2"

--- a/projects/Rockchip/options
+++ b/projects/Rockchip/options
@@ -76,3 +76,7 @@
 
   # debug tty path
     DEBUG_TTY="/dev/ttyS2"
+
+  # build with entware installer
+    ENTWARE_SUPPORT="yes"
+    ENTWARE_ARCH="aarch64-k3.10"


### PR DESCRIPTION
This PR enables entware which is already present in the JELOS buildroot. This brings the opkg package manager to the OS and allows users to install Linux applications.

Applications are stored in /storage/.opt and the folder is then added to the PATH variable on bootup.

To utilise entware. SSH to the device and type `installentware`

Reboot and test, `opkg install fdisk` for example.

Entware does not increase the image size or build time as it is just a simple script that fetches the true installer.