### PR TITLE
AMD64 P-state improvements, revert RK3566 drain fixes.

### DIFF
--- a/packages/hardware/quirks/devices/ayn Loki Max
+++ b/packages/hardware/quirks/devices/ayn Loki Max
@@ -1,1 +1,0 @@
-ayn Loki Zero

--- a/packages/hardware/quirks/devices/ayn Loki Max/010-led_control
+++ b/packages/hardware/quirks/devices/ayn Loki Max/010-led_control
@@ -1,0 +1,8 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+cat <<EOF >/storage/.config/profile.d/010-led_control
+DEVICE_LED_CONTROL="true"
+DEVICE_LED_BRIGHTNESS="true"
+EOF

--- a/packages/hardware/quirks/devices/ayn Loki Max/020-audio_latency
+++ b/packages/hardware/quirks/devices/ayn Loki Max/020-audio_latency
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-# Minimal OS variable loading for performance
 . /etc/profile.d/001-functions
 
-tocon "Configuring LEDs..."
-/usr/bin/ledcontrol
+AUDIO_LATENCY=$(get_setting audiolatency)
+if [ -z "${AUDIO_LATENCY}" ]
+then
+  set_setting global.audiolatency 64
+fi

--- a/packages/hardware/quirks/devices/ayn Loki Max/020-fan_control
+++ b/packages/hardware/quirks/devices/ayn Loki Max/020-fan_control
@@ -1,0 +1,11 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+cat <<EOF >/storage/.config/profile.d/020-fan_control
+DEVICE_HAS_FAN="true"
+DEVICE_PWM_FAN="$(find /sys/devices/platform/ayn-platform -name pwm1)"
+DEVICE_FAN_INPUT="$(find /sys/devices/platform/ayn-platform -name fan*_input)"
+DEVICE_TEMP_SENSOR="$(find /sys/devices/pci*/* -path "*/nvme" -prune -o -name temp1_input -print)"
+EOF
+

--- a/packages/hardware/quirks/devices/ayn Loki Max/050-modifiers
+++ b/packages/hardware/quirks/devices/ayn Loki Max/050-modifiers
@@ -1,0 +1,8 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+cat <<EOF >/storage/.config/profile.d/050-modifiers
+DEVICE_FUNC_KEYA_MODIFIER="BTN_MODE"
+DEVICE_FUNC_KEYB_MODIFIER="KEY_LEFTSHIFT"
+EOF

--- a/packages/hardware/quirks/devices/ayn Loki Max/bin/fancontrol
+++ b/packages/hardware/quirks/devices/ayn Loki Max/bin/fancontrol
@@ -1,0 +1,78 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+. /etc/profile
+
+DEBUG=false
+COOLING_PROFILE=$(get_setting "cooling.profile")
+
+log $0 "Setting profile to ${COOLING_PROFILE}"
+
+function set_control() {
+  log $0 "Set fan control to ${1}"
+  ectool -w 0x10 -z ${1} >/dev/null 2>&1
+}
+
+trap "set_control 0x01 && exit 0" SIGHUP SIGINT SIGQUIT SIGABRT
+
+if [ -e "/storage/.config/fancontrol.conf" ] && [ "${COOLING_PROFILE}" = "custom" ]
+then
+  log $0 "Loading configuration file" 2>/dev/null
+  source /storage/.config/fancontrol.conf
+  if [ ! $? = 0 ]
+  then
+    WARN="Custom fan profile could not be loaded, defaulting to auto."
+    log $0 "${WARN}"
+    COOLING_PROFILE="auto"
+    set_setting cooling.profile auto
+  fi
+fi
+
+
+if [ ! "${COOLING_PROFILE}" = "custom" ]
+then
+  if [ "${COOLING_PROFILE}" = "aggressive" ]
+  then
+    SPEEDS=(128 96 72)
+    TEMPS=(70000 65000 0)
+  elif [ "${COOLING_PROFILE}" = "moderate" ]
+  then
+    SPEEDS=(128 96 72 64 48)
+    TEMPS=(70000 65000 60000 55000 0)
+  elif [ "${COOLING_PROFILE}" = "quiet" ]
+  then
+    SPEEDS=(128 96 64 48 32)
+    TEMPS=(70000 65000 60000 55000 0)
+  else
+    # auto
+    set_control 0x01 >/dev/null 2>&1
+    exit 0
+  fi
+fi
+
+log $0 "Enabling fan control."
+set_control 0x00 >/dev/null 2>&1
+
+while true
+do
+  INDEX=0
+  CPU_TEMP=$(printf "%.0f" $(awk '{ total += $1; count++ } END { print total/count }' ${DEVICE_TEMP_SENSOR}))
+  $DEBUG && log $0 "CPU TEMP: ${CPU_TEMP}" 2>/dev/null
+  for TEMP in "${TEMPS[@]}"
+  do
+    if (( "${CPU_TEMP}" > "${TEMP}" )) && \
+       [ ! "${LASTSPEED}" = "${SPEEDS[${INDEX}]}" ]
+    then
+      $DEBUG && log $0 "Setting PWM FAN to ${SPEEDS[${INDEX}]} (${TEMP})" 2>/dev/null
+      ectool -w 0x11 -z $(printf '%x\n' ${SPEEDS[${INDEX}]}) >/dev/null 2>&1
+      LASTSPEED=${SPEEDS[${INDEX}]}
+      break
+    fi
+    INDEX=$(( $INDEX + 1 ))
+  done
+  sleep 2
+done
+
+log $0 "Disabling fan control."
+set_control 0x01 >/dev/null 2>&1

