### PR TITLE
Dolphin SA - use game name in save state file name - Thanks @Batocera!

### DIFF
--- a/packages/emulators/standalone/dolphin-sa/patches/wayland/000-add-wayland.patch
+++ b/packages/emulators/standalone/dolphin-sa/patches/wayland/000-add-wayland.patch
@@ -1,6 +1,6 @@
-diff -rupN dolphin.orig/CMake/FindWaylandProtocols.cmake dolphin/CMake/FindWaylandProtocols.cmake
+diff -rupN dolphin.orig/CMake/FindWaylandProtocols.cmake dolphin.ss/CMake/FindWaylandProtocols.cmake
 --- dolphin.orig/CMake/FindWaylandProtocols.cmake	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/CMake/FindWaylandProtocols.cmake	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/CMake/FindWaylandProtocols.cmake	2023-10-27 13:46:38.317333047 +0000
 @@ -0,0 +1,28 @@
 +# from https://github.com/glfw/glfw/blob/master/CMake/modules/FindWaylandProtocols.cmake
 +
@@ -30,9 +30,9 @@ diff -rupN dolphin.orig/CMake/FindWaylandProtocols.cmake dolphin/CMake/FindWayla
 +set(WAYLAND_PROTOCOLS_FOUND ${WaylandProtocols_FOUND})
 +set(WAYLAND_PROTOCOLS_PKGDATADIR ${WaylandProtocols_PKGDATADIR})
 +set(WAYLAND_PROTOCOLS_VERSION ${WaylandProtocols_VERSION})
-diff -rupN dolphin.orig/CMake/FindXKBCommon.cmake dolphin/CMake/FindXKBCommon.cmake
+diff -rupN dolphin.orig/CMake/FindXKBCommon.cmake dolphin.ss/CMake/FindXKBCommon.cmake
 --- dolphin.orig/CMake/FindXKBCommon.cmake	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/CMake/FindXKBCommon.cmake	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/CMake/FindXKBCommon.cmake	2023-10-27 13:46:38.317333047 +0000
 @@ -0,0 +1,33 @@
 +# - Try to find XKBCommon
 +# Once done, this will define
@@ -67,9 +67,9 @@ diff -rupN dolphin.orig/CMake/FindXKBCommon.cmake dolphin/CMake/FindXKBCommon.cm
 +)
 +
 +mark_as_advanced(XKBCOMMON_LIBRARY XKBCOMMON_INCLUDE_DIR)
-diff -rupN dolphin.orig/CMakeLists.txt dolphin/CMakeLists.txt
+diff -rupN dolphin.orig/CMakeLists.txt dolphin.ss/CMakeLists.txt
 --- dolphin.orig/CMakeLists.txt	2023-09-26 17:58:02.593990718 +0000
-+++ dolphin/CMakeLists.txt	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/CMakeLists.txt	2023-10-27 13:46:40.473383166 +0000
 @@ -47,6 +47,7 @@ set(DOLPHIN_DEFAULT_UPDATE_TRACK "" CACH
  
  if(UNIX AND NOT APPLE AND NOT ANDROID)
@@ -96,9 +96,9 @@ diff -rupN dolphin.orig/CMakeLists.txt dolphin/CMakeLists.txt
  if(ENABLE_EGL)
    find_package(EGL)
    if(EGL_FOUND)
-diff -rupN dolphin.orig/Source/Core/Common/CMakeLists.txt dolphin/Source/Core/Common/CMakeLists.txt
+diff -rupN dolphin.orig/Source/Core/Common/CMakeLists.txt dolphin.ss/Source/Core/Common/CMakeLists.txt
 --- dolphin.orig/Source/Core/Common/CMakeLists.txt	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin/Source/Core/Common/CMakeLists.txt	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/CMakeLists.txt	2023-10-27 13:46:39.913370149 +0000
 @@ -253,11 +253,20 @@ if(ENABLE_EGL AND EGL_FOUND)
        GL/GLInterface/EGLAndroid.cpp
        GL/GLInterface/EGLAndroid.h
@@ -125,9 +125,9 @@ diff -rupN dolphin.orig/Source/Core/Common/CMakeLists.txt dolphin/Source/Core/Co
    endif()
    target_include_directories(common PRIVATE ${EGL_INCLUDE_DIRS})
    target_link_libraries(common PUBLIC ${EGL_LIBRARIES})
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.cpp dolphin/Source/Core/Common/GL/GLContext.cpp
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.cpp dolphin.ss/Source/Core/Common/GL/GLContext.cpp
 --- dolphin.orig/Source/Core/Common/GL/GLContext.cpp	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin/Source/Core/Common/GL/GLContext.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLContext.cpp	2023-10-27 13:46:39.913370149 +0000
 @@ -25,6 +25,9 @@
  #if defined(ANDROID)
  #include "Common/GL/GLInterface/EGLAndroid.h"
@@ -163,9 +163,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.cpp dolphin/Source/Core/
  #if HAVE_EGL
    if (wsi.type == WindowSystemType::Headless || wsi.type == WindowSystemType::FBDev)
      context = std::make_unique<GLContextEGL>();
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.h dolphin/Source/Core/Common/GL/GLContext.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.h dolphin.ss/Source/Core/Common/GL/GLContext.h
 --- dolphin.orig/Source/Core/Common/GL/GLContext.h	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin/Source/Core/Common/GL/GLContext.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLContext.h	2023-10-27 13:46:39.913370149 +0000
 @@ -36,8 +36,8 @@ public:
    virtual bool MakeCurrent();
    virtual bool ClearCurrent();
@@ -177,9 +177,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.h dolphin/Source/Core/Co
  
    virtual void Swap();
    virtual void SwapInterval(int interval);
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.h dolphin/Source/Core/Common/GL/GLInterface/AGL.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.h dolphin.ss/Source/Core/Common/GL/GLInterface/AGL.h
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.h	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/AGL.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLInterface/AGL.h	2023-10-27 13:46:39.913370149 +0000
 @@ -27,6 +27,8 @@ public:
  
    bool MakeCurrent() override;
@@ -189,9 +189,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.h dolphin/Source/C
  
    void Update() override;
  
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.mm dolphin/Source/Core/Common/GL/GLInterface/AGL.mm
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.mm dolphin.ss/Source/Core/Common/GL/GLInterface/AGL.mm
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.mm	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/AGL.mm	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLInterface/AGL.mm	2023-10-27 13:46:39.913370149 +0000
 @@ -144,7 +144,7 @@ bool GLContextAGL::ClearCurrent()
    return true;
  }
@@ -201,9 +201,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.mm dolphin/Source/
  {
    if (!m_view)
      return;
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.cpp dolphin/Source/Core/Common/GL/GLInterface/EGL.cpp
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.cpp dolphin.ss/Source/Core/Common/GL/GLInterface/EGL.cpp
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.cpp	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/EGL.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLInterface/EGL.cpp	2023-10-27 13:46:39.913370149 +0000
 @@ -292,8 +292,8 @@ bool GLContextEGL::CreateWindowSurface()
  {
    if (!IsHeadless())
@@ -266,9 +266,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.cpp dolphin/Source
 +  m_backbuffer_width = static_cast<u32>(surface_width);
 +  m_backbuffer_height = static_cast<u32>(surface_height);
 +}
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.h dolphin/Source/Core/Common/GL/GLInterface/EGL.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.h dolphin.ss/Source/Core/Common/GL/GLInterface/EGL.h
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/EGL.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLInterface/EGL.h	2023-10-27 13:46:39.913370149 +0000
 @@ -22,7 +22,8 @@ public:
    bool MakeCurrent() override;
    bool ClearCurrent() override;
@@ -292,9 +292,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.h dolphin/Source/C
    EGLConfig m_config;
    bool m_supports_surfaceless = false;
    std::vector<int> m_attribs;
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.cpp dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.cpp
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.cpp dolphin.ss/Source/Core/Common/GL/GLInterface/EGLWayland.cpp
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLInterface/EGLWayland.cpp	2023-10-27 13:46:39.913370149 +0000
 @@ -0,0 +1,36 @@
 +// Copyright 2019 Dolphin Emulator Project
 +// Licensed under GPLv2+
@@ -332,9 +332,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.cpp dolphin
 +
 +  return reinterpret_cast<EGLNativeWindowType>(window);
 +}
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.h dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.h dolphin.ss/Source/Core/Common/GL/GLInterface/EGLWayland.h
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.h	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLInterface/EGLWayland.h	2023-10-27 13:46:39.913370149 +0000
 @@ -0,0 +1,19 @@
 +// Copyright 2019 Dolphin Emulator Project
 +// Licensed under GPLv2+
@@ -355,9 +355,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.h dolphin/S
 +  EGLDisplay OpenEGLDisplay() override;
 +  EGLNativeWindowType GetEGLNativeWindow(EGLConfig config) override;
 +};
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.cpp dolphin/Source/Core/Common/GL/GLInterface/EGLX11.cpp
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.cpp dolphin.ss/Source/Core/Common/GL/GLInterface/EGLX11.cpp
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.cpp	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/EGLX11.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLInterface/EGLX11.cpp	2023-10-27 13:46:39.913370149 +0000
 @@ -11,7 +11,7 @@ GLContextEGLX11::~GLContextEGLX11()
    m_render_window.reset();
  }
@@ -367,9 +367,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.cpp dolphin/Sou
  {
    m_render_window->UpdateDimensions();
    m_backbuffer_width = m_render_window->GetWidth();
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.h dolphin/Source/Core/Common/GL/GLInterface/EGLX11.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.h dolphin.ss/Source/Core/Common/GL/GLInterface/EGLX11.h
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/EGLX11.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLInterface/EGLX11.h	2023-10-27 13:46:39.913370149 +0000
 @@ -13,7 +13,7 @@ class GLContextEGLX11 final : public GLC
  public:
    ~GLContextEGLX11() override;
@@ -379,9 +379,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.h dolphin/Sourc
  
  protected:
    EGLDisplay OpenEGLDisplay() override;
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.cpp dolphin/Source/Core/Common/GL/GLInterface/GLX.cpp
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.cpp dolphin.ss/Source/Core/Common/GL/GLInterface/GLX.cpp
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.cpp	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/GLX.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLInterface/GLX.cpp	2023-10-27 13:46:39.913370149 +0000
 @@ -310,7 +310,7 @@ bool GLContextGLX::ClearCurrent()
    return glXMakeCurrent(m_display, None, nullptr);
  }
@@ -391,9 +391,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.cpp dolphin/Source
  {
    m_render_window->UpdateDimensions();
    m_backbuffer_width = m_render_window->GetWidth();
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.h dolphin/Source/Core/Common/GL/GLInterface/GLX.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.h dolphin.ss/Source/Core/Common/GL/GLInterface/GLX.h
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/GLX.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLInterface/GLX.h	2023-10-27 13:46:39.913370149 +0000
 @@ -24,7 +24,7 @@ public:
    bool MakeCurrent() override;
    bool ClearCurrent() override;
@@ -403,9 +403,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.h dolphin/Source/C
  
    void SwapInterval(int Interval) override;
    void Swap() override;
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.cpp dolphin/Source/Core/Common/GL/GLInterface/WGL.cpp
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.cpp dolphin.ss/Source/Core/Common/GL/GLInterface/WGL.cpp
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.cpp	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/WGL.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLInterface/WGL.cpp	2023-10-27 13:46:39.913370149 +0000
 @@ -480,7 +480,7 @@ bool GLContextWGL::ClearCurrent()
  }
  
