### PR TITLE
Revert lower:lower overlay configuration.

### DIFF
--- a/packages/virtual/emulators/system.d/storage-roms.mount
+++ b/packages/virtual/emulators/system.d/storage-roms.mount
@@ -7,7 +7,7 @@ DefaultDependencies=no
 What=none
 Where=/storage/roms
 Type=overlay
-Options=lowerdir=/storage/games-internal:/storage/games-external
+Options=lowerdir=/storage/games-external,upperdir=/storage/games-internal,workdir=/storage/.tmp/games-workdir
 
 [Install]
 WantedBy=jelos.target

--- a/packages/virtual/emulators/tmpfiles.d/jelos-dirs.conf
+++ b/packages/virtual/emulators/tmpfiles.d/jelos-dirs.conf
@@ -2,6 +2,7 @@
 # Copyright (C) 2021-present 351ELEC (https://github.com/351ELEC)
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
+d    /storage/.tmp/games-workdir	0777 root root - -
 d    /storage/games-internal		0777 root root - -
 d    /storage/games-external		0777 root root - -
 d    /storage/roms			0777 root root - -


### PR DESCRIPTION
## Description

Optimally we would be able to utilize a lower:lower overlay that mounts on /storage/roms, however we will fall back to a lower:upper configuration for the following reasons.

1. /storage/roms would be read only.  This wouldn't be an issue if all software was modified to use /storage/games-internal, however we have no control over external projects like PortMaster and ThemeMaster.
2. Not all storage options supported by JELOS support overlayfs.  We could work around this by using bind mounts for unsupported volumes.

Caveats to lower:upper:
* Anything written to /storage/games-internal will not be visible in /storage/roms until the overlay is restarted or if it is stopped prior to writing.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (only if you've built in the last few hours)

## How Has This Been Tested Locally?

Tested on Air Plus with ext4 microsd, and rgb30 with exfat.