--- a/packages/hardware/quirks/devices/ayn Loki Max/bin/ledcontrol
+++ b/packages/hardware/quirks/devices/ayn Loki Max/bin/ledcontrol
@@ -1,0 +1,173 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+#
+# A simple tool to manipulate the controller LEDs using ectool, thanks to
+# Ayn for the sample code.
+#
+# Schema:
+#
+# 0xB3 - RGB Mode
+# 0xAA - Save
+#
+# 0xB0 - Red
+# 0xB1 - Green
+# 0xB2 - Blue
+#
+
+. /etc/profile
+
+RGB_RED="0xB0"
+RGB_GREEN="0xB1"
+RGB_BLUE="0xB2"
+RGB_MODE="0xB3"
+RGB_SAVE="0xAA"
+RGB_IDLE="0x55"
+
+ECTOOL="/usr/sbin/ectool"
+DEBUG=false
+
+function debug_out() {
+  $DEBUG && echo "ledcontrol: $*"
+}
+
+function ec_save() {
+  TIMEOUT=0
+  while true
+  do
+    STATE="0x$(${ECTOOL} -r ${RGB_MODE})"
+    if [ "${STATE^^}" == "${RGB_SAVE}" ] || \
+       [ "${STATE}" == "${RGB_IDLE}" ] || \
+       [ "${TIMEOUT}" == 5 ]
+    then
+      break
+    fi
+    sleep .5
+    TIMEOUT=$(( TIMEOUT + 1 ))
+  done
+  ${ECTOOL} -w ${RGB_MODE} -z ${RGB_SAVE} >/dev/null 2>&1
+}
+
+function ec_set() {
+  debug_out "Set EC ${1} ${2}"
+  ${ECTOOL} -w ${1} -z ${2} >/dev/null 2>&1
+}
+
+function off() {
+  ec_save
+  ec_set ${RGB_RED} 0x00
+  ec_set ${RGB_GREEN} 0x00
+  ec_set ${RGB_BLUE} 0x00
+  ec_save
+}
+
+function intensity() {
+  printf "0x%X\n" $((${1} / ${2}))
+}
+
+GETBRIGHTNESS=$(get_setting led.brightness)
+if [ ! -z "${2}" ]
+then
+  LEDBRIGHTNESS=${2}
+  debug_out "Arg[2]: ${2}"
+elif [ ! -z "${GETBRIGHTNESS}" ]
+then
+  LEDBRIGHTNESS=${GETBRIGHTNESS}
+  debug_out "GETBRIGHTESS: ${GETBRIGHTNESS}"
+else
+  debug_out "NO SETTING: max"
+  LEDBRIGHTNESS=mid
+  set_setting led.brightness max
+fi
+
+case ${LEDBRIGHTNESS} in
+  max)
+    LEDBRIGHTNESS=1
+    set_setting led.brightness max
+  ;;
+  mid)
+    LEDBRIGHTNESS=2
+    set_setting led.brightness mid
+  ;;
+  min)
+    LEDBRIGHTNESS=4
+    set_setting led.brightness min
+  ;;
+esac
+
+case $1 in
+  red)
+    off
+    COLOR=$(intensity 0xFF ${LEDBRIGHTNESS})
+    ec_set ${RGB_RED} ${COLOR}
+    ec_set ${RGB_GREEN} 0x00
+    ec_set ${RGB_BLUE} 0x00
+    ec_save
+    set_setting led.color red
+  ;;
+  green)
+    off
+    COLOR=$(intensity 0xFF ${LEDBRIGHTNESS})
+    ec_set ${RGB_RED} 0x00
+    ec_set ${RGB_GREEN} ${COLOR}
+    ec_set ${RGB_BLUE} 0x00
+    ec_save
+    set_setting led.color green
+  ;;
+  blue)
+    off
+    COLOR=$(intensity 0xFF ${LEDBRIGHTNESS})
+    ec_set ${RGB_RED} 0x00
+    ec_set ${RGB_GREEN} 0x00
+    ec_set ${RGB_BLUE} ${COLOR}
+    ec_save
+    set_setting led.color blue
+  ;;
+  teal)
+    off
+    COLOR=$(intensity 0x80 ${LEDBRIGHTNESS})
+    ec_set ${RGB_RED} 0x00
+    ec_set ${RGB_GREEN} ${COLOR}
+    ec_set ${RGB_BLUE} ${COLOR}
+    ec_save
+    set_setting led.color teal
+  ;;
+  purple)
+    off
+    COLOR=$(intensity 0x80 ${LEDBRIGHTNESS})
+    ec_set ${RGB_RED} ${COLOR}
+    ec_set ${RGB_GREEN} 0x00
+    ec_set ${RGB_BLUE} ${COLOR}
+    ec_save
+    set_setting led.color purple
+  ;;
+  white)
+    off
+    COLOR=$(intensity 0x80 ${LEDBRIGHTNESS})
+    ec_set ${RGB_RED} ${COLOR}
+    ec_set ${RGB_GREEN} ${COLOR}
+    ec_set ${RGB_BLUE} ${COLOR}
+    ec_save
+    set_setting led.color purple
+  ;;
+  off)
+    off
+    set_setting led.color off
+  ;;
+  default)
+    del_setting led.color
+    ec_set ${RGB_MODE} 0x00
+  ;;
+  brightness)
+    set_setting led.brightness ${2}
+    ledcontrol $(get_setting led.color)
+  ;;
+  *)
+    COLOR=$(get_setting led.color)
+    if [ ! -z "${COLOR}" ]
+    then
+      ledcontrol ${COLOR}
+    fi
+  ;;
+esac

