### PR TITLE
esp8089: Improve stability by driving RST high instead of letting it float

### DIFF
--- a/packages/kernel/linux-drivers/esp8089/patches/002-fix_gpio_direction.patch
+++ b/packages/kernel/linux-drivers/esp8089/patches/002-fix_gpio_direction.patch
@@ -1,0 +1,14 @@
+diff -rupN esp8089-1.9.20230804.orig/sdio_stub.c esp8089-1.9.20230804/sdio_stub.c
+--- esp8089-1.9.20230804.orig/sdio_stub.c	2023-08-04 21:04:02.000000000 +0000
++++ esp8089-1.9.20230804/sdio_stub.c	2023-11-07 16:38:55.889274803 +0000
+@@ -38,8 +38,9 @@ void sif_platform_reset_target(void)
+ 	printk("ESP8089 reset via GPIO %d\n", esp_reset_gpio);
+ 	gpio_request(esp_reset_gpio,"esp_reset");
+ 	gpio_direction_output(esp_reset_gpio,0);
++	gpio_set_value(esp_reset_gpio,0);
+ 	msleep(200);
+-	gpio_direction_input(esp_reset_gpio);
++	gpio_set_value(esp_reset_gpio,1);
+ 	gpio_free(esp_reset_gpio);
+ }
+ 


### PR DESCRIPTION
## Description

This change patches the esp8089 driver to force RST high after the driver is done with it. This seems to fix the issue where the device would disappear from the SDIO bus and cause a kernel panic.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

- [x] Install dev build
- [x] Verify the wifi continues to work after passing more than 100,000 packets (would choke around 30,000 before)
- [x] Verify wifi still works after suspend/resume

**Test Configuration**:
* Build OS name and version: Ubuntu 22.04
* Docker (Y/N): Y
* JELOS Branch: dev
* Any additional information that may be useful: This change only affects the OGA v1.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation