### PR TITLE
Migrate boot.ini to device folder.

### DIFF
--- a/projects/Rockchip/bootloader/install
+++ b/projects/Rockchip/bootloader/install
@@ -85,43 +85,11 @@ fi
   ;;
 esac
 
-
 if [ "${BOOT_INI}" == true ]
 then
   echo "boot: create boot.ini..."
-  cat >${INSTALL}/usr/share/bootloader/boot.ini <<EOF
-odroidgoa-uboot-config   
- 
-setenv bootargs "boot=UUID=@BOOT_UUID@ disk=UUID=@DISK_UUID@ ${EXTRA_CMDLINE}"
-
-setenv loadaddr "0x02000000"
-setenv dtb_loadaddr "0x01f00000"
- 
-load mmc 1:1 \${loadaddr} KERNEL
-
-if test \${hwrev} = 'v11'; then
-  if gpio input c22; then
-    if gpio input d9; then
-      load mmc 1:1 \${dtb_loadaddr} rk3326-powkiddy-rgb10.dtb
-    else
-      load mmc 1:1 \${dtb_loadaddr} rk3326-odroid-go2-v11.dtb
-    fi
-  else 
-    load mmc 1:1 \${dtb_loadaddr} rk3326-anbernic-rg351m.dtb
-  fi
-elif test \${hwrev} = 'v10-go3'; then
-  load mmc 1:1 \${dtb_loadaddr} rk3326-odroid-go3.dtb
-elif test \${hwrev} = 'v10'; then
-  load mmc 1:1 \${dtb_loadaddr} rk3326-odroid-go2.dtb
-elif test \${hwrev} = 'rg351v'; then
-  load mmc 1:1 \${dtb_loadaddr} rk3326-anbernic-rg351v.dtb
-elif test \${hwrev} = 'rg351mp'; then
-  load mmc 1:1 \${dtb_loadaddr} rk3326-anbernic-rg351mp.dtb
-fi
-
-booti \${loadaddr} - \${dtb_loadaddr}
-
-EOF
+  cp -f ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/boot/boot.ini ${INSTALL}/usr/share/bootloader/boot.ini
+  sed -i "s~@EXTRA_CMDLINE@~${EXTRA_CMDLINE}~g" ${INSTALL}/usr/share/bootloader/boot.ini
 fi
 
 if [ "${EXT_LINUX_CONF}" == true ]

--- a/projects/Rockchip/bootloader/mkimage
+++ b/projects/Rockchip/bootloader/mkimage
@@ -49,41 +49,12 @@ esac
 #Create boot.ini
 if [ "${BOOT_INI}" == true ]
 then
-  echo "image: create boot.ini..."
-  cat >"${LE_TMP}/boot.ini" <<EOF
-odroidgoa-uboot-config
-
-setenv bootargs "boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} ${EXTRA_CMDLINE}"
-
-setenv loadaddr "0x02000000"
-setenv dtb_loadaddr "0x01f00000"
-
-load mmc 1:1 \${loadaddr} KERNEL
-
-if test \${hwrev} = 'v11'; then
-  if gpio input c22; then
-    if gpio input d9; then
-      load mmc 1:1 \${dtb_loadaddr} rk3326-powkiddy-rgb10.dtb
-    else
-      load mmc 1:1 \${dtb_loadaddr} rk3326-odroid-go2-v11.dtb
-    fi
-  else
-    load mmc 1:1 \${dtb_loadaddr} rk3326-anbernic-rg351m.dtb
-  fi
-elif test \${hwrev} = 'v10-go3'; then
-  load mmc 1:1 \${dtb_loadaddr} rk3326-odroid-go3.dtb
-elif test \${hwrev} = 'v10'; then
-  load mmc 1:1 \${dtb_loadaddr} rk3326-odroid-go2.dtb
-elif test \${hwrev} = 'rg351v'; then
-  load mmc 1:1 \${dtb_loadaddr} rk3326-anbernic-rg351v.dtb
-elif test \${hwrev} = 'rg351mp'; then
-  load mmc 1:1 \${dtb_loadaddr} rk3326-anbernic-rg351mp.dtb
-fi
-
-booti \${loadaddr} - \${dtb_loadaddr}
-
-EOF
-mcopy -so "${LE_TMP}/boot.ini" ::
+  echo "boot: create boot.ini..."
+  cp -f ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/boot/boot.ini ${LE_TMP}/boot.ini
+  sed -i "s~@UUID_SYSTEM@~${UUID_SYSTEM}~g" ${INSTALL}/usr/share/bootloader/boot.ini
+  sed -i "s~@UUID_STORAGE@~${UUID_STORAGE}~g" ${INSTALL}/usr/share/bootloader/boot.ini
+  sed -i "s~@EXTRA_CMDLINE@~${EXTRA_CMDLINE}~g" ${INSTALL}/usr/share/bootloader/boot.ini
+  mcopy -so "${LE_TMP}/boot.ini" ::
 fi
 
 mkdir -p "${LE_TMP}/extlinux"


### PR DESCRIPTION
## Description

This PR moves the hard coded 3326 boot.ini into a device folder (projects/Rockchip/devices/RK3326/boot), making the feature more dynamic and improves compatibility with other devices that will also need a boot script.