--- a/packages/hardware/quirks/devices/ayn Loki MiniPro
+++ b/packages/hardware/quirks/devices/ayn Loki MiniPro
@@ -1,1 +1,1 @@
-ayn Loki Zero
+ayn Loki Max

--- a/packages/hardware/quirks/devices/ayn Loki Zero/001-device_config
+++ b/packages/hardware/quirks/devices/ayn Loki Zero/001-device_config
@@ -1,0 +1,15 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+. /etc/profile.d/001-functions
+
+### Set the default device configuration
+cat <<EOF >/storage/.config/profile.d/001-device_config
+DEVICE_BASE_TDP="6w"
+DEVICE_LED_CONTROL="false"
+DEVICE_LED_BRIGHTNESS="false"
+DEVICE_HAS_FAN="false"
+DEVICE_VOLUMECTL="true"
+DEVICE_BRIGHTNESS="hardware"
+EOF

--- a/packages/jelos/sources/scripts/runemu.sh
+++ b/packages/jelos/sources/scripts/runemu.sh
@@ -123,7 +123,7 @@ fi
 ### We need the original system cooling profile later so get it now!
 COOLINGPROFILE=$(get_setting cooling.profile)
 
-### Set CPU TDP (AMD) or EPP (Intel)
+### Set CPU TDP and EPP
 CPU_VENDOR=$(cpu_vendor)
 case ${CPU_VENDOR} in
   AuthenticAMD)
