### PR TITLE
Fix GPU performance setting bug.

### DIFF
--- a/packages/jelos/profile.d/099-freqfunctions
+++ b/packages/jelos/profile.d/099-freqfunctions
@@ -85,41 +85,26 @@ set_gpu_gov() {
   fi
 }
 
-set_amdgpu_perf() {
-  for AMDGPU_PERF_DEVICE in $(find /sys/devices -name power_dpm_force_performance_level 2>/dev/null)
-  do
-    echo $1 >${AMDGPU_PERF_DEVICE} 2>/dev/null
-  done
-}
-
 onlinethreads() {
   set_online_threads ${1} ${2}
 }
 
 performance() {
   set_cpu_gov performance
-  set_amdgpu_perf profile_peak
-  set_gpu_gov performance
   set_dmc_gov performance
 }
 
 ondemand() {
   set_cpu_gov ondemand
-  set_amdgpu_perf auto
-  set_gpu_gov ondemand
   set_dmc_gov ondemand
 }
 
 schedutil() {
   set_cpu_gov schedutil
-  set_amdgpu_perf auto
-  set_gpu_gov ondemand
   set_dmc_gov ondemand
 }
 
 powersave() {
   set_cpu_gov powersave
-  set_amdgpu_perf low
-  set_gpu_gov powersave
   set_dmc_gov powersave
 }

--- a/packages/jelos/sources/post-update
+++ b/packages/jelos/sources/post-update
@@ -64,13 +64,6 @@ ln -sf /usr/share/locale /storage/.config/emulationstation/locale >>/var/log/con
 ### Add items below this line that are safe to remove after a period of time.
 ################################################################################
 
-### Added 20230409 as a helper for the quirks refactor.
-if [ ! -d "/storage/.config/profile_backup" ]
-then
-  mkdir /storage/.config/profile_backup
-  mv /storage/.config/profile.d/* /storage/.config/profile_backup
-fi
-
 ### 20230913 (reverted) Set the default output to Master for pipewire
 ES_SETTINGS="/storage/.config/emulationstation/es_settings.cfg"
 

--- a/packages/sysutils/powerstate/profile.d/030-powerfunctions
+++ b/packages/sysutils/powerstate/profile.d/030-powerfunctions
@@ -17,17 +17,41 @@ gpu_power_profile() {
 }
 
 get_gpu_performance_level() {
-  cat /sys/class/drm/card0/device/power_dpm_force_performance_level 2>/dev/null
+  case ${HW_ARCH} in
+    x86_64)
+      cat /sys/class/drm/card0/device/power_dpm_force_performance_level 2>/dev/null
+    ;;
+    aarch64)
+      get_setting system.gpuperf
+    ;;
+    esac
 }
 
 gpu_performance_level() {
-  for card in /sys/class/drm/card*/device/power_dpm_force_performance_level
-  do
-    if [ -e "${card}" ]
-    then
-      echo ${1} >${card} 2>/dev/null
-    fi
-  done
+  case ${HW_ARCH} in
+    x86_64)
+      for card in /sys/class/drm/card*/device/power_dpm_force_performance_level
+      do
+        if [ -e "${card}" ]
+        then
+          echo ${1} >${card} 2>/dev/null
+        fi
+      done
+    ;;
+    aarch64)
+      case ${1} in
+        profile_peak)
+          set_gpu_gov performance
+        ;;
+        auto|profile_standard)
+          set_gpu_gov ondemand
+        ;;
+        low)
+          set_gpu_gov powersave
+        ;;
+      esac
+    ;;
+  esac
 }
 
 pcie_aspm_policy() {

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="5155542"
+PKG_VERSION="94f95dc"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"

--- a/projects/Rockchip/devices/RK3566/options
+++ b/projects/Rockchip/devices/RK3566/options
@@ -89,7 +89,7 @@
     DRIVER_ADDONS="" #dvb-latest
 
   # debug tty path
-    DEBUG_TTY="/dev/ttyFIQ0"
+    DEBUG_TTY="/dev/ttyUSB0"
 
   # build and install bluetooth support (yes / no)
     BLUETOOTH_SUPPORT="yes"


### PR DESCRIPTION
## Description

Historically JELOS configured CPU/GPU/DMC performance modes via a single scheduling function.  Prior to implementing powerstate we extended that functionality to also manage AMD GPU performance.  This functionality conflicts with powerstate and has been deprecated in favor of new behavior that allows ARM devices to utilize the GPU performance feature previously available for AMD devices only.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Tested on AYN Loki Zero and Powkiddy RGB30.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