@@ -415,9 +415,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.cpp dolphin/Source
  {
    RECT rcWindow;
    GetClientRect(m_window_handle, &rcWindow);
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.h dolphin/Source/Core/Common/GL/GLInterface/WGL.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.h dolphin.ss/Source/Core/Common/GL/GLInterface/WGL.h
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/WGL.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/GL/GLInterface/WGL.h	2023-10-27 13:46:39.913370149 +0000
 @@ -19,7 +19,7 @@ public:
    bool MakeCurrent() override;
    bool ClearCurrent() override;
@@ -427,9 +427,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.h dolphin/Source/C
  
    void Swap() override;
    void SwapInterval(int interval) override;
-diff -rupN dolphin.orig/Source/Core/Common/WindowSystemInfo.h dolphin/Source/Core/Common/WindowSystemInfo.h
+diff -rupN dolphin.orig/Source/Core/Common/WindowSystemInfo.h dolphin.ss/Source/Core/Common/WindowSystemInfo.h
 --- dolphin.orig/Source/Core/Common/WindowSystemInfo.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/WindowSystemInfo.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Common/WindowSystemInfo.h	2023-10-27 13:46:39.937370706 +0000
 @@ -40,7 +40,11 @@ struct WindowSystemInfo
    // This is kept seperate as input may require a different handle to rendering, and
    // during video backend startup the surface pointer may change (MoltenVK).
@@ -443,9 +443,58 @@ diff -rupN dolphin.orig/Source/Core/Common/WindowSystemInfo.h dolphin/Source/Cor
    // Scale of the render surface. For hidpi systems, this will be >1.
    float render_surface_scale = 1.0f;
  };
