### PR TITLE
Add jslisten close hotkey to portmaster gui

### DIFF
--- a/packages/apps/portmaster/scripts/start_portmaster.sh
+++ b/packages/apps/portmaster/scripts/start_portmaster.sh
@@ -4,6 +4,7 @@
 # Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
+jslisten set "PortMaster"
 
 #Make sure PortMaster exists in .config/PortMaster
 if [ ! -d "/storage/.config/PortMaster" ]; then


### PR DESCRIPTION
should allow us to close portmaster in the event of a crash