### PR TITLE
Add dts for Powkiddy RGB10

### DIFF
--- a/projects/Rockchip/devices/RK3326/options
+++ b/projects/Rockchip/devices/RK3326/options
@@ -31,7 +31,7 @@
     BOOTLOADER="u-boot"
     TRUST_LABEL="trust"
     PARTITION_TABLE="msdos"
-    DEVICE_DTB=("rk3326-anbernic-rg351m" "rk3326-anbernic-rg351v"  "rk3326-odroid-go2" "rk3326-odroid-go2-v11" "rk3326-odroid-go3" "rk3326-rgb10")
+    DEVICE_DTB=("rk3326-anbernic-rg351m" "rk3326-anbernic-rg351v"  "rk3326-odroid-go2" "rk3326-odroid-go2-v11" "rk3326-odroid-go3" "rk3326-powkiddy-rgb10")
     UBOOT_DTB="${DEVICE_DTB[0]}"
     UBOOT_CONFIG="odroidgoa_defconfig"
     PKG_SOC="px30"

--- a/projects/Rockchip/devices/RK3326/options
+++ b/projects/Rockchip/devices/RK3326/options
@@ -31,7 +31,7 @@
     BOOTLOADER="u-boot"
     TRUST_LABEL="trust"
     PARTITION_TABLE="msdos"
-    DEVICE_DTB=("rk3326-anbernic-rg351m" "rk3326-anbernic-rg351v"  "rk3326-odroid-go2" "rk3326-odroid-go2-v11" "rk3326-odroid-go3")
+    DEVICE_DTB=("rk3326-anbernic-rg351m" "rk3326-anbernic-rg351v"  "rk3326-odroid-go2" "rk3326-odroid-go2-v11" "rk3326-odroid-go3" "rk3326-rgb10")
     UBOOT_DTB="${DEVICE_DTB[0]}"
     UBOOT_CONFIG="odroidgoa_defconfig"
     PKG_SOC="px30"

