### PR TITLE
Fix runahead settings.

### DIFF
--- a/packages/jelos/sources/scripts/setsettings.sh
+++ b/packages/jelos/sources/scripts/setsettings.sh
@@ -758,14 +758,20 @@ function set_runahead() {
     local RUNAHEAD="$(game_setting runahead)"
     local HAS_RUNAHEAD="$(match ${PLATFORM} ${NO_RUNAHEAD[@]})"
     case ${HAS_RUNAHEAD} in
-        0|false|none)
+        1)
             add_setting "none" "run_ahead_enabled" "false"
-            add_setting "none" "run_ahead_frames" "1"
+            add_setting "none" "run_ahead_frames" "0"
         ;;
         *)
-            add_setting "none" "run_ahead_enabled" "true"
-            add_setting "none" "run_ahead_frames" "${RUNAHEAD}"
-            add_setting "secondinstance" "run_ahead_secondary_instance"
+            if [ "${RUNAHEAD}" -gt 0 ]
+            then
+                add_setting "none" "run_ahead_enabled" "true"
+                add_setting "none" "run_ahead_frames" "${RUNAHEAD}"
+                add_setting "secondinstance" "run_ahead_secondary_instance"
+            else
+                add_setting "none" "run_ahead_enabled" "false"
+                add_setting "none" "run_ahead_frames" "0"
+            fi
         ;;
     esac
 }


### PR DESCRIPTION
# Pull Request Template

This change fixes run ahead not properly enabling and disabling when configured in EmulationStation.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Changed various run ahead settings in ES and started games.  Watched /var/log/exec.log in verbose mode to see changes being made.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
