### PR TITLE
x55 joystick update, and re-add factory reset.

### DIFF
--- a/packages/jelos/sources/scripts/factoryreset
+++ b/packages/jelos/sources/scripts/factoryreset
@@ -9,4 +9,12 @@ case "${1}" in
     rm -f /storage/.config/retroarch/retroarch.cfg
     cp -rf /usr/config/retroarch/retroarch.cfg /storage/.config/retroarch/retroarch.cfg
   ;;
+  "ALL")
+    systemctl stop ${UI_SERVICE}
+    cd /
+    find /storage -mindepth 1 \( ! -regex '^/storage/.update.*' -a ! -regex '^/storage/roms.*' \) -delete
+    mkdir /storage/.config/
+    sync
+    systemctl reboot
+  ;;
 esac

--- a/packages/sysutils/system-utils/sources/scripts/volume_sense
+++ b/packages/sysutils/system-utils/sources/scripts/volume_sense
@@ -202,4 +202,5 @@ mkcontroller 2>/dev/null ||:
           fi
         ;;
     esac
+    sleep .1
 done

--- a/packages/sysutils/system-utils/sources/scripts/volume_sense
+++ b/packages/sysutils/system-utils/sources/scripts/volume_sense
@@ -202,5 +202,4 @@ mkcontroller 2>/dev/null ||:
           fi
         ;;
     esac
-    sleep .1
 done

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="58a9a86aa957501753e7b2442efcbfb5dbdb9bac"
+PKG_VERSION="86f209752cc7eb47b22e3f00f807cf6d64ebc970"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"

--- a/projects/Rockchip/packages/linux/package.mk
+++ b/projects/Rockchip/packages/linux/package.mk
@@ -31,7 +31,7 @@ case ${DEVICE} in
   ;;
   *X55)
     PKG_URL="${PKG_SITE}/rk3566-x55-kernel.git"
-    PKG_VERSION="c7531bab2"
+    PKG_VERSION="9b92751b8fe21f9326d1a54dd5f675965a12d6e1"
     GET_HANDLER_SUPPORT="git"
     PKG_GIT_CLONE_BRANCH="main"
   ;;


### PR DESCRIPTION
* Cleans up x55 zed_joystick and implement radial thresholding. Thanks @littleguy77 and @JohnnyonFlame!
* Brings back the factory reset option in System Tools -> Danger Zone.
