### PR TITLE
Additional bug fixes and refinements for merged storage.

### DIFF
--- a/packages/jelos/sources/post-update
+++ b/packages/jelos/sources/post-update
@@ -107,7 +107,6 @@ then
     fi
     mv "${GAMES}"/* "${GAMES}/roms/" 
   done
-  systemctl restart jelos-automount
   touch /storage/.migrated_games2
 fi
 
@@ -136,3 +135,4 @@ then
   set_setting system.merged.storage 0
 fi
 
+systemctl restart jelos-automount

--- a/packages/jelos/sources/scripts/automount
+++ b/packages/jelos/sources/scripts/automount
@@ -9,11 +9,6 @@
 UPDATE_ROOT="/storage/.update"
 MOUNT_GAMES=$(get_setting system.automount)
 GAMES_DEVICE=$(get_setting system.gamesdevice)
-MS_DEVICE=$(get_setting system.merged.device)
-
-### Default to the external storage device.
-MOUNT_PATH="/storage/games-external"
-
 MS_PATH="/storage/roms"
 
 function unmount() {
@@ -25,6 +20,7 @@ function start_ms() {
   ### Entrypoint will be either games card found (external), or not found (internal).
   MOUNT_PATH="/storage/games-${1}"
 
+  MS_DEVICE=$(get_setting system.merged.device)
   ### If the merge target isn't defined and we have an external microsd, we should use the external card by default.
   if [ -z "${MS_DEVICE}" ] && \
      [ "${1}" = "external" ]
@@ -95,7 +91,7 @@ function load_modules() {
 }
 
 function mount_games() {
-      local MOUNT_PATH="/storage/games-external"
+      MOUNT_PATH="/storage/games-external"
       FSTYPE=$(blkid -o export ${1} | awk 'BEGIN {FS="="} /TYPE/ {print $2}')
       case ${FSTYPE} in
         ext4)
@@ -175,6 +171,13 @@ function find_games() {
       fi
     done
     log $0 "Could not find external card to mount, assume internal."
+
+    MS_DEVICE=$(get_setting system.merged.device)
+    ### If the merge target isn't defined and we do not have an external microsd, we should use the internal card by default.
+    if [ -z "${MS_DEVICE}" ]
+    then
+      set_setting system.merged.device internal
+    fi
     start_ms internal
     create_game_dirs
     exit 0

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="adc7cb5"
+PKG_VERSION="0f013c2"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
## Description

* Test for system.merged.device and bind to the internal device if it doesn't exist and no card is found.
* Restart automount later in post-update to ensure all config changes have been committed.
* Update EmulationStation.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Tested on AYN Loki Zero with internal and external storage (Ext4), AYANEO Air Plus with internal storage (Ext4), and RG353V with internal (Ext4) and external storage (ExFAT).