### PR TITLE
Clean up PortMaster vars

### DIFF
--- a/packages/apps/portmaster/scripts/portmaster_compatibility.sh
+++ b/packages/apps/portmaster/scripts/portmaster_compatibility.sh
@@ -5,10 +5,8 @@
 
 . /etc/profile
 
-PORTPLATFORM=$(tr -d '\0' </sys/firmware/devicetree/base/model 2>/dev/null)
-
 if [[ "${UI_SERVICE}" =~ weston.service ]]; then
-case ${PORTPLATFORM} in
+case ${QUIRK_DEVICE} in
   "Hardkernel ODROID-GO-Ultra"|"Powkiddy RGB10 MAX 3"|"Hardkernel ODROID-N2*")
     #Fixing ports on S922X, exclude FNA games
     for port in /storage/roms/ports/*.sh; do

--- a/packages/apps/portmaster/sources/control.txt
+++ b/packages/apps/portmaster/sources/control.txt
@@ -23,9 +23,8 @@ SDLDBUSERFILE="/storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt"
 clibs="/usr/lib/compat/"
 raloc="/usr/bin"
 raconf="--config /storage/.config/retroarch/retroarch.cfg"
-pdevice=$(tr -d '\0' </sys/firmware/devicetree/base/model 2>/dev/null)
 
-case ${pdevice} in
+case "${QUIRK_DEVICE}" in
   "Anbernic RG552")
     profile="rg552"
     lres="N"


### PR DESCRIPTION
We dont need to define the device, already have a feature for that. 