### PR TITLE
Add 6w TDP for Loki Zero (native).

### DIFF
--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="ea0f95a"
+PKG_VERSION="cc2ef90"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
Adds the native TDP setting for the AMD Silver 3050e found in the Loki Zero.