@@ -134,14 +134,13 @@ case ${CPU_VENDOR} in
       /usr/bin/overclock ${OVERCLOCK}
     fi
   ;;
-  GenuineIntel)
-    EPP=$(get_setting "power.epp" "${PLATFORM}" "${ROMNAME##*/}")
-    if [ ! -z ${EPP} ]
-    then
-      /usr/bin/set_epp ${EPP}
-    fi
-  ;;
 esac
+
+EPP=$(get_setting "power.epp" "${PLATFORM}" "${ROMNAME##*/}")
+if [ ! -z ${EPP} ]
+then
+  /usr/bin/set_epp ${EPP}
+fi
 
 GPUPERF=$(get_setting "gpuperf" "${PLATFORM}" "${ROMNAME##*/}")
 if [ ! -z ${GPUPERF} ]

--- a/packages/sysutils/powerstate/profile.d/030-powerfunctions
+++ b/packages/sysutils/powerstate/profile.d/030-powerfunctions
@@ -70,30 +70,51 @@ pcie_aspm_policy() {
 cpu_perftune() {
   CPUPOWERSAVE=$(get_setting system.power.cpu)
   POWERSAVEENABLED=$(get_setting system.powersave)
+  CPU="$(awk '/vendor_id/ {print $3;exit}' /proc/cpuinfo)"
+
   if [ "${CPUPOWERSAVE}" = "1" ] && \
      [ "${POWERSAVEENABLED}" = "1" ]
   then
-    CPU="$(awk '/vendor_id/ {print $3;exit}' /proc/cpuinfo)"
-    if [ "${CPU}" = "AuthenticAMD" ]
-    then
-      if [ "${1}" = "battery" ]
-      then
-        ryzenadj --power-saving >/dev/null 2>&1
-      else
-        ryzenadj --max-performance >/dev/null 2>&1
-      fi
-    elif [ "${CPU}" = "GenuineIntel" ]
-    then
-      for policy in $(find /sys/devices/system/cpu/cpufreq/policy*/ -name energy_performance_preference)
-      do
+    case ${CPU} in
+      AuthenticAMD)
         if [ "${1}" = "battery" ]
         then
-          echo power >${policy} >/dev/null 2>&1
+          ryzenadj --power-saving >/dev/null 2>&1
         else
-          echo performance >${policy} >/dev/null 2>&1
+          ryzenadj --max-performance >/dev/null 2>&1
         fi
-      done
-    fi
+      ;;
+    esac
+  fi
+
+  case ${CPU} in
+    AuthenticAMD)
+      PSTATE="amd_pstate"
+      STATUS="active"
+    ;;
+    GenuineIntel)
+      PSTATE="intel_pstate"
+      STATUS="passive"
+    ;;
+  esac
+
+  if [ -f "/sys/devices/system/cpu/${PSTATE}/status" ]
+  then
+    echo ${STATUS} >/sys/devices/system/cpu/${PSTATE}/status
+    while [ ! -f /sys/devices/system/cpu/cpufreq/policy0/energy_performance_preference ]
+    do
+      sleep .25
+    done
+    for policy in $(find /sys/devices/system/cpu/cpufreq/policy*/ -name energy_performance_preference)
+    do
+      EPP=$(get_setting system.power.epp)
+      if [ -z "${EPP}" ]
+      then
+        EPP="performance"
+        set_setting system.power.epp ${EPP}
+      fi
+      echo ${EPP} >${policy} 2>/dev/null
+    done
   fi
 }
 