-diff -rupN dolphin.orig/Source/Core/Core/Core.cpp dolphin/Source/Core/Core/Core.cpp
+diff -rupN dolphin.orig/Source/Core/Core/BootManager.cpp dolphin.ss/Source/Core/Core/BootManager.cpp
+--- dolphin.orig/Source/Core/Core/BootManager.cpp	2023-09-26 17:58:02.809995703 +0000
++++ dolphin.ss/Source/Core/Core/BootManager.cpp	2023-10-27 13:48:21.555727990 +0000
+@@ -64,6 +64,11 @@ bool BootCore(std::unique_ptr<BootParame
+   if (!StartUp.SetPathsAndGameMetadata(*boot))
+     return false;
+ 
++  if (std::holds_alternative<BootParameters::Disc>(boot->parameters))
++  {
++    StartUp.SetBaseSaveState(PathToFileName(std::get<BootParameters::Disc>(boot->parameters).path));
++  }
++
+   // Movie settings
+   if (Movie::IsPlayingInput() && Movie::IsConfigSaved())
+   {
+diff -rupN dolphin.orig/Source/Core/Core/ConfigManager.cpp dolphin.ss/Source/Core/Core/ConfigManager.cpp
+--- dolphin.orig/Source/Core/Core/ConfigManager.cpp	2023-09-26 17:58:02.809995703 +0000
++++ dolphin.ss/Source/Core/Core/ConfigManager.cpp	2023-10-27 13:48:21.555727990 +0000
+@@ -139,6 +139,10 @@ void SConfig::SetRunningGameMetadata(con
+   SetRunningGameMetadata(game_id, "", 0, 0, DiscIO::Region::Unknown);
+ }
+ 
++void SConfig::SetBaseSaveState(const std::string& base_save_state) {
++  m_base_save_state = base_save_state;
++}
++
+ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::string& gametdb_id,
+                                      u64 title_id, u16 revision, DiscIO::Region region)
+ {
+diff -rupN dolphin.orig/Source/Core/Core/ConfigManager.h dolphin.ss/Source/Core/Core/ConfigManager.h
+--- dolphin.orig/Source/Core/Core/ConfigManager.h	2023-09-26 17:58:02.809995703 +0000
++++ dolphin.ss/Source/Core/Core/ConfigManager.h	2023-10-27 13:48:21.555727990 +0000
+@@ -56,6 +56,8 @@ struct SConfig
+   // TODO: remove this as soon as the ticket view hack in IOS/ES/Views is dropped.
+   bool m_disc_booted_from_game_list = false;
+ 
++  const std::string& GetBaseSaveState() const { return m_base_save_state; }
++  void SetBaseSaveState(const std::string& base_save_state);
+   const std::string& GetGameID() const { return m_game_id; }
+   const std::string& GetGameTDBID() const { return m_gametdb_id; }
+   const std::string& GetTitleName() const { return m_title_name; }
+@@ -109,6 +111,7 @@ private:
+ 
+   static SConfig* m_Instance;
+ 
++  std::string m_base_save_state;
+   std::string m_game_id;
+   std::string m_gametdb_id;
+   std::string m_title_name;
+diff -rupN dolphin.orig/Source/Core/Core/Core.cpp dolphin.ss/Source/Core/Core/Core.cpp
 --- dolphin.orig/Source/Core/Core/Core.cpp	2023-09-26 17:58:02.809995703 +0000
-+++ dolphin/Source/Core/Core/Core.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Core/Core.cpp	2023-10-27 19:08:44.565345159 +0000
 @@ -474,6 +474,8 @@ static void EmuThread(std::unique_ptr<Bo
    // is relative to the render window, instead of the main window.
    ASSERT(g_controller_interface.IsInit());
@@ -455,9 +504,9 @@ diff -rupN dolphin.orig/Source/Core/Core/Core.cpp dolphin/Source/Core/Core/Core.
  
    Pad::LoadConfig();
    Pad::LoadGBAConfig();
-diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.cpp dolphin/Source/Core/Core/HW/GCPadEmu.cpp
+diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.cpp dolphin.ss/Source/Core/Core/HW/GCPadEmu.cpp
 --- dolphin.orig/Source/Core/Core/HW/GCPadEmu.cpp	2023-09-26 17:58:02.817995888 +0000
-+++ dolphin/Source/Core/Core/HW/GCPadEmu.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Core/HW/GCPadEmu.cpp	2023-10-27 13:46:40.045373218 +0000
 @@ -24,6 +24,7 @@ static const u16 button_bitmasks[] = {
      PAD_BUTTON_X,
      PAD_BUTTON_Y,
@@ -476,9 +525,9 @@ diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.cpp dolphin/Source/Core/Cor
    // sticks
    groups.emplace_back(m_main_stick = new ControllerEmu::OctagonAnalogStick(
                            MAIN_STICK_GROUP, _trans("Control Stick"), MAIN_STICK_GATE_RADIUS));
-diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.h dolphin/Source/Core/Core/HW/GCPadEmu.h
+diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.h dolphin.ss/Source/Core/Core/HW/GCPadEmu.h
 --- dolphin.orig/Source/Core/Core/HW/GCPadEmu.h	2023-09-26 17:58:02.817995888 +0000
-+++ dolphin/Source/Core/Core/HW/GCPadEmu.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/Core/HW/GCPadEmu.h	2023-10-27 13:46:40.045373218 +0000
 @@ -65,6 +65,7 @@ public:
    static constexpr const char* X_BUTTON = "X";
    static constexpr const char* Y_BUTTON = "Y";
@@ -487,9 +536,105 @@ diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.h dolphin/Source/Core/Core/
    static constexpr const char* START_BUTTON = "Start";
  
    // i18n: The left trigger button (labeled L on real controllers)
-diff -rupN dolphin.orig/Source/Core/DolphinLib.props dolphin/Source/Core/DolphinLib.props
+diff -rupN dolphin.orig/Source/Core/Core/State.cpp dolphin.ss/Source/Core/Core/State.cpp
+--- dolphin.orig/Source/Core/Core/State.cpp	2023-09-26 17:58:02.829996165 +0000
++++ dolphin.ss/Source/Core/Core/State.cpp	2023-10-27 19:10:09.907147486 +0000
+@@ -327,7 +327,10 @@ static std::string SystemTimeAsDoubleToS
+ #endif
+ }
+ 
+-static std::string MakeStateFilename(int number);
++static std::string MakeStateFilename(bool useId, int number);
++static std::string MakeStateFilename_partdirectory(int number);
++static std::string MakeStateFilename_partfileName(int number);
++static std::string MakeStateFilename_partfileID(int number);
+ 
+ // read state timestamps
+ static std::map<double, int> GetSavedStates()
+@@ -336,7 +339,7 @@ static std::map<double, int> GetSavedSta
+   std::map<double, int> m;
+   for (int i = 1; i <= (int)NUM_STATES; i++)
+   {
+-    std::string filename = MakeStateFilename(i);
++    std::string filename = MakeStateFilename(true, i);
+     if (File::Exists(filename))
+     {
+       if (ReadHeader(filename, header))
+@@ -536,7 +539,7 @@ bool ReadHeader(const std::string& filen
+ 
+ std::string GetInfoStringOfSlot(int slot, bool translate)
+ {
+-  std::string filename = MakeStateFilename(slot);
++  std::string filename = MakeStateFilename(true, slot);
+   if (!File::Exists(filename))
+     return translate ? Common::GetStringT("Empty") : "Empty";
+ 
+@@ -550,7 +553,7 @@ std::string GetInfoStringOfSlot(int slot
+ u64 GetUnixTimeOfSlot(int slot)
+ {
+   State::StateHeader header;
+-  if (!ReadHeader(MakeStateFilename(slot), header))
++  if (!ReadHeader(MakeStateFilename(true, slot), header))
+     return 0;
+ 
+   constexpr u64 MS_PER_SEC = 1000;
+@@ -751,20 +754,48 @@ void Shutdown()
+   }
+ }
+ 
+-static std::string MakeStateFilename(int number)
++static std::string MakeStateFilename(bool useId, int number)
+ {
+-  return fmt::format("{}{}.s{:02d}", File::GetUserPath(D_STATESAVES_IDX),
+-                     SConfig::GetInstance().GetGameID(), number);
++  // if the useId flag is set : if the file with name exits, returns it, otherwise, if the file with id exists, returns it, otherwise, return the file with name
++  // => priority with the file with name.
++  // if the game is not loaded from a file (disk), use the gameId
++  std::string filePartName = MakeStateFilename_partfileName(number);
++  std::string fileWithName = fmt::format("{}{}", MakeStateFilename_partdirectory(number), filePartName);
++  if (File::Exists(fileWithName) && filePartName != "")
++    return fileWithName;
++  std::string fileWithId = fmt::format("{}{}", MakeStateFilename_partdirectory(number), MakeStateFilename_partfileID(number));
++  if (File::Exists(fileWithId) && useId)
++    return fileWithId;
++  if(filePartName == "") return fileWithId;
++  return fileWithName;
++}
++
++static std::string MakeStateFilename_partdirectory(int number)
++{
++  return File::GetUserPath(D_STATESAVES_IDX);
++}
++
++static std::string MakeStateFilename_partfileID(int number)
++{
++  return fmt::format("{}.s{:02d}", SConfig::GetInstance().GetGameID(), number);
++}
++
++static std::string MakeStateFilename_partfileName(int number)
++{
++  std::string basesavestate = SConfig::GetInstance().GetBaseSaveState();
++  if(basesavestate == "") return "";
++  return fmt::format("{}.s{:02d}", basesavestate, number);
+ }
+ 
+ void Save(int slot, bool wait)
+ {
+-  SaveAs(MakeStateFilename(slot), wait);
++  std::string savePath = MakeStateFilename(false, slot);
++  SaveAs(savePath, wait);
+ }
+ 
+ void Load(int slot)
+ {
+-  LoadAs(MakeStateFilename(slot));
++  LoadAs(MakeStateFilename(true, slot));
+ }
+ 
+ void LoadLastSaved(int i)
+diff -rupN dolphin.orig/Source/Core/DolphinLib.props dolphin.ss/Source/Core/DolphinLib.props
 --- dolphin.orig/Source/Core/DolphinLib.props	2023-09-26 17:58:02.829996165 +0000
-+++ dolphin/Source/Core/DolphinLib.props	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/DolphinLib.props	2023-10-27 13:46:40.185376472 +0000
 @@ -1207,6 +1207,7 @@
      <ClCompile Include="VideoBackends\Vulkan\VKPerfQuery.cpp" />
      <ClCompile Include="VideoBackends\Vulkan\VKPipeline.cpp" />
@@ -498,9 +643,9 @@ diff -rupN dolphin.orig/Source/Core/DolphinLib.props dolphin/Source/Core/Dolphin
      <ClCompile Include="VideoBackends\Vulkan\VKShader.cpp" />
      <ClCompile Include="VideoBackends\Vulkan\VKStreamBuffer.cpp" />
      <ClCompile Include="VideoBackends\Vulkan\VKSwapChain.cpp" />
-diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/CMakeLists.txt dolphin/Source/Core/DolphinNoGUI/CMakeLists.txt
+diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/CMakeLists.txt dolphin.ss/Source/Core/DolphinNoGUI/CMakeLists.txt
 --- dolphin.orig/Source/Core/DolphinNoGUI/CMakeLists.txt	2023-09-26 17:58:02.833996257 +0000
-+++ dolphin/Source/Core/DolphinNoGUI/CMakeLists.txt	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/DolphinNoGUI/CMakeLists.txt	2023-10-27 13:46:40.157375820 +0000
 @@ -17,6 +17,22 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux"
    target_sources(dolphin-nogui PRIVATE PlatformFBDev.cpp)
  endif()
@@ -524,9 +669,9 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/CMakeLists.txt dolphin/Source/C
  set_target_properties(dolphin-nogui PROPERTIES OUTPUT_NAME dolphin-emu-nogui)
  
  target_link_libraries(dolphin-nogui
-diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/MainNoGUI.cpp dolphin/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/MainNoGUI.cpp dolphin.ss/Source/Core/DolphinNoGUI/MainNoGUI.cpp
 --- dolphin.orig/Source/Core/DolphinNoGUI/MainNoGUI.cpp	2023-09-26 17:58:02.833996257 +0000
-+++ dolphin/Source/Core/DolphinNoGUI/MainNoGUI.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/DolphinNoGUI/MainNoGUI.cpp	2023-10-27 13:46:40.173376194 +0000
 @@ -155,6 +155,11 @@ static std::unique_ptr<Platform> GetPlat
  {
    std::string platform_name = static_cast<const char*>(options.get("platform"));
@@ -550,9 +695,9 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/MainNoGUI.cpp dolphin/Source/Co
        });
  
    optparse::Values& options = CommandLineParse::ParseArguments(parser.get(), argc, argv);
-diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/Platform.h dolphin/Source/Core/DolphinNoGUI/Platform.h
+diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/Platform.h dolphin.ss/Source/Core/DolphinNoGUI/Platform.h
 --- dolphin.orig/Source/Core/DolphinNoGUI/Platform.h	2023-09-26 17:58:02.833996257 +0000
-+++ dolphin/Source/Core/DolphinNoGUI/Platform.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/DolphinNoGUI/Platform.h	2023-10-27 13:46:40.185376472 +0000
 @@ -35,6 +35,10 @@ public:
    static std::unique_ptr<Platform> CreateX11Platform();
  #endif
@@ -564,9 +709,9 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/Platform.h dolphin/Source/Core/
  #ifdef __linux__
    static std::unique_ptr<Platform> CreateFBDevPlatform();
  #endif
-diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformWayland.cpp dolphin/Source/Core/DolphinNoGUI/PlatformWayland.cpp
+diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformWayland.cpp dolphin.ss/Source/Core/DolphinNoGUI/PlatformWayland.cpp
 --- dolphin.orig/Source/Core/DolphinNoGUI/PlatformWayland.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/Source/Core/DolphinNoGUI/PlatformWayland.cpp	2023-09-26 18:27:27.334792936 +0000
++++ dolphin.ss/Source/Core/DolphinNoGUI/PlatformWayland.cpp	2023-10-27 13:46:40.185376472 +0000
 @@ -0,0 +1,364 @@
 +// Copyright 2018 Dolphin Emulator Project
 +// Licensed under GPLv2+
@@ -932,9 +1077,9 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformWayland.cpp dolphin/Sou
 +{
 +  return std::make_unique<PlatformWayland>();
 +}
-diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp dolphin/Source/Core/DolphinNoGUI/PlatformX11.cpp
+diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp dolphin.ss/Source/Core/DolphinNoGUI/PlatformX11.cpp
 --- dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp	2023-09-26 17:58:02.833996257 +0000
-+++ dolphin/Source/Core/DolphinNoGUI/PlatformX11.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/DolphinNoGUI/PlatformX11.cpp	2023-10-27 13:46:40.185376472 +0000
 @@ -57,8 +57,8 @@ private:
  #endif
    int m_window_x = Config::Get(Config::MAIN_RENDER_WINDOW_XPOS);
@@ -979,9 +1124,9 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp dolphin/Source/
      }
      break;
      }
-diff -rupN dolphin.orig/Source/Core/InputCommon/GCPadStatus.h dolphin/Source/Core/InputCommon/GCPadStatus.h
+diff -rupN dolphin.orig/Source/Core/InputCommon/GCPadStatus.h dolphin.ss/Source/Core/InputCommon/GCPadStatus.h
 --- dolphin.orig/Source/Core/InputCommon/GCPadStatus.h	2023-09-26 17:58:02.845996536 +0000
-+++ dolphin/Source/Core/InputCommon/GCPadStatus.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/InputCommon/GCPadStatus.h	2023-10-27 13:46:40.297379075 +0000
 @@ -26,6 +26,7 @@ enum PadButton
    PAD_BUTTON_X = 0x0400,
    PAD_BUTTON_Y = 0x0800,
@@ -990,9 +1135,9 @@ diff -rupN dolphin.orig/Source/Core/InputCommon/GCPadStatus.h dolphin/Source/Cor
  };
  
  struct GCPadStatus
-diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.cpp dolphin/Source/Core/VideoBackends/OGL/OGLRender.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.cpp dolphin.ss/Source/Core/VideoBackends/OGL/OGLRender.cpp
 --- dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/OGL/OGLRender.cpp	2023-09-26 21:41:39.568275473 +0000
++++ dolphin.ss/Source/Core/VideoBackends/OGL/OGLRender.cpp	2023-10-27 13:46:40.349380285 +0000
 @@ -471,11 +471,7 @@ Renderer::Renderer(std::unique_ptr<GLCon
    g_ogl_config.bSupportsDebug =
        GLExtensions::Supports("GL_KHR_debug") || GLExtensions::Supports("GL_ARB_debug_output");
@@ -1103,9 +1248,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.cpp dolphin/Sour
    m_backbuffer_width = m_main_gl_context->GetBackBufferWidth();
    m_backbuffer_height = m_main_gl_context->GetBackBufferHeight();
    m_system_framebuffer->UpdateDimensions(m_backbuffer_width, m_backbuffer_height);
-diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.h dolphin/Source/Core/VideoBackends/OGL/OGLRender.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.h dolphin.ss/Source/Core/VideoBackends/OGL/OGLRender.h
 --- dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/OGL/OGLRender.h	2023-09-26 21:32:17.039048706 +0000
++++ dolphin.ss/Source/Core/VideoBackends/OGL/OGLRender.h	2023-10-27 13:46:40.345380190 +0000
 @@ -31,6 +31,14 @@ enum GlslVersion
    GlslEs310,  // GLES 3.1
    GlslEs320,  // GLES 3.2
@@ -1149,9 +1294,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.h dolphin/Source
    bool bSupportsConservativeDepth;
    bool bSupportsImageLoadStore;
    bool bSupportsAniso;
-diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLTexture.cpp dolphin/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLTexture.cpp dolphin.ss/Source/Core/VideoBackends/OGL/OGLTexture.cpp
 --- dolphin.orig/Source/Core/VideoBackends/OGL/OGLTexture.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/OGL/OGLTexture.cpp	2023-09-26 21:34:37.398249032 +0000
++++ dolphin.ss/Source/Core/VideoBackends/OGL/OGLTexture.cpp	2023-10-27 13:46:40.345380190 +0000
 @@ -128,12 +128,18 @@ OGLTexture::OGLTexture(const TextureConf
    GLenum gl_internal_format = GetGLInternalFormatForTextureFormat(m_config.format, true);
    if (tex_config.IsMultisampled())
@@ -1172,9 +1317,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLTexture.cpp dolphin/Sou
    }
    else if (g_ogl_config.bSupportsTextureStorage)
    {
-diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp dolphin/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp dolphin.ss/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
 --- dolphin.orig/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp	2023-09-26 21:37:11.705777665 +0000
++++ dolphin.ss/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp	2023-10-27 13:46:40.341380098 +0000
 @@ -661,12 +661,13 @@ void ProgramShaderCache::CreateHeader()
    std::string SupportedESTextureBuffer;
    switch (g_ogl_config.SupportedESPointSize)
@@ -1233,9 +1378,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp dol
        v >= GlslEs310 ? "precision highp image2DArray;" : "");
  }
  
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.cpp dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.cpp dolphin.ss/Source/Core/VideoBackends/Software/SWOGLWindow.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Software/SWOGLWindow.cpp	2023-10-27 13:46:40.357380469 +0000
 @@ -32,6 +32,16 @@ bool SWOGLWindow::IsHeadless() const
    return m_gl_context->IsHeadless();
  }
@@ -1272,9 +1417,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.cpp dolph
  
    GLsizei glWidth = (GLsizei)m_gl_context->GetBackBufferWidth();
    GLsizei glHeight = (GLsizei)m_gl_context->GetBackBufferHeight();
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.h dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.h dolphin.ss/Source/Core/VideoBackends/Software/SWOGLWindow.h
 --- dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Software/SWOGLWindow.h	2023-10-27 13:46:40.357380469 +0000
 @@ -20,6 +20,10 @@ public:
    GLContext* GetContext() const { return m_gl_context.get(); }
    bool IsHeadless() const;
@@ -1286,9 +1431,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.h dolphin
    // Image to show, will be swapped immediately
    void ShowImage(const AbstractTexture* image, const MathUtil::Rectangle<int>& xfb_region);
  
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.cpp dolphin/Source/Core/VideoBackends/Software/SWRenderer.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.cpp dolphin.ss/Source/Core/VideoBackends/Software/SWRenderer.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Software/SWRenderer.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Software/SWRenderer.cpp	2023-10-27 13:46:40.357380469 +0000
 @@ -60,17 +60,17 @@ SWRenderer::CreateFramebuffer(AbstractTe
                                 static_cast<SWTexture*>(depth_attachment));
  }
@@ -1342,9 +1487,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.cpp dolphi
  u32 SWRenderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 InputData)
  {
    u32 value = 0;
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.h dolphin/Source/Core/VideoBackends/Software/SWRenderer.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.h dolphin.ss/Source/Core/VideoBackends/Software/SWRenderer.h
 --- dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Software/SWRenderer.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Software/SWRenderer.h	2023-10-27 13:46:40.357380469 +0000
 @@ -29,7 +29,7 @@ public:
    std::unique_ptr<AbstractFramebuffer>
    CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment) override;
@@ -1363,9 +1508,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.h dolphin/
    std::unique_ptr<SWOGLWindow> m_window;
  };
  }  // namespace SW
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CMakeLists.txt dolphin/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CMakeLists.txt dolphin.ss/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/CMakeLists.txt	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/CMakeLists.txt	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/CMakeLists.txt	2023-10-27 13:46:40.357380469 +0000
 @@ -35,6 +35,8 @@ add_library(videovulkan
    VulkanContext.h
    VulkanLoader.cpp
@@ -1375,9 +1520,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CMakeLists.txt dolphin/
  )
  
  target_link_libraries(videovulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp	2023-10-27 13:46:40.357380469 +0000
 @@ -10,24 +10,24 @@
  #include "Common/MsgHandler.h"
  #include "Common/Thread.h"
@@ -1776,9 +1921,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cp
 -
 -std::unique_ptr<CommandBufferManager> g_command_buffer_mgr;
  }  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h dolphin.ss/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h	2023-10-27 13:46:40.357380469 +0000
 @@ -22,10 +22,12 @@
  
  namespace Vulkan
