### PR TITLE
Low volume fix

### DIFF
--- a/packages/jelos/autostart/050-audio
+++ b/packages/jelos/autostart/050-audio
@@ -37,5 +37,10 @@ then
   VOLUME="${DEVICE_VOLUME}"
 fi
 
+### Set the primary card volume to 100%
+### to eliminate low audio on some devices.
+amixer -c 0 -q sset "Master" 100%
+
+### Now set the pipewire mixer volume
 /usr/bin/volume ${VOLUME}
 


### PR DESCRIPTION

Set the card 0 volume to 100% and then set the system volume.  This corrects conditions where the pipewire volume is not the same as the card 0 volume which results in low volume output.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Verified to correct the issue on S922X family of devices.  Tested to have no negative impact on AMD64, RK3566, and RK3326.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
