### PR TITLE
Set Mesa to compile with O3 and not Ofast

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -100,6 +100,11 @@ else
   PKG_MESON_OPTS_TARGET+=" -Dvulkan-drivers="
 fi
 
+pre_configure_target() {
+  TARGET_CFLAGS=$(echo ${CFLAGS} | sed -e "s|-Ofast|-O3|")
+  TARGET_CXXFLAGS=$(echo ${CXXFLAGS} | sed -e "s|-Ofast|-O3|")
+}
+
 post_makeinstall_target() {
   case ${DEVICE} in
     S922X)


### PR DESCRIPTION
This should fix graphics issues seen in Yuzu. Should probably clean up other bugs as well. 