@@ -1917,9 +2062,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h 
 +};
  
  }  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/Constants.h dolphin/Source/Core/VideoBackends/Vulkan/Constants.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/Constants.h dolphin.ss/Source/Core/VideoBackends/Vulkan/Constants.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/Constants.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/Constants.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/Constants.h	2023-10-27 13:46:40.357380469 +0000
 @@ -12,7 +12,7 @@
  namespace Vulkan
  {
@@ -1929,9 +2074,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/Constants.h dolphin/Sou
  
  // Number of frames in flight, will be used to decide how many descriptor pools are used
  constexpr size_t NUM_FRAMES_IN_FLIGHT = 2;
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp	2023-10-27 13:46:40.357380469 +0000
 @@ -389,6 +389,8 @@ VkSampler ObjectCache::GetSampler(const
  VkRenderPass ObjectCache::GetRenderPass(VkFormat color_format, VkFormat depth_format,
                                          u32 multisamples, VkAttachmentLoadOp load_op)
@@ -1950,9 +2095,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp dolphin
    for (auto& it : m_render_pass_cache)
      vkDestroyRenderPass(g_vulkan_context->GetDevice(), it.second, nullptr);
    m_render_pass_cache.clear();
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.h dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.h dolphin.ss/Source/Core/VideoBackends/Vulkan/ObjectCache.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/ObjectCache.h	2023-10-27 13:46:40.357380469 +0000
 @@ -7,6 +7,7 @@
  #include <cstddef>
  #include <map>
@@ -1969,9 +2114,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.h dolphin/S
    using RenderPassCacheKey = std::tuple<VkFormat, VkFormat, u32, VkAttachmentLoadOp>;
    std::map<RenderPassCacheKey, VkRenderPass> m_render_pass_cache;
  
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp dolphin/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp	2023-10-27 13:46:40.357380469 +0000
 @@ -8,6 +8,7 @@
  
  #include "Common/Assert.h"
@@ -1992,9 +2137,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp dolph
  }
  
  void StagingBuffer::BufferMemoryBarrier(VkCommandBuffer command_buffer, VkBuffer buffer,
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.cpp dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/StateTracker.cpp	2023-10-27 13:46:40.369380750 +0000
 @@ -16,59 +16,93 @@
  
  namespace Vulkan
@@ -2393,9 +2538,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.cpp dolphi
                              VK_PIPELINE_BIND_POINT_COMPUTE,
                              g_object_cache->GetPipelineLayout(PIPELINE_LAYOUT_COMPUTE), 0, 1,
                              &m_compute_descriptor_set, 1, &m_bindings.utility_ubo_offset);
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.h dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.h dolphin.ss/Source/Core/VideoBackends/Vulkan/StateTracker.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/StateTracker.h	2023-10-27 13:46:40.369380750 +0000
 @@ -13,28 +13,24 @@
  
  namespace Vulkan
@@ -2470,9 +2615,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.h dolphin/
 +  VkRect2D m_render_area = {};
  };
  }  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp	2023-10-27 13:46:40.369380750 +0000
 @@ -12,6 +12,7 @@
  #include "VideoBackends/Vulkan/StagingBuffer.h"
  #include "VideoBackends/Vulkan/StateTracker.h"
@@ -2609,9 +2754,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp dolph
  }
  
  bool VKBoundingBox::CreateGPUBuffer()
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKMain.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKMain.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKMain.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKMain.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKMain.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKMain.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKMain.cpp	2023-10-27 13:46:40.369380750 +0000
 @@ -18,6 +18,7 @@
  #include "VideoBackends/Vulkan/VKVertexManager.h"
  #include "VideoBackends/Vulkan/VulkanContext.h"
@@ -2695,9 +2840,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKMain.cpp dolphin/Sour
    g_vulkan_context.reset();
    ShutdownShared();
    UnloadVulkanLibrary();
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp	2023-10-27 13:46:40.369380750 +0000
 @@ -11,6 +11,7 @@
  #include "Common/Logging/Log.h"
  #include "Common/MsgHandler.h"
@@ -2816,9 +2961,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp dolphin
    {
      Renderer::GetInstance()->ExecuteCommandBuffer(true, blocking);
    }
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp	2023-10-27 13:46:40.369380750 +0000
 @@ -31,6 +31,7 @@
  #include "VideoBackends/Vulkan/VKVertexFormat.h"
  #include "VideoBackends/Vulkan/VulkanContext.h"
@@ -3538,9 +3683,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp dolphin/
  }
  
  }  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp	2023-10-27 13:46:40.377380934 +0000
 @@ -0,0 +1,155 @@
 +// Copyright 2022 Dolphin Emulator Project
 +// SPDX-License-Identifier: GPL-2.0-or-later
@@ -3697,9 +3842,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp dolphin
 +
 +std::unique_ptr<Scheduler> g_scheduler;
 +}  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.h dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.h dolphin.ss/Source/Core/VideoBackends/Vulkan/VKScheduler.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.h	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKScheduler.h	2023-10-27 13:46:40.377380934 +0000
 @@ -0,0 +1,160 @@
 +// Copyright 2022 Dolphin Emulator Project
 +// SPDX-License-Identifier: GPL-2.0-or-later
@@ -3861,9 +4006,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.h dolphin/S
 +
 +extern std::unique_ptr<Scheduler> g_scheduler;
 +}  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp	2023-10-27 13:46:40.377380934 +0000
 @@ -12,6 +12,7 @@
  #include "Common/MsgHandler.h"
  
@@ -3936,9 +4081,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp dolp
    m_tracked_fences.erase(m_tracked_fences.begin(),
                           m_current_offset == iter->second ? m_tracked_fences.end() : ++iter);
    m_current_offset = new_offset;
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp	2023-10-27 13:46:40.377380934 +0000
 @@ -13,9 +13,9 @@
  
  #include "VideoBackends/Vulkan/CommandBufferManager.h"
@@ -4102,9 +4247,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp dolphin
    m_surface = CreateVulkanSurface(g_vulkan_context->GetVulkanInstance(), m_wsi);
    if (m_surface == VK_NULL_HANDLE)
      return false;
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.h dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.h dolphin.ss/Source/Core/VideoBackends/Vulkan/VKSwapChain.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKSwapChain.h	2023-10-27 13:46:40.377380934 +0000
 @@ -3,6 +3,7 @@
  
  #pragma once
@@ -4157,9 +4302,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.h dolphin/S
    u32 m_width = 0;
    u32 m_height = 0;
    u32 m_layers = 0;
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKTexture.cpp	2023-10-27 13:46:40.377380934 +0000
 @@ -21,6 +21,7 @@
  #include "VideoBackends/Vulkan/VKStreamBuffer.h"
  #include "VideoBackends/Vulkan/VulkanContext.h"
@@ -4666,9 +4811,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.cpp dolphin/S
    }
  }
  }  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.h dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.h dolphin.ss/Source/Core/VideoBackends/Vulkan/VKTexture.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKTexture.h	2023-10-27 13:46:40.377380934 +0000
 @@ -67,8 +67,8 @@ public:
    // irrelevant and will not be loaded.
    void OverrideImageLayout(VkImageLayout new_layout);
@@ -4680,9 +4825,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.h dolphin/Sou
  
  private:
    bool CreateView(VkImageViewType type);
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp	2023-10-27 13:46:40.377380934 +0000
 @@ -15,6 +15,7 @@
  #include "VideoBackends/Vulkan/CommandBufferManager.h"
  #include "VideoBackends/Vulkan/StateTracker.h"
@@ -4876,9 +5021,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp dol
    return true;
  }
  }  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp dolphin/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp	2023-10-27 13:46:40.377380934 +0000
 @@ -274,6 +274,13 @@ bool VulkanContext::SelectInstanceExtens
      return false;
    }
@@ -4893,9 +5038,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp dolph
  #if defined(VK_USE_PLATFORM_ANDROID_KHR)
    if (wstype == WindowSystemType::Android &&
        !AddExtension(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, true))
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl dolphin/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl dolphin.ss/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl	2023-10-27 13:46:40.377380934 +0000
 @@ -49,6 +49,11 @@ VULKAN_INSTANCE_ENTRY_POINT(vkCreateXlib
  VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceXlibPresentationSupportKHR, false)
  #endif
@@ -4908,9 +5053,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl d
  #if defined(VK_USE_PLATFORM_ANDROID_KHR)
  VULKAN_INSTANCE_ENTRY_POINT(vkCreateAndroidSurfaceKHR, false)
  #endif
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanLoader.h dolphin/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanLoader.h dolphin.ss/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanLoader.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VulkanLoader.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VulkanLoader.h	2023-10-27 13:46:40.377380934 +0000
 @@ -13,6 +13,10 @@
  #define VK_USE_PLATFORM_XLIB_KHR
  #endif
@@ -4922,9 +5067,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanLoader.h dolphin/
  #if defined(ANDROID)
  #define VK_USE_PLATFORM_ANDROID_KHR
  #endif
-diff -rupN dolphin.orig/Source/Core/VideoCommon/FramebufferManager.cpp dolphin/Source/Core/VideoCommon/FramebufferManager.cpp
+diff -rupN dolphin.orig/Source/Core/VideoCommon/FramebufferManager.cpp dolphin.ss/Source/Core/VideoCommon/FramebufferManager.cpp
 --- dolphin.orig/Source/Core/VideoCommon/FramebufferManager.cpp	2023-09-26 17:58:02.857996813 +0000
-+++ dolphin/Source/Core/VideoCommon/FramebufferManager.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoCommon/FramebufferManager.cpp	2023-10-27 13:46:40.429382144 +0000
 @@ -630,7 +630,7 @@ void FramebufferManager::DestroyReadback
  
  bool FramebufferManager::CreateReadbackFramebuffer()
@@ -4961,9 +5106,9 @@ diff -rupN dolphin.orig/Source/Core/VideoCommon/FramebufferManager.cpp dolphin/S
      destination_list->push_back({{cs_x, cs_y, z, point_size}, color});
      return;
    }
-diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.cpp dolphin/Source/Core/VideoCommon/RenderBase.cpp
+diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.cpp dolphin.ss/Source/Core/VideoCommon/RenderBase.cpp
 --- dolphin.orig/Source/Core/VideoCommon/RenderBase.cpp	2023-09-26 17:58:02.857996813 +0000
-+++ dolphin/Source/Core/VideoCommon/RenderBase.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoCommon/RenderBase.cpp	2023-10-27 13:46:40.429382144 +0000
 @@ -364,19 +364,24 @@ void Renderer::RenderToXFB(u32 xfbAddr,
      return;
  }
@@ -5025,9 +5170,9 @@ diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.cpp dolphin/Source/Co
    m_surface_resized.Set();
  }
  
-diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.h dolphin/Source/Core/VideoCommon/RenderBase.h
+diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.h dolphin.ss/Source/Core/VideoCommon/RenderBase.h
 --- dolphin.orig/Source/Core/VideoCommon/RenderBase.h	2023-09-26 17:58:02.857996813 +0000
-+++ dolphin/Source/Core/VideoCommon/RenderBase.h	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoCommon/RenderBase.h	2023-10-27 13:46:40.429382144 +0000
 @@ -193,7 +193,8 @@ public:
    std::tuple<MathUtil::Rectangle<int>, MathUtil::Rectangle<int>>
    ConvertStereoRectangle(const MathUtil::Rectangle<int>& rc) const;
@@ -5068,9 +5213,9 @@ diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.h dolphin/Source/Core
  
    // These will be set on the first call to SetWindowSize.
    int m_last_window_request_width = 0;
-diff -rupN dolphin.orig/Source/Core/VideoCommon/TextureCacheBase.cpp dolphin/Source/Core/VideoCommon/TextureCacheBase.cpp
+diff -rupN dolphin.orig/Source/Core/VideoCommon/TextureCacheBase.cpp dolphin.ss/Source/Core/VideoCommon/TextureCacheBase.cpp
 --- dolphin.orig/Source/Core/VideoCommon/TextureCacheBase.cpp	2023-09-26 17:58:02.857996813 +0000
