### PR TITLE
Mednafen bugfixes

### DIFF
--- a/packages/emulators/standalone/mednafen/config/common/mednafen.cfg
+++ b/packages/emulators/standalone/mednafen/config/common/mednafen.cfg
@@ -546,19 +546,19 @@ ffspeed 15
 fftoggle 1
 
 ;Format string for movie filename.
-filesys.fname_movie %f.%M%p.%x
+filesys.fname_movie %f.%M%p.mednafen.%x
 
 ;Format string for save games filename.
-filesys.fname_sav %f.%M%x
+filesys.fname_sav %f.mednafen.%M%x
 
 ;Format string for save game backups filename.
-filesys.fname_savbackup %f.%m%z%p.%x
+filesys.fname_savbackup %f.%m%z%p.mednafen.%x
 
 ;Format string for screen snapshot filenames.
-filesys.fname_snap %f-%p.%x
+filesys.fname_snap %f-%p.mednafen.%x
 
 ;Format string for state filename.
-filesys.fname_state %f.%M%X
+filesys.fname_state %f.mednafen.%M%X
 
 ;Enable old handling of .gz file extensions with respect to data file path construction.
 filesys.old_gz_naming 0
@@ -726,7 +726,7 @@ gb.yscale 6.000000
 gb.yscalefs 1.000000
 
 ;Path to optional GBA BIOS ROM image.
-gba.bios  /storage/roms/bios/gba_bios.bin
+gba.bios gba_bios.bin
 
 ;Enable (automatic) usage of this module.
 gba.enable 1
@@ -1047,7 +1047,7 @@ lynx.yscale 6.000000
 lynx.yscalefs 1.000000
 
 ;Path to the CD BIOS
-md.cdbios /storage/roms/bios/us_scd1_9210.bin
+md.cdbios us_scd1_9210.bin
 
 ;Correct the aspect ratio.
 md.correct_aspect 1
@@ -3306,7 +3306,7 @@ pce.adpcmvolume 100
 pce.arcadecard 1
 
 ;Path to the CD BIOS
-pce.cdbios /storage/roms/bios/syscard3.pce
+pce.cdbios syscard3.pce
 
 ;CD-DA volume.
 pce.cddavolume 100
@@ -3339,7 +3339,7 @@ pce.forcemono 0
 pce.forcesgx 0
 
 ;Path to the GE CD BIOS
-pce.gecdbios /storage/roms/bios/gecard.pce
+pce.gecdbios gecard.pce
 
 ;Show horizontal overscan area.
 pce.h_overscan 0
@@ -4125,7 +4125,7 @@ pce_fast.adpcmvolume 100
 pce_fast.arcadecard 1
 
 ;Path to the CD BIOS
-pce_fast.cdbios /storage/roms/bios/syscard3.pce
+pce_fast.cdbios syscard3.pce
 
 ;CD-DA volume.
 pce_fast.cddavolume 100
@@ -4608,7 +4608,7 @@ pcfx.adpcm.emulate_buggy_codec 0
 pcfx.adpcm.suppress_channel_reset_clicks 1
 
 ;Path to the ROM BIOS
-pcfx.bios /storage/roms/bios/pcfx.rom
+pcfx.bios pcfx.rom
 
 ;Emulated CD-ROM speed.
 pcfx.cdspeed 2
@@ -7363,11 +7363,11 @@ apple2.yscale 4.000000
 
 apple2.yscalefs 1.000000
 
-psx.bios_eu /storage/roms/bios/scph5502.bin
+psx.bios_eu scph5502.bin
 
-psx.bios_jp /storage/roms/bios/scph5500.bin
+psx.bios_jp scph5500.bin
 
-psx.bios_na /storage/roms/bios/scph5501.bin
+psx.bios_na scph5501.bin
 
 psx.bios_sanity 1
 
@@ -9815,25 +9815,25 @@ sasplay.yscalefs 1.000000
 
 ss.affinity.vdp2 0
 
-ss.bios_jp /storage/roms/bios/sega_101.bin
+ss.bios_jp sega_101.bin
 
-ss.bios_na_eu /storage/roms/bios/mpr-17933.bin
+ss.bios_na_eu mpr-17933.bin
 
 ss.bios_sanity 1
 
-ss.bios_stv_eu /storage/roms/bios/epr-17954a.ic8
+ss.bios_stv_eu epr-17954a.ic8
 
-ss.bios_stv_jp /storage/roms/bios/epr-20091.ic8
+ss.bios_stv_jp epr-20091.ic8
 
-ss.bios_stv_na /storage/roms/bios/epr-17952a.ic8
+ss.bios_stv_na epr-17952a.ic8
 
 ss.cart auto
 
 ss.cart.auto_default backup
 
-ss.cart.kof95_path /storage/roms/bios/mpr-18811-mx.ic1
+ss.cart.kof95_path mpr-18811-mx.ic1
 
-ss.cart.ultraman_path /storage/roms/bios/mpr-19367-mx.ic1
+ss.cart.ultraman_path mpr-19367-mx.ic1
 
 ss.cd_sanity 1
 

--- a/packages/emulators/standalone/mednafen/scripts/mednafen_gen_config.sh
+++ b/packages/emulators/standalone/mednafen/scripts/mednafen_gen_config.sh
@@ -100,7 +100,7 @@ for CONTROL in DEVICE_BTN_AL_DOWN DEVICE_BTN_AL_UP DEVICE_BTN_AL_LEFT    \
                DEVICE_BTN_DPAD_LEFT DEVICE_BTN_DPAD_RIGHT
 
 do
-    sed -i -e "s/@${CONTROL}@//g" $MEDNAFEN_HOME/mednafen.cfg
+    sed -i -e "s/@${CONTROL}@/${!CONTROL}/g" $MEDNAFEN_HOME/mednafen.cfg
 done
 
 else

--- a/packages/emulators/standalone/mednafen/scripts/mednafen_gen_config.sh
+++ b/packages/emulators/standalone/mednafen/scripts/mednafen_gen_config.sh
@@ -76,10 +76,10 @@ do
     sed -i -e "s/@${CONTROL}@/button_${!CONTROL}/g" $MEDNAFEN_HOME/mednafen.cfg
 done
 
-DEVICE_BTN_DPAD_UP="abs_7-"
-DEVICE_BTN_DPAD_DOWN="abs_7+"
-DEVICE_BTN_DPAD_LEFT="abs_6-"
-DEVICE_BTN_DPAD_RIGHT="abs_6+"
+DEVICE_BTN_DPAD_UP="abs_6-"
+DEVICE_BTN_DPAD_DOWN="abs_6+"
+DEVICE_BTN_DPAD_LEFT="abs_5-"
+DEVICE_BTN_DPAD_RIGHT="abs_5+"
 
 # These inputs are probably prefixed with something else than button_
 # Just null out the sticks until it is supported in the controller profile


### PR DESCRIPTION
# Mednafen bugfixes wip

## Description

- 351 macro expansion fix
- 351 d-pad control definitions
- bios path fixes, somehow gba was broken.
- savename, snapshotname, recordingname suffixed with mednafen to specify origin

more bugfixes to come in later PRs