--- a/packages/sysutils/system-utils/sources/autostart/AMD64/002-overclock
+++ b/packages/sysutils/system-utils/sources/autostart/AMD64/002-overclock
@@ -1,11 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-# Minimal OS variable loading for performance
 . /etc/profile.d/001-functions
-
-CPU_VENDOR=$(cpu_vendor)
 
 case ${CPU_VENDOR} in
   AuthenticAMD)
@@ -17,33 +14,5 @@ case ${CPU_VENDOR} in
       set_setting system.overclock off
     fi
     /usr/bin/overclock boot
-  ;;
-  GenuineIntel)
-    tocon "Configuring system EPP..."
-
-    ###
-    ### Enable dynamic boost.
-    ###
-
-    if [ -f "/sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost" ]
-    then
-      echo 1 >/sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost
-    fi
-
-    ###
-    ### Energy Performance Preference isn't writeable if pstates are in
-    ### active mode.
-    ###
-
-    if [ -f "/sys/devices/system/cpu/intel_pstate/status" ]
-    then
-      echo passive >/sys/devices/system/cpu/intel_pstate/status
-    fi
-
-    EPP=$(get_setting system.power.epp)
-    if [ ! -z ${EPP} ]
-    then
-      /usr/bin/set_epp
-    fi
   ;;
 esac

--- a/packages/sysutils/system-utils/sources/devices/AMD64/set_epp
+++ b/packages/sysutils/system-utils/sources/devices/AMD64/set_epp
@@ -15,17 +15,38 @@ then
   PROFILE=$(get_setting system.power.epp)
   if [ -z "${PROFILE}" ]
   then
-    PROFILE="balance_performance"
+    PROFILE="performance"
+    set_setting system.power.epp ${PROFILE}
   fi
 else
   PROFILE=$1
 fi
+CPU_VENDOR=$(cpu_vendor)
 
-case ${PROFILE} in
-  *)
-    for POLICY in $(find /sys/devices/system/cpu/cpufreq -name policy[0-9]*)
-    do
-      echo ${PROFILE} >${POLICY}/energy_performance_preference 2>/dev/null
-    done
+case ${CPU_VENDOR} in
+  AuthenticAMD)
+    PSTATE="amd_pstate"
+    STATUS="active"
+  ;;
+  GenuineIntel)
+    PSTATE="intel_pstate"
+    STATUS="passive"
   ;;
 esac
+
+if [ -f "/sys/devices/system/cpu/${PSTATE}/status" ]
+then
+  echo ${STATUS} >/sys/devices/system/cpu/${PSTATE}/status
+  while [ ! -f /sys/devices/system/cpu/cpufreq/policy0/energy_performance_preference ]
+  do
+    sleep .25
+  done
+  case ${PROFILE} in
+    *)
+      for POLICY in $(find /sys/devices/system/cpu/cpufreq -name policy[0-9]*)
+      do
+        echo ${PROFILE} >${POLICY}/energy_performance_preference 2>/dev/null
+      done
+    ;;
+  esac
+fi

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="cc2ef90"
+PKG_VERSION="6c712ff"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"

--- a/projects/PC/devices/AMD64/options
+++ b/projects/PC/devices/AMD64/options
@@ -14,7 +14,7 @@
     esac
 
   # kernel command line
-    EXTRA_CMDLINE="quiet console=tty0 ssh consoleblank=0 systemd.show_status=0 loglevel=0 panic=20 intel_pstate=active amd_pstate=active amd_pstate.shared_mem=1 amdgpu.dpm=1"
+    EXTRA_CMDLINE="quiet console=tty0 ssh consoleblank=0 systemd.show_status=0 loglevel=0 panic=20 intel_pstate=passive amd_pstate=active amd_pstate.shared_mem=1 amdgpu.dpm=1"
 
   # Partition label
     PARTITION_TABLE="msdos"

--- a/projects/Rockchip/devices/RK3566-X55/options
+++ b/projects/Rockchip/devices/RK3566-X55/options
@@ -31,7 +31,7 @@
     BOOTLOADER="u-boot"
     PARTITION_TABLE="gpt"
     UBOOT_LABEL="uboot"
