### PR TITLE
Rename rk817-battery to battery to fix ES battery indicator

### DIFF
--- a/projects/Rockchip/packages/linux/patches/RK3566-ML/002-rk817-power-driver-names.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3566-ML/002-rk817-power-driver-names.patch
@@ -1,0 +1,21 @@
+diff -rupN linux-6.6-orig/drivers/power/supply/rk817_charger.c linux-6.6/drivers/power/supply/rk817_charger.c
+--- linux-6.6-orig/drivers/power/supply/rk817_charger.c	2023-10-30 02:31:08.000000000 +0000
++++ linux-6.6/drivers/power/supply/rk817_charger.c	2023-11-22 19:43:15.957223087 +0000
+@@ -679,7 +679,7 @@ static enum power_supply_usb_type rk817_
+ };
+ 
+ static const struct power_supply_desc rk817_bat_desc = {
+-	.name = "rk817-battery",
++	.name = "battery",
+ 	.type = POWER_SUPPLY_TYPE_BATTERY,
+ 	.properties = rk817_bat_props,
+ 	.num_properties = ARRAY_SIZE(rk817_bat_props),
+@@ -687,7 +687,7 @@ static const struct power_supply_desc rk
+ };
+ 
+ static const struct power_supply_desc rk817_chg_desc = {
+-	.name = "rk817-charger",
++	.name = "charger",
+ 	.type = POWER_SUPPLY_TYPE_USB,
+ 	.usb_types = rk817_usb_type,
+ 	.num_usb_types = ARRAY_SIZE(rk817_usb_type),


### PR DESCRIPTION
Patches the rk817 battery driver to have ES compatible driver names.