-+++ dolphin/Source/Core/VideoCommon/TextureCacheBase.cpp	2023-09-26 18:02:22.836042087 +0000
++++ dolphin.ss/Source/Core/VideoCommon/TextureCacheBase.cpp	2023-10-27 13:46:40.429382144 +0000
 @@ -1046,7 +1046,7 @@ static void SetSamplerState(u32 index, f
      // that have arbitrary contents, eg. are used for fog effects where the
      // distance they kick in at is important to preserve at any resolution.

--- a/packages/emulators/standalone/dolphin-sa/patches/wayland/000-add-wayland.patch
+++ b/packages/emulators/standalone/dolphin-sa/patches/wayland/000-add-wayland.patch
@@ -1,6 +1,6 @@
-diff -rupN dolphin.orig/CMake/FindWaylandProtocols.cmake dolphin.ss/CMake/FindWaylandProtocols.cmake
+diff -rupN dolphin.orig/CMake/FindWaylandProtocols.cmake dolphin/CMake/FindWaylandProtocols.cmake
 --- dolphin.orig/CMake/FindWaylandProtocols.cmake	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin.ss/CMake/FindWaylandProtocols.cmake	2023-10-27 13:46:38.317333047 +0000
++++ dolphin/CMake/FindWaylandProtocols.cmake	2023-10-27 13:46:38.317333047 +0000
 @@ -0,0 +1,28 @@
 +# from https://github.com/glfw/glfw/blob/master/CMake/modules/FindWaylandProtocols.cmake
 +
@@ -30,9 +30,9 @@ diff -rupN dolphin.orig/CMake/FindWaylandProtocols.cmake dolphin.ss/CMake/FindWa
 +set(WAYLAND_PROTOCOLS_FOUND ${WaylandProtocols_FOUND})
 +set(WAYLAND_PROTOCOLS_PKGDATADIR ${WaylandProtocols_PKGDATADIR})
 +set(WAYLAND_PROTOCOLS_VERSION ${WaylandProtocols_VERSION})
-diff -rupN dolphin.orig/CMake/FindXKBCommon.cmake dolphin.ss/CMake/FindXKBCommon.cmake
+diff -rupN dolphin.orig/CMake/FindXKBCommon.cmake dolphin/CMake/FindXKBCommon.cmake
 --- dolphin.orig/CMake/FindXKBCommon.cmake	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin.ss/CMake/FindXKBCommon.cmake	2023-10-27 13:46:38.317333047 +0000
++++ dolphin/CMake/FindXKBCommon.cmake	2023-10-27 13:46:38.317333047 +0000
 @@ -0,0 +1,33 @@
 +# - Try to find XKBCommon
 +# Once done, this will define
@@ -67,9 +67,9 @@ diff -rupN dolphin.orig/CMake/FindXKBCommon.cmake dolphin.ss/CMake/FindXKBCommon
 +)
 +
 +mark_as_advanced(XKBCOMMON_LIBRARY XKBCOMMON_INCLUDE_DIR)
-diff -rupN dolphin.orig/CMakeLists.txt dolphin.ss/CMakeLists.txt
+diff -rupN dolphin.orig/CMakeLists.txt dolphin/CMakeLists.txt
 --- dolphin.orig/CMakeLists.txt	2023-09-26 17:58:02.593990718 +0000
-+++ dolphin.ss/CMakeLists.txt	2023-10-27 13:46:40.473383166 +0000
++++ dolphin/CMakeLists.txt	2023-10-27 13:46:40.473383166 +0000
 @@ -47,6 +47,7 @@ set(DOLPHIN_DEFAULT_UPDATE_TRACK "" CACH
  
  if(UNIX AND NOT APPLE AND NOT ANDROID)
@@ -96,9 +96,9 @@ diff -rupN dolphin.orig/CMakeLists.txt dolphin.ss/CMakeLists.txt
  if(ENABLE_EGL)
    find_package(EGL)
    if(EGL_FOUND)
-diff -rupN dolphin.orig/Source/Core/Common/CMakeLists.txt dolphin.ss/Source/Core/Common/CMakeLists.txt
+diff -rupN dolphin.orig/Source/Core/Common/CMakeLists.txt dolphin/Source/Core/Common/CMakeLists.txt
 --- dolphin.orig/Source/Core/Common/CMakeLists.txt	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin.ss/Source/Core/Common/CMakeLists.txt	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/CMakeLists.txt	2023-10-27 13:46:39.913370149 +0000
 @@ -253,11 +253,20 @@ if(ENABLE_EGL AND EGL_FOUND)
        GL/GLInterface/EGLAndroid.cpp
        GL/GLInterface/EGLAndroid.h
@@ -125,9 +125,9 @@ diff -rupN dolphin.orig/Source/Core/Common/CMakeLists.txt dolphin.ss/Source/Core
    endif()
    target_include_directories(common PRIVATE ${EGL_INCLUDE_DIRS})
    target_link_libraries(common PUBLIC ${EGL_LIBRARIES})
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.cpp dolphin.ss/Source/Core/Common/GL/GLContext.cpp
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.cpp dolphin/Source/Core/Common/GL/GLContext.cpp
 --- dolphin.orig/Source/Core/Common/GL/GLContext.cpp	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLContext.cpp	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLContext.cpp	2023-10-27 13:46:39.913370149 +0000
 @@ -25,6 +25,9 @@
  #if defined(ANDROID)
  #include "Common/GL/GLInterface/EGLAndroid.h"
@@ -163,9 +163,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.cpp dolphin.ss/Source/Co
  #if HAVE_EGL
    if (wsi.type == WindowSystemType::Headless || wsi.type == WindowSystemType::FBDev)
      context = std::make_unique<GLContextEGL>();
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.h dolphin.ss/Source/Core/Common/GL/GLContext.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.h dolphin/Source/Core/Common/GL/GLContext.h
 --- dolphin.orig/Source/Core/Common/GL/GLContext.h	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLContext.h	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLContext.h	2023-10-27 13:46:39.913370149 +0000
 @@ -36,8 +36,8 @@ public:
    virtual bool MakeCurrent();
    virtual bool ClearCurrent();
@@ -177,9 +177,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.h dolphin.ss/Source/Core
  
    virtual void Swap();
    virtual void SwapInterval(int interval);
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.h dolphin.ss/Source/Core/Common/GL/GLInterface/AGL.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.h dolphin/Source/Core/Common/GL/GLInterface/AGL.h
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.h	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLInterface/AGL.h	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/AGL.h	2023-10-27 13:46:39.913370149 +0000
 @@ -27,6 +27,8 @@ public:
  
    bool MakeCurrent() override;
@@ -189,9 +189,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.h dolphin.ss/Sourc
  
    void Update() override;
  
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.mm dolphin.ss/Source/Core/Common/GL/GLInterface/AGL.mm
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.mm dolphin/Source/Core/Common/GL/GLInterface/AGL.mm
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.mm	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLInterface/AGL.mm	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/AGL.mm	2023-10-27 13:46:39.913370149 +0000
 @@ -144,7 +144,7 @@ bool GLContextAGL::ClearCurrent()
    return true;
  }
@@ -201,9 +201,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.mm dolphin.ss/Sour
  {
    if (!m_view)
      return;
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.cpp dolphin.ss/Source/Core/Common/GL/GLInterface/EGL.cpp
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.cpp dolphin/Source/Core/Common/GL/GLInterface/EGL.cpp
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.cpp	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLInterface/EGL.cpp	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/EGL.cpp	2023-10-27 13:46:39.913370149 +0000
 @@ -292,8 +292,8 @@ bool GLContextEGL::CreateWindowSurface()
  {
    if (!IsHeadless())
@@ -266,9 +266,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.cpp dolphin.ss/Sou
 +  m_backbuffer_width = static_cast<u32>(surface_width);
 +  m_backbuffer_height = static_cast<u32>(surface_height);
 +}
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.h dolphin.ss/Source/Core/Common/GL/GLInterface/EGL.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.h dolphin/Source/Core/Common/GL/GLInterface/EGL.h
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLInterface/EGL.h	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/EGL.h	2023-10-27 13:46:39.913370149 +0000
 @@ -22,7 +22,8 @@ public:
    bool MakeCurrent() override;
    bool ClearCurrent() override;
@@ -292,9 +292,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.h dolphin.ss/Sourc
    EGLConfig m_config;
    bool m_supports_surfaceless = false;
    std::vector<int> m_attribs;
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.cpp dolphin.ss/Source/Core/Common/GL/GLInterface/EGLWayland.cpp
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.cpp dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.cpp
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLInterface/EGLWayland.cpp	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.cpp	2023-10-27 13:46:39.913370149 +0000
 @@ -0,0 +1,36 @@
 +// Copyright 2019 Dolphin Emulator Project
 +// Licensed under GPLv2+
@@ -332,9 +332,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.cpp dolphin
 +
 +  return reinterpret_cast<EGLNativeWindowType>(window);
 +}
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.h dolphin.ss/Source/Core/Common/GL/GLInterface/EGLWayland.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.h dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.h
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.h	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLInterface/EGLWayland.h	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.h	2023-10-27 13:46:39.913370149 +0000
 @@ -0,0 +1,19 @@
 +// Copyright 2019 Dolphin Emulator Project
 +// Licensed under GPLv2+
@@ -355,9 +355,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.h dolphin.s
 +  EGLDisplay OpenEGLDisplay() override;
 +  EGLNativeWindowType GetEGLNativeWindow(EGLConfig config) override;
 +};
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.cpp dolphin.ss/Source/Core/Common/GL/GLInterface/EGLX11.cpp
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.cpp dolphin/Source/Core/Common/GL/GLInterface/EGLX11.cpp
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.cpp	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLInterface/EGLX11.cpp	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/EGLX11.cpp	2023-10-27 13:46:39.913370149 +0000
 @@ -11,7 +11,7 @@ GLContextEGLX11::~GLContextEGLX11()
    m_render_window.reset();
  }
@@ -367,9 +367,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.cpp dolphin.ss/
  {
    m_render_window->UpdateDimensions();
    m_backbuffer_width = m_render_window->GetWidth();
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.h dolphin.ss/Source/Core/Common/GL/GLInterface/EGLX11.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.h dolphin/Source/Core/Common/GL/GLInterface/EGLX11.h
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLInterface/EGLX11.h	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/EGLX11.h	2023-10-27 13:46:39.913370149 +0000
 @@ -13,7 +13,7 @@ class GLContextEGLX11 final : public GLC
  public:
    ~GLContextEGLX11() override;
@@ -379,9 +379,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.h dolphin.ss/So
  
  protected:
    EGLDisplay OpenEGLDisplay() override;
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.cpp dolphin.ss/Source/Core/Common/GL/GLInterface/GLX.cpp
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.cpp dolphin/Source/Core/Common/GL/GLInterface/GLX.cpp
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.cpp	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLInterface/GLX.cpp	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/GLX.cpp	2023-10-27 13:46:39.913370149 +0000
 @@ -310,7 +310,7 @@ bool GLContextGLX::ClearCurrent()
    return glXMakeCurrent(m_display, None, nullptr);
  }
@@ -391,9 +391,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.cpp dolphin.ss/Sou
  {
    m_render_window->UpdateDimensions();
    m_backbuffer_width = m_render_window->GetWidth();
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.h dolphin.ss/Source/Core/Common/GL/GLInterface/GLX.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.h dolphin/Source/Core/Common/GL/GLInterface/GLX.h
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLInterface/GLX.h	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/GLX.h	2023-10-27 13:46:39.913370149 +0000
 @@ -24,7 +24,7 @@ public:
    bool MakeCurrent() override;
    bool ClearCurrent() override;
@@ -403,9 +403,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.h dolphin.ss/Sourc
  
    void SwapInterval(int Interval) override;
    void Swap() override;
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.cpp dolphin.ss/Source/Core/Common/GL/GLInterface/WGL.cpp
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.cpp dolphin/Source/Core/Common/GL/GLInterface/WGL.cpp
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.cpp	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLInterface/WGL.cpp	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/WGL.cpp	2023-10-27 13:46:39.913370149 +0000
 @@ -480,7 +480,7 @@ bool GLContextWGL::ClearCurrent()
  }
  
