### PR TITLE
Update Gambatte & Add TWB64 - Pack 3

### DIFF
--- a/packages/emulators/libretro/gambatte-lr/package.mk
+++ b/packages/emulators/libretro/gambatte-lr/package.mk
@@ -20,7 +20,7 @@
 ################################################################################
 
 PKG_NAME="gambatte-lr"
-PKG_VERSION="327137ec04d514b6c06c30c8b1d0b5da4267af6c"
+PKG_VERSION="9b232311f4f462a5dc26187b511ea361d30c5959"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/jelos/sources/scripts/setsettings.sh
+++ b/packages/jelos/sources/scripts/setsettings.sh
@@ -927,6 +927,7 @@ function set_gambatte() {
         local COLORIZATION=$(game_setting renderer.colorization)
         local TWB1_COLORIZATION=$(game_setting renderer.twb1_colorization)
         local TWB2_COLORIZATION=$(game_setting renderer.twb2_colorization)
+        local TWB3_COLORIZATION=$(game_setting renderer.twb3_colorization)
         local PIXELSHIFT1_COLORIZATION=$(game_setting renderer.pixelshift1_colorization)
 
 	if [ -n "${COLORIZATION}" ]
@@ -946,6 +947,7 @@ function set_gambatte() {
                     echo 'gambatte_gb_internal_palette = "'${COLORIZATION}'"' >> ${GAMBATTECONF}
                     echo 'gambatte_gb_palette_twb64_1 = "'${TWB1_COLORIZATION}'"' >> ${GAMBATTECONF}
                     echo 'gambatte_gb_palette_twb64_2 = "'${TWB2_COLORIZATION}'"' >> ${GAMBATTECONF}
+                    echo 'gambatte_gb_palette_twb64_3 = "'${TWB3_COLORIZATION}'"' >> ${GAMBATTECONF}
 		    echo 'gambatte_gb_palette_pixelshift_1 = "'${PIXELSHIFT1_COLORIZATION}'"' >> ${GAMBATTECONF}
                 ;;
             esac


### PR DESCRIPTION
Updates gambatte as palettes have been fixed, this will allow for your TWB64 - Pack 3 to be passed to RArch after you select it in the ES menu.