### PR TITLE
RK3326 - Perf mode for GBA & PSX

### DIFF
--- a/packages/hardware/quirks/platforms/RK3326/060-game_settings
+++ b/packages/hardware/quirks/platforms/RK3326/060-game_settings
@@ -5,7 +5,7 @@
 . /etc/profile.d/001-functions
 
 ### Set the default performance scaling mode for a few systems.
-for SYSTEM in dreamcast n64 psp saturn
+for SYSTEM in dreamcast n64 psp saturn psx gba
 do
   SETTING=$(get_setting ${SYSTEM})
   if [ -z ${SETTING} ]


### PR DESCRIPTION
some more demanding title for psx and gba need a little more juice on the rk3326