@@ -415,9 +415,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.cpp dolphin.ss/Sou
  {
    RECT rcWindow;
    GetClientRect(m_window_handle, &rcWindow);
-diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.h dolphin.ss/Source/Core/Common/GL/GLInterface/WGL.h
+diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.h dolphin/Source/Core/Common/GL/GLInterface/WGL.h
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin.ss/Source/Core/Common/GL/GLInterface/WGL.h	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/WGL.h	2023-10-27 13:46:39.913370149 +0000
 @@ -19,7 +19,7 @@ public:
    bool MakeCurrent() override;
    bool ClearCurrent() override;
@@ -427,9 +427,9 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.h dolphin.ss/Sourc
  
    void Swap() override;
    void SwapInterval(int interval) override;
-diff -rupN dolphin.orig/Source/Core/Common/WindowSystemInfo.h dolphin.ss/Source/Core/Common/WindowSystemInfo.h
+diff -rupN dolphin.orig/Source/Core/Common/WindowSystemInfo.h dolphin/Source/Core/Common/WindowSystemInfo.h
 --- dolphin.orig/Source/Core/Common/WindowSystemInfo.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin.ss/Source/Core/Common/WindowSystemInfo.h	2023-10-27 13:46:39.937370706 +0000
++++ dolphin/Source/Core/Common/WindowSystemInfo.h	2023-10-27 13:46:39.937370706 +0000
 @@ -40,7 +40,11 @@ struct WindowSystemInfo
    // This is kept seperate as input may require a different handle to rendering, and
    // during video backend startup the surface pointer may change (MoltenVK).
@@ -443,9 +443,9 @@ diff -rupN dolphin.orig/Source/Core/Common/WindowSystemInfo.h dolphin.ss/Source/
    // Scale of the render surface. For hidpi systems, this will be >1.
    float render_surface_scale = 1.0f;
  };
-diff -rupN dolphin.orig/Source/Core/Core/BootManager.cpp dolphin.ss/Source/Core/Core/BootManager.cpp
+diff -rupN dolphin.orig/Source/Core/Core/BootManager.cpp dolphin/Source/Core/Core/BootManager.cpp
 --- dolphin.orig/Source/Core/Core/BootManager.cpp	2023-09-26 17:58:02.809995703 +0000
-+++ dolphin.ss/Source/Core/Core/BootManager.cpp	2023-10-27 13:48:21.555727990 +0000
++++ dolphin/Source/Core/Core/BootManager.cpp	2023-10-27 13:48:21.555727990 +0000
 @@ -64,6 +64,11 @@ bool BootCore(std::unique_ptr<BootParame
    if (!StartUp.SetPathsAndGameMetadata(*boot))
      return false;
@@ -458,9 +458,9 @@ diff -rupN dolphin.orig/Source/Core/Core/BootManager.cpp dolphin.ss/Source/Core/
    // Movie settings
    if (Movie::IsPlayingInput() && Movie::IsConfigSaved())
    {
-diff -rupN dolphin.orig/Source/Core/Core/ConfigManager.cpp dolphin.ss/Source/Core/Core/ConfigManager.cpp
+diff -rupN dolphin.orig/Source/Core/Core/ConfigManager.cpp dolphin/Source/Core/Core/ConfigManager.cpp
 --- dolphin.orig/Source/Core/Core/ConfigManager.cpp	2023-09-26 17:58:02.809995703 +0000
-+++ dolphin.ss/Source/Core/Core/ConfigManager.cpp	2023-10-27 13:48:21.555727990 +0000
++++ dolphin/Source/Core/Core/ConfigManager.cpp	2023-10-27 13:48:21.555727990 +0000
 @@ -139,6 +139,10 @@ void SConfig::SetRunningGameMetadata(con
    SetRunningGameMetadata(game_id, "", 0, 0, DiscIO::Region::Unknown);
  }
@@ -472,9 +472,9 @@ diff -rupN dolphin.orig/Source/Core/Core/ConfigManager.cpp dolphin.ss/Source/Cor
  void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::string& gametdb_id,
                                       u64 title_id, u16 revision, DiscIO::Region region)
  {
-diff -rupN dolphin.orig/Source/Core/Core/ConfigManager.h dolphin.ss/Source/Core/Core/ConfigManager.h
+diff -rupN dolphin.orig/Source/Core/Core/ConfigManager.h dolphin/Source/Core/Core/ConfigManager.h
 --- dolphin.orig/Source/Core/Core/ConfigManager.h	2023-09-26 17:58:02.809995703 +0000
-+++ dolphin.ss/Source/Core/Core/ConfigManager.h	2023-10-27 13:48:21.555727990 +0000
++++ dolphin/Source/Core/Core/ConfigManager.h	2023-10-27 13:48:21.555727990 +0000
 @@ -56,6 +56,8 @@ struct SConfig
    // TODO: remove this as soon as the ticket view hack in IOS/ES/Views is dropped.
    bool m_disc_booted_from_game_list = false;
@@ -492,9 +492,9 @@ diff -rupN dolphin.orig/Source/Core/Core/ConfigManager.h dolphin.ss/Source/Core/
    std::string m_game_id;
    std::string m_gametdb_id;
    std::string m_title_name;
-diff -rupN dolphin.orig/Source/Core/Core/Core.cpp dolphin.ss/Source/Core/Core/Core.cpp
+diff -rupN dolphin.orig/Source/Core/Core/Core.cpp dolphin/Source/Core/Core/Core.cpp
 --- dolphin.orig/Source/Core/Core/Core.cpp	2023-09-26 17:58:02.809995703 +0000
-+++ dolphin.ss/Source/Core/Core/Core.cpp	2023-10-27 19:08:44.565345159 +0000
++++ dolphin/Source/Core/Core/Core.cpp	2023-10-27 19:08:44.565345159 +0000
 @@ -474,6 +474,8 @@ static void EmuThread(std::unique_ptr<Bo
    // is relative to the render window, instead of the main window.
    ASSERT(g_controller_interface.IsInit());
@@ -504,9 +504,9 @@ diff -rupN dolphin.orig/Source/Core/Core/Core.cpp dolphin.ss/Source/Core/Core/Co
  
    Pad::LoadConfig();
    Pad::LoadGBAConfig();
-diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.cpp dolphin.ss/Source/Core/Core/HW/GCPadEmu.cpp
+diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.cpp dolphin/Source/Core/Core/HW/GCPadEmu.cpp
 --- dolphin.orig/Source/Core/Core/HW/GCPadEmu.cpp	2023-09-26 17:58:02.817995888 +0000
-+++ dolphin.ss/Source/Core/Core/HW/GCPadEmu.cpp	2023-10-27 13:46:40.045373218 +0000
++++ dolphin/Source/Core/Core/HW/GCPadEmu.cpp	2023-10-27 13:46:40.045373218 +0000
 @@ -24,6 +24,7 @@ static const u16 button_bitmasks[] = {
      PAD_BUTTON_X,
      PAD_BUTTON_Y,
@@ -525,9 +525,9 @@ diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.cpp dolphin.ss/Source/Core/
    // sticks
    groups.emplace_back(m_main_stick = new ControllerEmu::OctagonAnalogStick(
                            MAIN_STICK_GROUP, _trans("Control Stick"), MAIN_STICK_GATE_RADIUS));
-diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.h dolphin.ss/Source/Core/Core/HW/GCPadEmu.h
+diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.h dolphin/Source/Core/Core/HW/GCPadEmu.h
 --- dolphin.orig/Source/Core/Core/HW/GCPadEmu.h	2023-09-26 17:58:02.817995888 +0000
-+++ dolphin.ss/Source/Core/Core/HW/GCPadEmu.h	2023-10-27 13:46:40.045373218 +0000
++++ dolphin/Source/Core/Core/HW/GCPadEmu.h	2023-10-27 13:46:40.045373218 +0000
 @@ -65,6 +65,7 @@ public:
    static constexpr const char* X_BUTTON = "X";
    static constexpr const char* Y_BUTTON = "Y";
@@ -536,9 +536,9 @@ diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.h dolphin.ss/Source/Core/Co
    static constexpr const char* START_BUTTON = "Start";
  
    // i18n: The left trigger button (labeled L on real controllers)
-diff -rupN dolphin.orig/Source/Core/Core/State.cpp dolphin.ss/Source/Core/Core/State.cpp
+diff -rupN dolphin.orig/Source/Core/Core/State.cpp dolphin/Source/Core/Core/State.cpp
 --- dolphin.orig/Source/Core/Core/State.cpp	2023-09-26 17:58:02.829996165 +0000
-+++ dolphin.ss/Source/Core/Core/State.cpp	2023-10-27 19:10:09.907147486 +0000
++++ dolphin/Source/Core/Core/State.cpp	2023-10-27 19:10:09.907147486 +0000
 @@ -327,7 +327,10 @@ static std::string SystemTimeAsDoubleToS
  #endif
  }
@@ -632,9 +632,9 @@ diff -rupN dolphin.orig/Source/Core/Core/State.cpp dolphin.ss/Source/Core/Core/S
  }
  
  void LoadLastSaved(int i)
-diff -rupN dolphin.orig/Source/Core/DolphinLib.props dolphin.ss/Source/Core/DolphinLib.props
+diff -rupN dolphin.orig/Source/Core/DolphinLib.props dolphin/Source/Core/DolphinLib.props
 --- dolphin.orig/Source/Core/DolphinLib.props	2023-09-26 17:58:02.829996165 +0000
-+++ dolphin.ss/Source/Core/DolphinLib.props	2023-10-27 13:46:40.185376472 +0000
++++ dolphin/Source/Core/DolphinLib.props	2023-10-27 13:46:40.185376472 +0000
 @@ -1207,6 +1207,7 @@
      <ClCompile Include="VideoBackends\Vulkan\VKPerfQuery.cpp" />
      <ClCompile Include="VideoBackends\Vulkan\VKPipeline.cpp" />
@@ -643,9 +643,9 @@ diff -rupN dolphin.orig/Source/Core/DolphinLib.props dolphin.ss/Source/Core/Dolp
      <ClCompile Include="VideoBackends\Vulkan\VKShader.cpp" />
      <ClCompile Include="VideoBackends\Vulkan\VKStreamBuffer.cpp" />
      <ClCompile Include="VideoBackends\Vulkan\VKSwapChain.cpp" />
-diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/CMakeLists.txt dolphin.ss/Source/Core/DolphinNoGUI/CMakeLists.txt
+diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/CMakeLists.txt dolphin/Source/Core/DolphinNoGUI/CMakeLists.txt
 --- dolphin.orig/Source/Core/DolphinNoGUI/CMakeLists.txt	2023-09-26 17:58:02.833996257 +0000
-+++ dolphin.ss/Source/Core/DolphinNoGUI/CMakeLists.txt	2023-10-27 13:46:40.157375820 +0000
++++ dolphin/Source/Core/DolphinNoGUI/CMakeLists.txt	2023-10-27 13:46:40.157375820 +0000
 @@ -17,6 +17,22 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux"
    target_sources(dolphin-nogui PRIVATE PlatformFBDev.cpp)
  endif()
@@ -669,9 +669,9 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/CMakeLists.txt dolphin.ss/Sourc
  set_target_properties(dolphin-nogui PROPERTIES OUTPUT_NAME dolphin-emu-nogui)
  
  target_link_libraries(dolphin-nogui
-diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/MainNoGUI.cpp dolphin.ss/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/MainNoGUI.cpp dolphin/Source/Core/DolphinNoGUI/MainNoGUI.cpp
 --- dolphin.orig/Source/Core/DolphinNoGUI/MainNoGUI.cpp	2023-09-26 17:58:02.833996257 +0000
-+++ dolphin.ss/Source/Core/DolphinNoGUI/MainNoGUI.cpp	2023-10-27 13:46:40.173376194 +0000
++++ dolphin/Source/Core/DolphinNoGUI/MainNoGUI.cpp	2023-10-27 13:46:40.173376194 +0000
 @@ -155,6 +155,11 @@ static std::unique_ptr<Platform> GetPlat
  {
    std::string platform_name = static_cast<const char*>(options.get("platform"));
@@ -695,9 +695,9 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/MainNoGUI.cpp dolphin.ss/Source
        });
  
    optparse::Values& options = CommandLineParse::ParseArguments(parser.get(), argc, argv);
-diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/Platform.h dolphin.ss/Source/Core/DolphinNoGUI/Platform.h
+diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/Platform.h dolphin/Source/Core/DolphinNoGUI/Platform.h
 --- dolphin.orig/Source/Core/DolphinNoGUI/Platform.h	2023-09-26 17:58:02.833996257 +0000
-+++ dolphin.ss/Source/Core/DolphinNoGUI/Platform.h	2023-10-27 13:46:40.185376472 +0000
++++ dolphin/Source/Core/DolphinNoGUI/Platform.h	2023-10-27 13:46:40.185376472 +0000
 @@ -35,6 +35,10 @@ public:
    static std::unique_ptr<Platform> CreateX11Platform();
  #endif
@@ -709,9 +709,9 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/Platform.h dolphin.ss/Source/Co
  #ifdef __linux__
    static std::unique_ptr<Platform> CreateFBDevPlatform();
  #endif
-diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformWayland.cpp dolphin.ss/Source/Core/DolphinNoGUI/PlatformWayland.cpp
+diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformWayland.cpp dolphin/Source/Core/DolphinNoGUI/PlatformWayland.cpp
 --- dolphin.orig/Source/Core/DolphinNoGUI/PlatformWayland.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin.ss/Source/Core/DolphinNoGUI/PlatformWayland.cpp	2023-10-27 13:46:40.185376472 +0000
++++ dolphin/Source/Core/DolphinNoGUI/PlatformWayland.cpp	2023-10-27 13:46:40.185376472 +0000
 @@ -0,0 +1,364 @@
 +// Copyright 2018 Dolphin Emulator Project
 +// Licensed under GPLv2+
@@ -1077,9 +1077,9 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformWayland.cpp dolphin.ss/
 +{
 +  return std::make_unique<PlatformWayland>();
 +}
-diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp dolphin.ss/Source/Core/DolphinNoGUI/PlatformX11.cpp
+diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp dolphin/Source/Core/DolphinNoGUI/PlatformX11.cpp
 --- dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp	2023-09-26 17:58:02.833996257 +0000
-+++ dolphin.ss/Source/Core/DolphinNoGUI/PlatformX11.cpp	2023-10-27 13:46:40.185376472 +0000
++++ dolphin/Source/Core/DolphinNoGUI/PlatformX11.cpp	2023-10-27 13:46:40.185376472 +0000
 @@ -57,8 +57,8 @@ private:
  #endif
    int m_window_x = Config::Get(Config::MAIN_RENDER_WINDOW_XPOS);
@@ -1124,9 +1124,9 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp dolphin.ss/Sour
      }
      break;
      }