--- a/projects/Rockchip/packages/linux/patches/RK3326/001-powkiddy-rgb10-dts.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3326/001-powkiddy-rgb10-dts.patch
@@ -213,8 +213,8 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-rgb10.dts linux/arch/a
 +
 +	battery: battery {
 +		compatible = "simple-battery";
-+		charge-full-design-microamp-hours = <3000000>;
-+		charge-term-current-microamp = <300000>;
++		charge-full-design-microamp-hours = <2800000>;
++		charge-term-current-microamp = <280000>;
 +		constant-charge-current-max-microamp = <2000000>;
 +		constant-charge-voltage-max-microvolt = <4200000>;
 +		factory-internal-resistance-micro-ohms = <180000>;

--- a/projects/Rockchip/packages/linux/patches/RK3326/001-powkiddy-rgb10-dts.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3326/001-powkiddy-rgb10-dts.patch
@@ -5,13 +5,13 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/Makefile linux/arch/arm64/boo
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-odroid-go2.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-odroid-go2-v11.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-odroid-go3.dtb
-+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-rgb10.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-powkiddy-rgb10.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-a1.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2s.dtb
-diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-rgb10.dts linux/arch/arm64/boot/dts/rockchip/rk3326-rgb10.dts
---- linux.orig/arch/arm64/boot/dts/rockchip/rk3326-rgb10.dts	1970-01-01 00:00:00.000000000 +0000
-+++ linux/arch/arm64/boot/dts/rockchip/rk3326-rgb10.dts	2023-10-29 19:31:19.751624080 +0000
+diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-powkiddy-rgb10.dts linux/arch/arm64/boot/dts/rockchip/rk3326-powkiddy-rgb10.dts
+--- linux.orig/arch/arm64/boot/dts/rockchip/rk3326-powkiddy-rgb10.dts	1970-01-01 00:00:00.000000000 +0000
++++ linux/arch/arm64/boot/dts/rockchip/rk3326-powkiddy-rgb10.dts	2023-10-29 19:31:19.751624080 +0000
 @@ -0,0 +1,299 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
@@ -25,7 +25,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-rgb10.dts linux/arch/a
 +
 +/ {
 +	model = "Powkiddy RGB10";
-+	compatible = "hardkernel,rk3326-odroid-go2-v11", "rockchip,rk3326";
++	compatible = "powkiddy,rk3326-rgb10", "rockchip,rk3326";
 +
 +	aliases {
 +		mmc1 = &sdio;

--- a/projects/Rockchip/packages/linux/patches/RK3326/001-powkiddy-rgb10-dts.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3326/001-powkiddy-rgb10-dts.patch
@@ -1,0 +1,315 @@
+diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/Makefile linux/arch/arm64/boot/dts/rockchip/Makefile
+--- linux.orig/arch/arm64/boot/dts/rockchip/Makefile	2023-10-29 19:29:06.983692813 +0000
++++ linux/arch/arm64/boot/dts/rockchip/Makefile	2023-10-29 19:30:35.815676699 +0000
+@@ -12,6 +12,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-an
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-odroid-go2.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-odroid-go2-v11.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-odroid-go3.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-rgb10.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-a1.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2s.dtb
+diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-rgb10.dts linux/arch/arm64/boot/dts/rockchip/rk3326-rgb10.dts
+--- linux.orig/arch/arm64/boot/dts/rockchip/rk3326-rgb10.dts	1970-01-01 00:00:00.000000000 +0000
++++ linux/arch/arm64/boot/dts/rockchip/rk3326-rgb10.dts	2023-10-29 19:31:19.751624080 +0000
+@@ -0,0 +1,299 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2019 Hardkernel Co., Ltd
++ * Copyright (c) 2020 Theobroma Systems Design und Consulting GmbH
++ * Copyright (c) 2022 Maya Matuszczyk <maccraft123mc@gmail.com>
++ */
++
++/dts-v1/;
++#include "rk3326-odroid-go.dtsi"
++
++/ {
++	model = "Powkiddy RGB10";
++	compatible = "hardkernel,rk3326-odroid-go2-v11", "rockchip,rk3326";
++
++	aliases {
++		mmc1 = &sdio;
++	};
++
++	gpio_keys: volume-keys {
++		compatible = "gpio-keys-polled";
++		poll-interval = <5>;
++		autorepeat;
++
++		volume-up-button {
++			label = "VOLUME-UP";
++			linux,code = <KEY_VOLUMEUP>;
++			gpios = <&gpio2 RK_PA4 GPIO_ACTIVE_LOW>;
++
++		};
++		volume-down-button {
++			label = "VOLUME-DOWN";
++			linux,code = <KEY_VOLUMEDOWN>;
++			gpios = <&gpio2 RK_PA1 GPIO_ACTIVE_LOW>;
++
++		};
++	};
++
++	joypad: odroidgo2-joypad {
++                compatible = "odroidgo2-v11-joypad";
++
++                /*
++                  - odroidgo2-joypad sysfs list -
++		   * for poll device interval(ms)
++		   /sys/devices/platform/odroidgo2_joypad/poll_interval [rw]
++                   * for button-adc-fuzz
++		   /sys/devices/platform/odroidgo2_joypad/adc_fuzz [r]
++                   * for button-adc-flat
++		   /sys/devices/platform/odroidgo2_joypad/adc_flat [r]
++
++		   * for report control(1:enable, 0:disable)
++		   /sys/devices/platform/odroidgo2_joypad/enable [rw]
++		   * for adc calibration value setup(1:current adcs value -> cal value)
++		   /sys/devices/platform/odroidgo2_joypad/adc_cal [rw]
++                */
++
++		/* gpio pincontrol setup */
++                pinctrl-names = "default";
++                pinctrl-0 = <&btn_pins>;
++
++		/* JOY_X, JOY_Y Channel define */
++		io-channel-names = "joy_x", "joy_y";
++		io-channels = <&saradc 1>, <&saradc 2>;
++
++		/* adc channel count */
++		button-adc-count = <2>;
++
++		/* adc calculate scale */
++		button-adc-scale = <2>;
++
++		/* adc deadzone range  */
++		button-adc-deadzone = <20>;
++
++		/*
++		    joy-stick voltage range
++		    /sys/devices/platform/ff288000.saradc/iio:device0
++		    adc-x : in_voltage1_raw
++		    adc-y : in_voltage2_raw
++
++		    range calculate.
++		    (adc raw max value - adc raw min value) * scale * 1.7515
++		*/
++		button-adc-x-range = <1800>;
++		button-adc-y-range = <1800>;
++
++		/*
++		  specifies fuzz value that is used to filter noise from
++		  the event stream.
++		*/
++		button-adc-fuzz = <32>;
++		button-adc-flat = <32>;
++
++		/* poll device interval (ms), adc read interval */
++		poll-interval = <10>;
++
++		/* gpio button auto repeat set value : default disable */
++		/*
++			autorepeat;
++		*/
++
++		/*
++		      *** RGB10 Switch layoout ***
++		|------------------------------------------------|
++		| sw15                                      sw16 |
++		|        sw20                         sw21       |
++		|------------------------------------------------|
++		|    sw1  vol- |-------------------| vol+ sw8    |
++		|  sw3   sw4   |                   |   sw7   sw5 |
++		|     sw2      |    LCD Display    |      sw6    |
++		|              |                   |             |
++		|              |-------------------|             |
++		|------------------------------------------------|
++		*/
++                /*
++                    joypad driver is poll-device driver.
++                    poll-device is does not support wakeup-source.
++		*/
++                sw1 {
++                        gpios = <&gpio1 RK_PB4 GPIO_ACTIVE_LOW>;
++                        label = "GPIO DPAD-UP";
++                        linux,code = <BTN_DPAD_UP>; // 0x220
++                };
++                sw2 {
++                        gpios = <&gpio1 RK_PB5 GPIO_ACTIVE_LOW>;
++                        label = "GPIO DPAD-DOWN";
++                        linux,code = <BTN_DPAD_DOWN>; // 0x221
++                };
++                sw3 {
++                        gpios = <&gpio1 RK_PB6 GPIO_ACTIVE_LOW>;
++                        label = "GPIO DPAD-LEFT";
++                        linux,code = <BTN_DPAD_LEFT>; // 0x222
++                };
++                sw4 {
++                        gpios = <&gpio1 RK_PB7 GPIO_ACTIVE_LOW>;
++                        label = "GPIO DPAD-RIGHT";
++                        linux,code = <BTN_DPAD_RIGHT>; // 0x223
++                };
++                sw5 {
++                        gpios = <&gpio1 RK_PA2 GPIO_ACTIVE_LOW>;
++                        label = "GPIO KEY BTN-A";
++                        linux,code = <BTN_EAST>; // 0x131
++                };
++                sw6 {
++                        gpios = <&gpio1 RK_PA5 GPIO_ACTIVE_LOW>;
++                        label = "GPIO BTN-B";
++                        linux,code = <BTN_SOUTH>; // 0x130
++                };
++                sw7 {
++                        gpios = <&gpio1 RK_PA6 GPIO_ACTIVE_LOW>;
++                        label = "GPIO BTN-Y";
++                        linux,code = <BTN_WEST>; // 0x134
++                };
++                sw8 {
++                        gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_LOW>;
++                        label = "GPIO BTN-X";
++                        linux,code = <BTN_NORTH>; // 0x133
++                };
++                sw9 {
++                        gpios = <&gpio2 RK_PA0 GPIO_ACTIVE_LOW>;
++                        label = "GPIO F1";
++                        linux,code = <BTN_TRIGGER_HAPPY1>; // 0x2c0
++                };
++                sw10 {
++                        gpios = <&gpio3 RK_PB2 GPIO_ACTIVE_LOW>;
++                        label = "GPIO F2";
++                        linux,code = <BTN_TRIGGER_HAPPY2>; // 0x2c1
++                };
++                sw13 {
++                        gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
++                        label = "GPIO F5";
++                        linux,code = <BTN_TRIGGER_HAPPY5>; // 0x2c4
++                };
++                sw14 {
++                        gpios = <&gpio2 RK_PA5 GPIO_ACTIVE_LOW>;
++                        label = "GPIO F6";
++                        linux,code = <BTN_TRIGGER_HAPPY6>; // 0x13c
++                };
++                sw15 {
++                        gpios = <&gpio2 RK_PA6 GPIO_ACTIVE_LOW>;
++                        label = "GPIO TOP-LEFT";
++                        linux,code = <BTN_TL>; // 0x02
++                };
++                sw16 {
++                        gpios = <&gpio2 RK_PA7 GPIO_ACTIVE_LOW>;
++                        label = "GPIO TOP-RIGHT";
++                        linux,code = <BTN_TR>; // 0x05
++                };
++                sw20 {
++                        gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
++                        label = "GPIO TOP-LEFT2";
++                        linux,code = <BTN_TL2>;
++                };
++                sw21 {
++                        gpios = <&gpio2 RK_PA3 GPIO_ACTIVE_LOW>;
++                        label = "GPIO TOP-RIGHT2";
++                        linux,code = <BTN_TR2>;
++                };
++        };
++
++	battery: battery {
++		compatible = "simple-battery";
++		charge-full-design-microamp-hours = <3000000>;
++		charge-term-current-microamp = <300000>;
++		constant-charge-current-max-microamp = <2000000>;
++		constant-charge-voltage-max-microvolt = <4200000>;
++		factory-internal-resistance-micro-ohms = <180000>;
++		voltage-max-design-microvolt = <4100000>;
++		voltage-min-design-microvolt = <3500000>;
++
++		ocv-capacity-celsius = <20>;
++		ocv-capacity-table-0 =  <4046950 100>, <4001920 95>, <3967900 90>, <3919950 85>,
++					<3888450 80>, <3861850 75>, <3831540 70>, <3799130 65>,
++					<3768190 60>, <3745650 55>, <3726610 50>, <3711630 45>,
++					<3696720 40>, <3685660 35>, <3674950 30>, <3663050 25>,
++					<3649470 20>, <3635260 15>, <3616920 10>, <3592440 5>,
++					<3574170 0>;
++	};
++
++	wifi_pwrseq: wifi-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_pwrseq_pins>;
++		/*reset-gpios = <&gpio3 RK_PB1 GPIO_ACTIVE_LOW>;*/
++	};
++};
++
++&internal_display {
++	compatible = "elida,kd35t133";
++	iovcc-supply = <&vcc_lcd>;
++	vdd-supply = <&vcc_lcd>;
++	rotation = <270>;
++};
++
++&rk817 {
++	regulators {
++		vcc_wifi: LDO_REG9 {
++			regulator-name = "vcc_wifi";
++			regulator-min-microvolt = <3300000>;
++			regulator-max-microvolt = <3300000>;
++			regulator-always-on;
++			regulator-boot-on;
++
++			regulator-state-mem {
++				regulator-off-in-suspend;
++				regulator-suspend-microvolt = <3300000>;
++			};
++		};
++	};
++};
++
++&rk817_charger {
++	monitored-battery = <&battery>;
++};
++
++&sdio {
++	bus-width = <4>;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	disable-wp;
++	keep-power-in-suspend;
++	non-removable;
++	vmmc-supply = <&vcc_wifi>;
++	status = "okay";
++
++	esp8089: wifi@1 {
++		compatible = "esp,esp8089";
++		reg = <1>;
++		esp,crystal-26M-en = <2>;
++	};
++};
++
++&pinctrl {
++	btns {
++		btn_pins: btn-pins {
++			rockchip,pins = <1 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>,
++					<1 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>,
++					<1 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>,
++					<1 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>,
++					<1 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>,
++					<1 RK_PB5 RK_FUNC_GPIO &pcfg_pull_up>,
++					<1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_up>,
++					<1 RK_PB7 RK_FUNC_GPIO &pcfg_pull_up>,
++					<2 RK_PA0 RK_FUNC_GPIO &pcfg_pull_up>,
++					<2 RK_PA1 RK_FUNC_GPIO &pcfg_pull_up>,
++					<2 RK_PA4 RK_FUNC_GPIO &pcfg_pull_up>,
++					<2 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>,
++					<2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>,
++					<2 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>,
++					<3 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>,
++					<3 RK_PB7 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	wifi {
++		wifi_pwrseq_pins: wifi-pwrseq-pins {
++			rockchip,pins = /*<3 RK_PB1 RK_FUNC_GPIO &pcfg_pull_up>,*/
++					<3 RK_PB6 RK_FUNC_GPIO &pcfg_output_high>;
++		};
++	};
++};
+


### PR DESCRIPTION
## Description

This commit builds a dtb for the Powkiddy RGB10. U-Boot detects it as an Odroid Go Advance Black Edition, but that device has a different button mapping. As there's currently no way to tell the two apart, boot.ini will have to be manually edited to use the rk3325-rgb10.dtb file for this change to apply. That will either need to be documented in the wiki, or just ignore it until we find a way to distinguish the two devices.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested Locally?

Edited boot.ini to use the new dtb, verified all buttons now working as expected.

**Test Configuration**:
* Build OS name and version: Ubuntu 22.04
* Docker (Y/N): Y
* JELOS Branch: dev

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation