### PR TITLE
Retroarch v1.16.0.3

### DIFF
--- a/config/blocklist
+++ b/config/blocklist
@@ -10,5 +10,5 @@ melonds-sa #Broken OpenGL renderer upstream
 mupen64plus-sa-ui-console #Causes segfaults
 nanoboyadvance-sa #SDL version removed after this commit
 freechaf-lr #build issue, revisit.
-pcsx_rearmed-lr #pins version as new releases have artifacting issues.
 kronos-sa #using the release version of kronos had better results.
+retroarch #pinning to release versions for stability.

--- a/packages/emulators/libretro/pcsx_rearmed-lr/package.mk
+++ b/packages/emulators/libretro/pcsx_rearmed-lr/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="pcsx_rearmed-lr"
-PKG_VERSION="e34ef5a"
+PKG_VERSION="ff3890db8ef473ee5eae6a7120ee39d761a86620"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/pcsx_rearmed"

--- a/packages/emulators/standalone/retroarch/package.mk
+++ b/packages/emulators/standalone/retroarch/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="retroarch"
-PKG_VERSION="f091b5a9e9475255e5efaded5f95c9750fdfe15e"
+PKG_VERSION="6c2cc456284fcfa6fa5f94664950926c020d2f7b" # v1.16.0.3
 PKG_SITE="https://github.com/libretro/RetroArch"
 PKG_URL="${PKG_SITE}.git"
 PKG_LICENSE="GPLv3"


### PR DESCRIPTION
## Description

Retroarch breaks 32bit cheevos after updating to rcheevos v11. To mitigate, we're going to fall back and pin to v1.16.0.3.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Tested on RGB30, verified that 32bit and 64bit PSX retroachievements work correctly.