-diff -rupN dolphin.orig/Source/Core/InputCommon/GCPadStatus.h dolphin.ss/Source/Core/InputCommon/GCPadStatus.h
+diff -rupN dolphin.orig/Source/Core/InputCommon/GCPadStatus.h dolphin/Source/Core/InputCommon/GCPadStatus.h
 --- dolphin.orig/Source/Core/InputCommon/GCPadStatus.h	2023-09-26 17:58:02.845996536 +0000
-+++ dolphin.ss/Source/Core/InputCommon/GCPadStatus.h	2023-10-27 13:46:40.297379075 +0000
++++ dolphin/Source/Core/InputCommon/GCPadStatus.h	2023-10-27 13:46:40.297379075 +0000
 @@ -26,6 +26,7 @@ enum PadButton
    PAD_BUTTON_X = 0x0400,
    PAD_BUTTON_Y = 0x0800,
@@ -1135,9 +1135,9 @@ diff -rupN dolphin.orig/Source/Core/InputCommon/GCPadStatus.h dolphin.ss/Source/
  };
  
  struct GCPadStatus
-diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.cpp dolphin.ss/Source/Core/VideoBackends/OGL/OGLRender.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.cpp dolphin/Source/Core/VideoBackends/OGL/OGLRender.cpp
 --- dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/OGL/OGLRender.cpp	2023-10-27 13:46:40.349380285 +0000
++++ dolphin/Source/Core/VideoBackends/OGL/OGLRender.cpp	2023-10-27 13:46:40.349380285 +0000
 @@ -471,11 +471,7 @@ Renderer::Renderer(std::unique_ptr<GLCon
    g_ogl_config.bSupportsDebug =
        GLExtensions::Supports("GL_KHR_debug") || GLExtensions::Supports("GL_ARB_debug_output");
@@ -1248,9 +1248,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.cpp dolphin.ss/S
    m_backbuffer_width = m_main_gl_context->GetBackBufferWidth();
    m_backbuffer_height = m_main_gl_context->GetBackBufferHeight();
    m_system_framebuffer->UpdateDimensions(m_backbuffer_width, m_backbuffer_height);
-diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.h dolphin.ss/Source/Core/VideoBackends/OGL/OGLRender.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.h dolphin/Source/Core/VideoBackends/OGL/OGLRender.h
 --- dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/OGL/OGLRender.h	2023-10-27 13:46:40.345380190 +0000
++++ dolphin/Source/Core/VideoBackends/OGL/OGLRender.h	2023-10-27 13:46:40.345380190 +0000
 @@ -31,6 +31,14 @@ enum GlslVersion
    GlslEs310,  // GLES 3.1
    GlslEs320,  // GLES 3.2
@@ -1294,9 +1294,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.h dolphin.ss/Sou
    bool bSupportsConservativeDepth;
    bool bSupportsImageLoadStore;
    bool bSupportsAniso;
-diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLTexture.cpp dolphin.ss/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLTexture.cpp dolphin/Source/Core/VideoBackends/OGL/OGLTexture.cpp
 --- dolphin.orig/Source/Core/VideoBackends/OGL/OGLTexture.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/OGL/OGLTexture.cpp	2023-10-27 13:46:40.345380190 +0000
++++ dolphin/Source/Core/VideoBackends/OGL/OGLTexture.cpp	2023-10-27 13:46:40.345380190 +0000
 @@ -128,12 +128,18 @@ OGLTexture::OGLTexture(const TextureConf
    GLenum gl_internal_format = GetGLInternalFormatForTextureFormat(m_config.format, true);
    if (tex_config.IsMultisampled())
@@ -1317,9 +1317,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLTexture.cpp dolphin.ss/
    }
    else if (g_ogl_config.bSupportsTextureStorage)
    {
-diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp dolphin.ss/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp dolphin/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
 --- dolphin.orig/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp	2023-10-27 13:46:40.341380098 +0000
++++ dolphin/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp	2023-10-27 13:46:40.341380098 +0000
 @@ -661,12 +661,13 @@ void ProgramShaderCache::CreateHeader()
    std::string SupportedESTextureBuffer;
    switch (g_ogl_config.SupportedESPointSize)
@@ -1378,9 +1378,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp dol
        v >= GlslEs310 ? "precision highp image2DArray;" : "");
  }
  
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.cpp dolphin.ss/Source/Core/VideoBackends/Software/SWOGLWindow.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.cpp dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Software/SWOGLWindow.cpp	2023-10-27 13:46:40.357380469 +0000
++++ dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.cpp	2023-10-27 13:46:40.357380469 +0000
 @@ -32,6 +32,16 @@ bool SWOGLWindow::IsHeadless() const
    return m_gl_context->IsHeadless();
  }
@@ -1417,9 +1417,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.cpp dolph
  
    GLsizei glWidth = (GLsizei)m_gl_context->GetBackBufferWidth();
    GLsizei glHeight = (GLsizei)m_gl_context->GetBackBufferHeight();
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.h dolphin.ss/Source/Core/VideoBackends/Software/SWOGLWindow.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.h dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.h
 --- dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Software/SWOGLWindow.h	2023-10-27 13:46:40.357380469 +0000
++++ dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.h	2023-10-27 13:46:40.357380469 +0000
 @@ -20,6 +20,10 @@ public:
    GLContext* GetContext() const { return m_gl_context.get(); }
    bool IsHeadless() const;
@@ -1431,9 +1431,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.h dolphin
    // Image to show, will be swapped immediately
    void ShowImage(const AbstractTexture* image, const MathUtil::Rectangle<int>& xfb_region);
  
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.cpp dolphin.ss/Source/Core/VideoBackends/Software/SWRenderer.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.cpp dolphin/Source/Core/VideoBackends/Software/SWRenderer.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Software/SWRenderer.cpp	2023-10-27 13:46:40.357380469 +0000
++++ dolphin/Source/Core/VideoBackends/Software/SWRenderer.cpp	2023-10-27 13:46:40.357380469 +0000
 @@ -60,17 +60,17 @@ SWRenderer::CreateFramebuffer(AbstractTe
                                 static_cast<SWTexture*>(depth_attachment));
  }
@@ -1487,9 +1487,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.cpp dolphi
  u32 SWRenderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 InputData)
  {
    u32 value = 0;
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.h dolphin.ss/Source/Core/VideoBackends/Software/SWRenderer.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.h dolphin/Source/Core/VideoBackends/Software/SWRenderer.h
 --- dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Software/SWRenderer.h	2023-10-27 13:46:40.357380469 +0000
++++ dolphin/Source/Core/VideoBackends/Software/SWRenderer.h	2023-10-27 13:46:40.357380469 +0000
 @@ -29,7 +29,7 @@ public:
    std::unique_ptr<AbstractFramebuffer>
    CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment) override;
@@ -1508,9 +1508,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.h dolphin.
    std::unique_ptr<SWOGLWindow> m_window;
  };
  }  // namespace SW
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CMakeLists.txt dolphin.ss/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CMakeLists.txt dolphin/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/CMakeLists.txt	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/CMakeLists.txt	2023-10-27 13:46:40.357380469 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/CMakeLists.txt	2023-10-27 13:46:40.357380469 +0000
 @@ -35,6 +35,8 @@ add_library(videovulkan
    VulkanContext.h
    VulkanLoader.cpp
@@ -1520,9 +1520,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CMakeLists.txt dolphin.
  )
  
  target_link_libraries(videovulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp	2023-10-27 13:46:40.357380469 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp	2023-10-27 13:46:40.357380469 +0000
 @@ -10,24 +10,24 @@
  #include "Common/MsgHandler.h"
  #include "Common/Thread.h"
@@ -1921,9 +1921,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cp
 -
 -std::unique_ptr<CommandBufferManager> g_command_buffer_mgr;
  }  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h dolphin.ss/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h	2023-10-27 13:46:40.357380469 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h	2023-10-27 13:46:40.357380469 +0000
 @@ -22,10 +22,12 @@
  
  namespace Vulkan
@@ -2062,9 +2062,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h 
 +};
  
  }  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/Constants.h dolphin.ss/Source/Core/VideoBackends/Vulkan/Constants.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/Constants.h dolphin/Source/Core/VideoBackends/Vulkan/Constants.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/Constants.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/Constants.h	2023-10-27 13:46:40.357380469 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/Constants.h	2023-10-27 13:46:40.357380469 +0000
 @@ -12,7 +12,7 @@
  namespace Vulkan
  {
@@ -2074,9 +2074,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/Constants.h dolphin.ss/
  
  // Number of frames in flight, will be used to decide how many descriptor pools are used
  constexpr size_t NUM_FRAMES_IN_FLIGHT = 2;
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp	2023-10-27 13:46:40.357380469 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp	2023-10-27 13:46:40.357380469 +0000
 @@ -389,6 +389,8 @@ VkSampler ObjectCache::GetSampler(const
  VkRenderPass ObjectCache::GetRenderPass(VkFormat color_format, VkFormat depth_format,
                                          u32 multisamples, VkAttachmentLoadOp load_op)
@@ -2095,9 +2095,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp dolphin
    for (auto& it : m_render_pass_cache)
      vkDestroyRenderPass(g_vulkan_context->GetDevice(), it.second, nullptr);
    m_render_pass_cache.clear();
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.h dolphin.ss/Source/Core/VideoBackends/Vulkan/ObjectCache.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.h dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/ObjectCache.h	2023-10-27 13:46:40.357380469 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.h	2023-10-27 13:46:40.357380469 +0000
 @@ -7,6 +7,7 @@
  #include <cstddef>
  #include <map>
@@ -2114,9 +2114,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.h dolphin.s
    using RenderPassCacheKey = std::tuple<VkFormat, VkFormat, u32, VkAttachmentLoadOp>;
    std::map<RenderPassCacheKey, VkRenderPass> m_render_pass_cache;
  
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp dolphin/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp	2023-10-27 13:46:40.357380469 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp	2023-10-27 13:46:40.357380469 +0000
 @@ -8,6 +8,7 @@
  
  #include "Common/Assert.h"
@@ -2137,9 +2137,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp dolph
  }
  
  void StagingBuffer::BufferMemoryBarrier(VkCommandBuffer command_buffer, VkBuffer buffer,
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.cpp dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/StateTracker.cpp	2023-10-27 13:46:40.369380750 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.cpp	2023-10-27 13:46:40.369380750 +0000
 @@ -16,59 +16,93 @@
  
  namespace Vulkan
@@ -2538,9 +2538,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.cpp dolphi
                              VK_PIPELINE_BIND_POINT_COMPUTE,
                              g_object_cache->GetPipelineLayout(PIPELINE_LAYOUT_COMPUTE), 0, 1,
                              &m_compute_descriptor_set, 1, &m_bindings.utility_ubo_offset);
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.h dolphin.ss/Source/Core/VideoBackends/Vulkan/StateTracker.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.h dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/StateTracker.h	2023-10-27 13:46:40.369380750 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.h	2023-10-27 13:46:40.369380750 +0000
 @@ -13,28 +13,24 @@
  
  namespace Vulkan
@@ -2615,9 +2615,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.h dolphin.
 +  VkRect2D m_render_area = {};
  };
  }  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp	2023-10-27 13:46:40.369380750 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp	2023-10-27 13:46:40.369380750 +0000
 @@ -12,6 +12,7 @@
  #include "VideoBackends/Vulkan/StagingBuffer.h"
  #include "VideoBackends/Vulkan/StateTracker.h"
