### PR TITLE
Fix panel reporting on mainline-3566

### DIFF
--- a/packages/hardware/quirks/devices/Anbernic RG353P/info.d/001-panel
+++ b/packages/hardware/quirks/devices/Anbernic RG353P/info.d/001-panel
@@ -1,11 +1,11 @@
 #!/bin/sh
-ID=$(dmesg | grep "panel id:" | sed "s#^.*panel id: ##g")
+ID=$(dmesg | grep "panel")
 case ${ID} in
-  "30 52")
-    ID="v1 (${ID})"
+  *newvision*)
+    ID="v1"
   ;;
-  "38 21")
-    ID="v2 (${ID})"
+  *sitronix*)
+    ID="v2"
   ;;
   *)
     ID="Unknown"
@@ -15,4 +15,4 @@ esac
 if [ -n "${ID}" ]
 then
   echo "PANEL VERSION: ${ID}"
-fi 
+fi

--- a/packages/hardware/quirks/devices/Anbernic RG353V/info.d/001-panel
+++ b/packages/hardware/quirks/devices/Anbernic RG353V/info.d/001-panel
@@ -1,10 +1,10 @@
 #!/bin/sh
-ID=$(dmesg | grep "panel id:" | sed "s#^.*panel id: ##g")
+ID=$(dmesg | grep "panel")
 case ${ID} in
-  "30 52")
+  *newvision*)
     ID="v1"
   ;;
-  "38 21")
+  *sitronix*)
     ID="v2"
   ;;
   *)
@@ -15,4 +15,4 @@ esac
 if [ -n "${ID}" ]
 then
   echo "PANEL VERSION: ${ID}"
-fi 
+fi


### PR DESCRIPTION
## Description

This will fix the panel reporting for mainline, in es's system information panel

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Testing with v1 panel, dmesg obtained for v2