### PR TITLE
Fix suspend/resume for esp8089

### DIFF
--- a/packages/sysutils/sleep/sources/modules.bad
+++ b/packages/sysutils/sleep/sources/modules.bad
@@ -1,2 +1,3 @@
 dwc2
 mt7921e mt7921_common mt76_connac_lib mt76
+esp8089

--- a/projects/Rockchip/packages/linux/patches/RK3326/000-rk3326-devices.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3326/000-rk3326-devices.patch
@@ -1239,7 +1239,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-odroid-go2-v11.dts lin
 +			regulator-boot-on;
 +
 +			regulator-state-mem {
-+				regulator-on-in-suspend;
++				regulator-off-in-suspend;
 +				regulator-suspend-microvolt = <3300000>;
 +			};
 +		};


### PR DESCRIPTION
## Description

The esp8089 driver doesn't handle suspend/resume correctly. Added it to modules.bad and set the regulator to off in suspend to save battery power.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Installed test build to my OGA BE, went through a suspend/resume cycle, verified system doesn't lock up and wifi works after resume.

**Test Configuration**:
* Build OS name and version: Ubuntu 23.04
* Docker (Y/N): Y
* JELOS Branch: dev

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