@@ -2754,9 +2754,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp dolph
  }
  
  bool VKBoundingBox::CreateGPUBuffer()
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKMain.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKMain.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKMain.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKMain.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKMain.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKMain.cpp	2023-10-27 13:46:40.369380750 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKMain.cpp	2023-10-27 13:46:40.369380750 +0000
 @@ -18,6 +18,7 @@
  #include "VideoBackends/Vulkan/VKVertexManager.h"
  #include "VideoBackends/Vulkan/VulkanContext.h"
@@ -2840,9 +2840,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKMain.cpp dolphin.ss/S
    g_vulkan_context.reset();
    ShutdownShared();
    UnloadVulkanLibrary();
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp	2023-10-27 13:46:40.369380750 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp	2023-10-27 13:46:40.369380750 +0000
 @@ -11,6 +11,7 @@
  #include "Common/Logging/Log.h"
  #include "Common/MsgHandler.h"
@@ -2961,9 +2961,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp dolphin
    {
      Renderer::GetInstance()->ExecuteCommandBuffer(true, blocking);
    }
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp	2023-10-27 13:46:40.369380750 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp	2023-10-27 13:46:40.369380750 +0000
 @@ -31,6 +31,7 @@
  #include "VideoBackends/Vulkan/VKVertexFormat.h"
  #include "VideoBackends/Vulkan/VulkanContext.h"
@@ -3683,9 +3683,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp dolphin.
  }
  
  }  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp	2023-10-27 13:46:40.377380934 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp	2023-10-27 13:46:40.377380934 +0000
 @@ -0,0 +1,155 @@
 +// Copyright 2022 Dolphin Emulator Project
 +// SPDX-License-Identifier: GPL-2.0-or-later
@@ -3842,9 +3842,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp dolphin
 +
 +std::unique_ptr<Scheduler> g_scheduler;
 +}  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.h dolphin.ss/Source/Core/VideoBackends/Vulkan/VKScheduler.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.h dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.h	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKScheduler.h	2023-10-27 13:46:40.377380934 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.h	2023-10-27 13:46:40.377380934 +0000
 @@ -0,0 +1,160 @@
 +// Copyright 2022 Dolphin Emulator Project
 +// SPDX-License-Identifier: GPL-2.0-or-later
@@ -4006,9 +4006,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.h dolphin.s
 +
 +extern std::unique_ptr<Scheduler> g_scheduler;
 +}  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp	2023-10-27 13:46:40.377380934 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp	2023-10-27 13:46:40.377380934 +0000
 @@ -12,6 +12,7 @@
  #include "Common/MsgHandler.h"
  
@@ -4081,9 +4081,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp dolp
    m_tracked_fences.erase(m_tracked_fences.begin(),
                           m_current_offset == iter->second ? m_tracked_fences.end() : ++iter);
    m_current_offset = new_offset;
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp	2023-10-27 13:46:40.377380934 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp	2023-10-27 13:46:40.377380934 +0000
 @@ -13,9 +13,9 @@
  
  #include "VideoBackends/Vulkan/CommandBufferManager.h"
@@ -4247,9 +4247,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp dolphin
    m_surface = CreateVulkanSurface(g_vulkan_context->GetVulkanInstance(), m_wsi);
    if (m_surface == VK_NULL_HANDLE)
      return false;
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.h dolphin.ss/Source/Core/VideoBackends/Vulkan/VKSwapChain.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.h dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKSwapChain.h	2023-10-27 13:46:40.377380934 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.h	2023-10-27 13:46:40.377380934 +0000
 @@ -3,6 +3,7 @@
  
  #pragma once
@@ -4302,9 +4302,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.h dolphin.s
    u32 m_width = 0;
    u32 m_height = 0;
    u32 m_layers = 0;
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKTexture.cpp	2023-10-27 13:46:40.377380934 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.cpp	2023-10-27 13:46:40.377380934 +0000
 @@ -21,6 +21,7 @@
  #include "VideoBackends/Vulkan/VKStreamBuffer.h"
  #include "VideoBackends/Vulkan/VulkanContext.h"
@@ -4811,9 +4811,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.cpp dolphin.s
    }
  }
  }  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.h dolphin.ss/Source/Core/VideoBackends/Vulkan/VKTexture.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.h dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKTexture.h	2023-10-27 13:46:40.377380934 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.h	2023-10-27 13:46:40.377380934 +0000
 @@ -67,8 +67,8 @@ public:
    // irrelevant and will not be loaded.
    void OverrideImageLayout(VkImageLayout new_layout);
@@ -4825,9 +4825,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.h dolphin.ss/
  
  private:
    bool CreateView(VkImageViewType type);
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp	2023-10-27 13:46:40.377380934 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp	2023-10-27 13:46:40.377380934 +0000
 @@ -15,6 +15,7 @@
  #include "VideoBackends/Vulkan/CommandBufferManager.h"
  #include "VideoBackends/Vulkan/StateTracker.h"
@@ -5021,9 +5021,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp dol
    return true;
  }
  }  // namespace Vulkan
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp dolphin.ss/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp dolphin/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp	2023-10-27 13:46:40.377380934 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp	2023-10-27 13:46:40.377380934 +0000
 @@ -274,6 +274,13 @@ bool VulkanContext::SelectInstanceExtens
      return false;
    }
@@ -5038,9 +5038,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp dolph
  #if defined(VK_USE_PLATFORM_ANDROID_KHR)
    if (wstype == WindowSystemType::Android &&
        !AddExtension(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, true))
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl dolphin.ss/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl dolphin/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl	2023-10-27 13:46:40.377380934 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl	2023-10-27 13:46:40.377380934 +0000
 @@ -49,6 +49,11 @@ VULKAN_INSTANCE_ENTRY_POINT(vkCreateXlib
  VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceXlibPresentationSupportKHR, false)
  #endif
@@ -5053,9 +5053,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl d
  #if defined(VK_USE_PLATFORM_ANDROID_KHR)
  VULKAN_INSTANCE_ENTRY_POINT(vkCreateAndroidSurfaceKHR, false)
  #endif
-diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanLoader.h dolphin.ss/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
+diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanLoader.h dolphin/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanLoader.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin.ss/Source/Core/VideoBackends/Vulkan/VulkanLoader.h	2023-10-27 13:46:40.377380934 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VulkanLoader.h	2023-10-27 13:46:40.377380934 +0000
 @@ -13,6 +13,10 @@
  #define VK_USE_PLATFORM_XLIB_KHR
  #endif
@@ -5067,9 +5067,9 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanLoader.h dolphin.
  #if defined(ANDROID)
  #define VK_USE_PLATFORM_ANDROID_KHR
  #endif
-diff -rupN dolphin.orig/Source/Core/VideoCommon/FramebufferManager.cpp dolphin.ss/Source/Core/VideoCommon/FramebufferManager.cpp
+diff -rupN dolphin.orig/Source/Core/VideoCommon/FramebufferManager.cpp dolphin/Source/Core/VideoCommon/FramebufferManager.cpp
 --- dolphin.orig/Source/Core/VideoCommon/FramebufferManager.cpp	2023-09-26 17:58:02.857996813 +0000
-+++ dolphin.ss/Source/Core/VideoCommon/FramebufferManager.cpp	2023-10-27 13:46:40.429382144 +0000
++++ dolphin/Source/Core/VideoCommon/FramebufferManager.cpp	2023-10-27 13:46:40.429382144 +0000
 @@ -630,7 +630,7 @@ void FramebufferManager::DestroyReadback
  
  bool FramebufferManager::CreateReadbackFramebuffer()
@@ -5106,9 +5106,9 @@ diff -rupN dolphin.orig/Source/Core/VideoCommon/FramebufferManager.cpp dolphin.s
      destination_list->push_back({{cs_x, cs_y, z, point_size}, color});
      return;
    }
-diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.cpp dolphin.ss/Source/Core/VideoCommon/RenderBase.cpp
+diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.cpp dolphin/Source/Core/VideoCommon/RenderBase.cpp
 --- dolphin.orig/Source/Core/VideoCommon/RenderBase.cpp	2023-09-26 17:58:02.857996813 +0000
-+++ dolphin.ss/Source/Core/VideoCommon/RenderBase.cpp	2023-10-27 13:46:40.429382144 +0000
++++ dolphin/Source/Core/VideoCommon/RenderBase.cpp	2023-10-27 13:46:40.429382144 +0000
 @@ -364,19 +364,24 @@ void Renderer::RenderToXFB(u32 xfbAddr,
      return;
  }
@@ -5170,9 +5170,9 @@ diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.cpp dolphin.ss/Source
    m_surface_resized.Set();
  }
  
-diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.h dolphin.ss/Source/Core/VideoCommon/RenderBase.h
+diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.h dolphin/Source/Core/VideoCommon/RenderBase.h
 --- dolphin.orig/Source/Core/VideoCommon/RenderBase.h	2023-09-26 17:58:02.857996813 +0000
-+++ dolphin.ss/Source/Core/VideoCommon/RenderBase.h	2023-10-27 13:46:40.429382144 +0000
++++ dolphin/Source/Core/VideoCommon/RenderBase.h	2023-10-27 13:46:40.429382144 +0000
 @@ -193,7 +193,8 @@ public:
    std::tuple<MathUtil::Rectangle<int>, MathUtil::Rectangle<int>>
    ConvertStereoRectangle(const MathUtil::Rectangle<int>& rc) const;
@@ -5213,9 +5213,9 @@ diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.h dolphin.ss/Source/C
  
    // These will be set on the first call to SetWindowSize.
    int m_last_window_request_width = 0;
-diff -rupN dolphin.orig/Source/Core/VideoCommon/TextureCacheBase.cpp dolphin.ss/Source/Core/VideoCommon/TextureCacheBase.cpp
+diff -rupN dolphin.orig/Source/Core/VideoCommon/TextureCacheBase.cpp dolphin/Source/Core/VideoCommon/TextureCacheBase.cpp
 --- dolphin.orig/Source/Core/VideoCommon/TextureCacheBase.cpp	2023-09-26 17:58:02.857996813 +0000
-+++ dolphin.ss/Source/Core/VideoCommon/TextureCacheBase.cpp	2023-10-27 13:46:40.429382144 +0000
++++ dolphin/Source/Core/VideoCommon/TextureCacheBase.cpp	2023-10-27 13:46:40.429382144 +0000
 @@ -1046,7 +1046,7 @@ static void SetSamplerState(u32 index, f
      // that have arbitrary contents, eg. are used for fog effects where the
      // distance they kick in at is important to preserve at any resolution.


### PR DESCRIPTION
changes based on this patch:
https://github.com/batocera-linux/batocera.linux/blob/master/package/batocera/emulators/dolphin-emu/011-savestate-with-romname.patch