### PR TITLE
Revert mesa (build failure), bump AMD64 kernel to 6.6.1.

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -31,9 +31,9 @@ esac
 get_graphicdrivers
 
 PKG_MESON_OPTS_TARGET="-Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
-                       -Dgallium-extra-hud=true \
-                       -Dgallium-nine=true \
+                       -Dgallium-extra-hud=false \
                        -Dgallium-omx=disabled \
+                       -Dgallium-nine=false \
                        -Dgallium-opencl=disabled \
                        -Dshader-cache=enabled \
                        -Dshared-glapi=enabled \

--- a/packages/kernel/linux/package.mk
+++ b/packages/kernel/linux/package.mk
@@ -4,7 +4,7 @@
 
 PKG_NAME="linux"
 PKG_LICENSE="GPL"
-PKG_VERSION="6.5.11"
+PKG_VERSION="6.6.1"
 PKG_URL="https://www.kernel.org/pub/linux/kernel/v6.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_SITE="http://www.kernel.org"
 PKG_DEPENDS_HOST="ccache:host rsync:host openssl:host"


### PR DESCRIPTION
* Revert mesa changes - 3399 isn't building correctly.
* Bump Linux to 6.6.1 for AMD64.
