### PR TITLE
Add autodetection for RGB10

### DIFF
--- a/projects/Rockchip/bootloader/install
+++ b/projects/Rockchip/bootloader/install
@@ -101,7 +101,11 @@ load mmc 1:1 \${loadaddr} KERNEL
 
 if test \${hwrev} = 'v11'; then
   if gpio input c22; then
-    load mmc 1:1 \${dtb_loadaddr} rk3326-odroid-go2-v11.dtb
+    if gpio input d9; then
+      load mmc 1:1 \${dtb_loadaddr} rk3326-powkiddy-rgb10.dtb
+    else
+      load mmc 1:1 \${dtb_loadaddr} rk3326-odroid-go2-v11.dtb
+    fi
   else 
     load mmc 1:1 \${dtb_loadaddr} rk3326-anbernic-rg351m.dtb
   fi

--- a/projects/Rockchip/bootloader/mkimage
+++ b/projects/Rockchip/bootloader/mkimage
@@ -62,7 +62,11 @@ load mmc 1:1 \${loadaddr} KERNEL
 
 if test \${hwrev} = 'v11'; then
   if gpio input c22; then
-    load mmc 1:1 \${dtb_loadaddr} rk3326-odroid-go2-v11.dtb
+    if gpio input d9; then
+      load mmc 1:1 \${dtb_loadaddr} rk3326-powkiddy-rgb10.dtb
+    else
+      load mmc 1:1 \${dtb_loadaddr} rk3326-odroid-go2-v11.dtb
+    fi
   else
     load mmc 1:1 \${dtb_loadaddr} rk3326-anbernic-rg351m.dtb
   fi


### PR DESCRIPTION
## Description

The wifi reset GPIO tests high on the OGA-BE but low on the RGB10, so we can use this to detect which system we're running on at boot time. Modified boot.ini to decide which dtb to load.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Flashed new build to a SD card. Putting it in my OGA-BE reports the correct system, and putting it in the RGB10 also reports the correct system.

**Test Configuration**:
* Build OS name and version: Ubuntu 22.04
* Docker (Y/N): Y
* JELOS Branch: dev

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
