### PR TITLE
u-boot-Odroid_GOU: boot from SD first if it is present

### DIFF
--- a/projects/Amlogic/packages/u-boot-Odroid_GOU/patches/005-boot-from-sd-first.patch
+++ b/projects/Amlogic/packages/u-boot-Odroid_GOU/patches/005-boot-from-sd-first.patch
@@ -1,0 +1,12 @@
+--- a/board/hardkernel/odroidgo4/odroidgo4.c
++++ b/board/hardkernel/odroidgo4/odroidgo4.c
+@@ -165,8 +165,8 @@
+ }
+ int board_mmc_init(bd_t	*bis)
+ {
+-	board_mmc_register(SDIO_PORT_C);	// eMMC
+ 	board_mmc_register(SDIO_PORT_B);	// SD card
++	board_mmc_register(SDIO_PORT_C);	// eMMC
+ 
+ 	return 0;
+ }


### PR DESCRIPTION
This PR changes u-boot boot order on Odroid GO-Ultra and RGB10MAX3 Pro.

If a user has JELOS installed on eMMC and has an SD card inserted with JELOS also installed then u-boot will boot from the SD first.

This allows a user to dual boot easily by just ejecting the SD card.