### PR TITLE
Add wifi driver for OGA Black Edition

### DIFF
--- a/packages/kernel/linux-drivers/esp8089/modprobe.d/esp8089.conf
+++ b/packages/kernel/linux-drivers/esp8089/modprobe.d/esp8089.conf
@@ -1,0 +1,1 @@
+options esp8089 esp_reset_gpio=105

--- a/packages/kernel/linux-drivers/esp8089/package.mk
+++ b/packages/kernel/linux-drivers/esp8089/package.mk
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+PKG_NAME="esp8089"
+PKG_VERSION="1.9.20230804"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/al177/esp8089"
+PKG_URL="https://github.com/al177/esp8089/archive/refs/tags/1.9.20230804.tar.gz"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="${LINUX_DEPENDS}"
+PKG_LONGDESC="ESP8089 Wifi Driver"
+PKG_IS_KERNEL_PKG="yes"
+PKG_TOOLCHAIN="make"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  make V=1 \
+       ARCH=${TARGET_KERNEL_ARCH} \
+       KSRC=$(kernel_path) \
+       CROSS_COMPILE=${TARGET_KERNEL_PREFIX} \
+       TARGET=$(kernel_version) \
+       KERNEL_MODULES=$(get_build_dir linux)/.install_pkg/$(get_full_module_dir) \
+       KBUILD=$(get_build_dir linux)
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
+    cp *.ko ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
+}

--- a/packages/kernel/linux-drivers/esp8089/patches/001-fix-sdio-detect.patch
+++ b/packages/kernel/linux-drivers/esp8089/patches/001-fix-sdio-detect.patch
@@ -1,0 +1,47 @@
+--- a/sdio_sif_esp.c	2023-08-04 15:04:02.000000000 -0600
++++ b/sdio_sif_esp.c	2023-10-27 12:08:08.302695270 -0600
+@@ -50,6 +50,24 @@
+ //unsigned int esp_msg_level = 0;
+ unsigned int esp_msg_level = ESP_DBG_ERROR | ESP_SHOW;
+ 
++/* HdG: Note:
++ * 1) MMC_HAS_FORCE_DETECT_CHANGE is a hack which is set by my sunxi-wip
++ *    tree. FIXME replace with a version check once mmc_force_detect_change()
++ *    is added to the mainline kernel.
++ * 2) This version does NOT implement keep_power, the dts must mark the
++ *    regulators as regulator-always-on and not use mmc-pwrseq for this stub
++ *    to work.
++ */
++#ifndef MMC_HAS_FORCE_DETECT_CHANGE
++void mmc_force_detect_change(struct mmc_host *host, unsigned long delay,
++			     bool keep_power)
++{
++	host->caps &= ~MMC_CAP_NONREMOVABLE;
++	host->caps |= MMC_CAP_NEEDS_POLL;
++	mmc_detect_change(host, delay);
++}
++#endif
++
+ static struct semaphore esp_powerup_sem;
+ 
+ static enum esp_sdio_state sif_sdio_state;
+@@ -500,6 +518,7 @@
+         int err = 0;
+         struct esp_pub *epub;
+         struct esp_sdio_ctrl *sctrl;
++        struct mmc_host *host = func->card->host;
+ 
+         esp_dbg(ESP_DBG_TRACE,
+                         "sdio_func_num: 0x%X, vendor id: 0x%X, dev id: 0x%X, block size: 0x%X/0x%X\n",
+@@ -609,6 +628,10 @@
+ 	if(sif_sdio_state == ESP_SDIO_STATE_FIRST_INIT){
+ 		esp_dbg(ESP_DBG_ERROR, "first normal exit\n");
+ 		sif_sdio_state = ESP_SDIO_STATE_FIRST_NORMAL_EXIT;
++
++		/* Rescan the esp8089 after loading the initial firmware */
++		mmc_force_detect_change(host, msecs_to_jiffies(100), true);
++
+ 		up(&esp_powerup_sem);
+ 	}
+ 
+ 

--- a/projects/Rockchip/devices/RK3326/options
+++ b/projects/Rockchip/devices/RK3326/options
@@ -84,7 +84,7 @@
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="RTL8812AU RTL8814AU RTL8821AU RTL8821CU RTL88x2BU"
+    ADDITIONAL_DRIVERS="RTL8812AU RTL8814AU RTL8821AU RTL8821CU RTL88x2BU esp8089"
 
   # build and install driver addons (yes / no)
     DRIVER_ADDONS_SUPPORT="no"

--- a/projects/Rockchip/packages/linux/patches/RK3326/000-rk3326-devices.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3326/000-rk3326-devices.patch
@@ -1218,7 +1218,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-odroid-go2-v11.dts lin
 +		compatible = "mmc-pwrseq-simple";
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&wifi_pwrseq_pins>;
-+		reset-gpios = <&gpio3 RK_PB1 GPIO_ACTIVE_LOW>;
++		/*reset-gpios = <&gpio3 RK_PB1 GPIO_ACTIVE_LOW>;*/
 +	};
 +};
 +
@@ -1235,6 +1235,8 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-odroid-go2-v11.dts lin
 +			regulator-name = "vcc_wifi";
 +			regulator-min-microvolt = <3300000>;
 +			regulator-max-microvolt = <3300000>;
++			regulator-always-on;
++			regulator-boot-on;
 +
 +			regulator-state-mem {
 +				regulator-on-in-suspend;
@@ -1254,16 +1256,14 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-odroid-go2-v11.dts lin
 +	cap-sdio-irq;
 +	disable-wp;
 +	keep-power-in-suspend;
-+	mmc-pwrseq = <&wifi_pwrseq>;
 +	non-removable;
 +	vmmc-supply = <&vcc_wifi>;
-+	#address-cells = <1>;
-+	#size-cells = <0>;
 +	status = "okay";
 +
 +	esp8089: wifi@1 {
 +		compatible = "esp,esp8089";
 +		reg = <1>;
++		esp,crystal-26M-en = <2>;
 +	};
 +};
 +
@@ -1291,7 +1291,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-odroid-go2-v11.dts lin
 +
 +	wifi {
 +		wifi_pwrseq_pins: wifi-pwrseq-pins {
-+			rockchip,pins = <3 RK_PB1 RK_FUNC_GPIO &pcfg_pull_up>,
++			rockchip,pins = /*<3 RK_PB1 RK_FUNC_GPIO &pcfg_pull_up>,*/
 +					<3 RK_PB6 RK_FUNC_GPIO &pcfg_output_high>;
 +		};
 +	};


### PR DESCRIPTION
## Description
Added the esp8089 driver to make wifi work on the Odroid Go Advance Black Edition

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?
Tested on my personal Odroid Go Advance. Wifi scanning and connecting work as expected.

**Test Configuration**:
* Build OS name and version: Ubuntu 23.04
* Docker (Y/N): Y
* JELOS Branch: dev
* Any additional information that may be useful:
The driver is pulled from this repo: https://github.com/al177/esp8089
A patch was added to get around features that exist in the Rockchip kernel branch but not mainline.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
