### PR TITLE
Disable ext4 orphan file optimization in mkimage

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -110,7 +110,7 @@ dd if="${DISK}" of="${LE_TMP}/part2.ext4" bs=512 count=0 seek="${STORAGE_PART_CO
 
 # create filesystem on part2
 echo "image: creating filesystem on part2..."
-mke2fs -F -q -t ext4 -m 0 "${LE_TMP}/part2.ext4"
+mke2fs -F -q -t ext4 -m 0 -O ^orphan_file "${LE_TMP}/part2.ext4"
 tune2fs -L "${DISTRO_DISKLABEL}" -U ${UUID_STORAGE} "${LE_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
 e2fsck -n "${LE_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
 sync


### PR DESCRIPTION
## Description

Disable ext4 orphan file optimization in mkimage for greater filesystem compatibility with Ubuntu 22.04

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Ran host dumpe2fs on the ext4 partition to verify all features are recognized and compared against an image built before this change.

**Test Configuration**:
* Build OS name and version: Ubuntu 22.04
* Docker (Y/N): Y
* JELOS Branch: dev