### PR TITLE
Increase rk3326 ram voltage - fix devices that wont boot

### DIFF
--- a/projects/Rockchip/packages/linux/patches/RK3326/000-rk3326-devices.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3326/000-rk3326-devices.patch
@@ -102,7 +102,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/px30.dtsi linux/arch/arm64/bo
 +		compatible = "operating-points-v2";
 +		opp-786000000 {
 +			opp-hz = /bits/ 64 <786000000>;
-+			opp-microvolt = <1100000>;
++			opp-microvolt = <1125000>;
 +		};
 +	};
 +


### PR DESCRIPTION
A few people have had issues with booting JELOS on their rg351p. Sounds like this is related to needing a little more voltage on the ram. Hopefully this resolves that issue. 