### PR TITLE
fix for wireguard installation

### DIFF
--- a/packages/network/wireguard-tools/package.mk
+++ b/packages/network/wireguard-tools/package.mk
@@ -27,5 +27,5 @@ makeinstall_target() {
     cp ${PKG_DIR}/scripts/wg-genconfig ${INSTALL}/usr/bin
     cp ${PKG_BUILD}/src/wg ${INSTALL}/usr/bin
     cp ${PKG_BUILD}/src/wg-quick/linux.bash ${INSTALL}/usr/bin/wg-quick
-    chmod -755 ${INSTALL}/usr/bin/*
+    chmod 755 ${INSTALL}/usr/bin/*
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Fix wireguard-tools installation by removing an extra dash in "chmod -755 ${INSTALL}/usr/bin/*"

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested Locally?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] make docker-S922X completed successfully

**Test Configuration**:
* Build OS name and version: Ubuntu 22.04 x86
* Docker (Y/N): Y
* JELOS Branch: dev
* Any additional information that may be useful: n/a

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
