### PR TITLE
Include cps1, cps2, and cps3 in list of cheevo support

### DIFF
--- a/packages/jelos/sources/scripts/setsettings.sh
+++ b/packages/jelos/sources/scripts/setsettings.sh
@@ -52,6 +52,9 @@ declare -a HAS_CHEEVOS=(    arcade
                             atari7800
                             atarilynx
                             colecovision
+                            cps1
+                            cps2
+                            cps3
                             dreamcast
                             famicom
                             fbn


### PR DESCRIPTION
# Pull Request Template

## Description

cps1, cps2, and cps3 default to using FBNeo, which supports Retro Achievements. They work the same as games launched from "arcade" or "neogeo" using FBNeo (and those are already specified in the file).

Fixes # (issue)

I noticed that games launched from CPS1/2/3 weren't having the /tmp/.retroarch.cfg applied (which contained Retro Achievement settings applied from Emulation Station). This corrects that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

I cloned dev branch, made the changes, compiled, flashed image to RGB30, put my connection settings back in, loaded a game from CPS3, Achievements logged in and popped right up.

**Test Configuration**:
* Build OS name and version: Win11 / WSL
* Docker (Y/N): Y
* JELOS Branch: dev

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

