### PR TITLE
rk3326: enable kernel serial output

### DIFF
--- a/projects/Rockchip/devices/RK3326/options
+++ b/projects/Rockchip/devices/RK3326/options
@@ -70,7 +70,7 @@
     WINDOWMANAGER="weston"
   
   # kernel serial console
-    EXTRA_CMDLINE="quiet rootwait console=tty0 ssh consoleblank=0 systemd.show_status=0 loglevel=0 panic=20"
+    EXTRA_CMDLINE="quiet rootwait console=ttyFIQ0 console=tty0 ssh consoleblank=0 systemd.show_status=0 loglevel=0 panic=20"
 
   # additional packages to install
     ADDITIONAL_PACKAGES=""


### PR DESCRIPTION
## Description

Enable kernel serial output by default in order to aid debug issues.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Not tested because I haven't been able to build an image yet.