-    TRUST_LABEL="trust"
+    TRUST_LABEL="resource"
     DEVICE_DTB=("rk3566-evb2-lp4x-v10-linux")
     UBOOT_DTB="rk3566"
     UBOOT_CONFIG="rk3568_defconfig"
@@ -41,7 +41,6 @@
     PKG_BL31="${PKG_RKBIN}/bin/rk35/rk3568_bl31_v1.42.elf"
     PKG_LOAD_ADDR="0x0a100000"
     BOOT_INI=false
-    FDTDIR=false
     EXT_LINUX_CONF=true
 
   # Additional kernel make parameters (for example to specify the u-boot loadaddress)

--- a/projects/Rockchip/devices/RK3566/options
+++ b/projects/Rockchip/devices/RK3566/options
@@ -31,7 +31,7 @@
     BOOTLOADER="u-boot"
     PARTITION_TABLE="gpt"
     UBOOT_LABEL="uboot"
-    TRUST_LABEL="trust"
+    TRUST_LABEL="resource"
     DEVICE_DTB=("rk3566-rg353p-linux" "rk3566-rg353v-linux" "rk3566-rg353m-linux" "rk3566-rg503-linux" "rk3566-rk2023-linux" "rk3566-rgb30-linux")
     UBOOT_DTB="rk3566"
     UBOOT_CONFIG="rk3568_defconfig"

--- a/projects/Rockchip/packages/linux/package.mk
+++ b/projects/Rockchip/packages/linux/package.mk
@@ -31,7 +31,7 @@ case ${DEVICE} in
   ;;
   *X55)
     PKG_URL="${PKG_SITE}/rk3566-x55-kernel.git"
-    PKG_VERSION="ec1669474"
+    PKG_VERSION="9b92751b8fe21f9326d1a54dd5f675965a12d6e1"
     GET_HANDLER_SUPPORT="git"
     PKG_GIT_CLONE_BRANCH="main"
   ;;

--- a/projects/Rockchip/packages/u-boot/package.mk
+++ b/projects/Rockchip/packages/u-boot/package.mk
@@ -20,7 +20,7 @@ case ${DEVICE} in
   ;;
   RK356*)
     PKG_URL="${PKG_SITE}/rk356x-uboot.git"
-    PKG_VERSION="02e1249"
+    PKG_VERSION="88b2f26"
   ;;
   RK3399)
     PKG_URL="${PKG_SITE}/rk3399-uboot.git"

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -80,19 +80,19 @@ STORAGE_PART_START=$(( ${SYSTEM_PART_END} + 1 ))
 STORAGE_PART_END=$(( ${STORAGE_PART_START} + (${STORAGE_SIZE} * 1024 * 1024 / 512) - 1 ))
 
 if [ "${PARTITION_TABLE}" = "gpt" ]; then
-  echo "image: Create boot partition."
+  echo "image: Create GPT boot partition."
   parted -s "${DISK}" -a min unit s mkpart boot fat32 ${SYSTEM_PART_START} ${SYSTEM_PART_END}
 else
-  echo "image: Create primary partition."
+  echo "image: Create MBR boot partition."
   parted -s "${DISK}" -a min unit s mkpart primary fat32 ${SYSTEM_PART_START} ${SYSTEM_PART_END}
   parted -s "${DISK}" set 1 boot on
 fi
 
 if [ "${PARTITION_TABLE}" = "gpt" ]; then
-    echo "image: Create storage partition."
+    echo "image: Create GPT storage partition."
     parted -s "${DISK}" -a min unit s mkpart storage ext4 ${STORAGE_PART_START} ${STORAGE_PART_END}
   else
-    echo "image: Create primary partition."
+    echo "image: Create MBR Storage partition."
     parted -s "${DISK}" -a min unit s mkpart primary ext4 ${STORAGE_PART_START} ${STORAGE_PART_END}
 fi
 sync


### PR DESCRIPTION
* Improved support for AMD p-state drivers (<7w idle on AMD 6800U).
* Break Loki Zero link to configure proper default TDP for Max and MiniPro.
* Revert drain when charged while powered off support for RK3566.