### PR TITLE
Start working on Qt6

### DIFF
--- a/packages/graphics/qt6/package.mk
+++ b/packages/graphics/qt6/package.mk
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2023-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+
+PKG_NAME="qt6"
+PKG_MAJOR_VERSION="6.6"
+PKG_VERSION="${PKG_MAJOR_VERSION}.1"
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://download.qt.io"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="QT6 - Qt is a full development framework with tools designed to streamline the creation of applications and user interfaces for desktop, embedded, and mobile platforms."
+
+PKG_DEPENDS_TARGET+=" 	qt6base \
+			qt6tools \
+			qtwayland"

--- a/packages/graphics/qt6/package.mk
+++ b/packages/graphics/qt6/package.mk
@@ -7,8 +7,8 @@ PKG_VERSION="${PKG_MAJOR_VERSION}.1"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://download.qt.io"
 PKG_DEPENDS_TARGET="toolchain"
-PKG_LONGDESC="QT6 - Qt is a full development framework with tools designed to streamline the creation of applications and user interfaces for desktop, embedded, and mobile platforms."
+PKG_LONGDESC="Qt6 - Qt is a full development framework with tools designed to streamline the creation of applications and user interfaces for desktop, embedded, and mobile platforms."
 
 PKG_DEPENDS_TARGET+=" 	qt6base \
 			qt6tools \
-			qtwayland"
+			qt6wayland"

--- a/packages/graphics/qt6/qt6base/package.mk
+++ b/packages/graphics/qt6/qt6base/package.mk
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2023-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+
+PKG_NAME="qt6base"
+PKG_MAJOR_VERSION="6.6"
+PKG_VERSION="${PKG_MAJOR_VERSION}.1"
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://download.qt.io"
+PKG_URL="${PKG_SITE}/archive/qt/${PKG_MAJOR_VERSION}/${PKG_VERSION}/submodules/qtbase-everywhere-src-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_HOST="toolchain:host"
+PKG_DEPENDS_TARGET="toolchain qt6base:host xorgproto"
+PKG_LONGDESC="QT6 base package"
+
+pre_configure_host() {
+PKG_CMAKE_OPTS_HOST+="
+        -GNinja \
+        -DFEATURE_gui=ON \
+        -DFEATURE_openssl_linked=ON \
+        -DFEATURE_concurrent=ON \
+        -DFEATURE_xml=ON \
+        -DFEATURE_sql=ON \
+        -DFEATURE_testlib=ON \
+        -DFEATURE_network=ON \
+        -DFEATURE_dbus=ON \
+        -DFEATURE_icu=OFF \
+        -DFEATURE_glib=OFF \
+        -DFEATURE_system_pcre2=ON \
+        -DFEATURE_system_zlib=ON \
+        -DQT_BUILD_TESTS_BY_DEFAULT=OFF \
+        -DQT_BUILD_EXAMPLES_BY_DEFAULT=OFF \
+        -DCMAKE_CROSSCOMPILING=OFF"
+}
+
+pre_configure_target() {
+  PKG_CMAKE_OPTS_TARGET+="
+	-GNinja \
+        -DQT_HOST_PATH=${PKG_BUILD}/.x86_64-linux-gnu \
+        -DFEATURE_gui=ON \
+	-DFEATURE_concurrent=OFF \
+	-DFEATURE_xml=OFF \
+	-DFEATURE_sql=OFF \
+	-DFEATURE_testlib=OFF \
+	-DFEATURE_network=ON \
+	-DFEATURE_icu=OFF \
+	-DFEATURE_glib=OFF \
+	-DFEATURE_system_doubleconversion=OFF \
+	-DFEATURE_system_pcre2=ON \
+	-DFEATURE_system_zlib=ON \
+	-DFEATURE_libudev=ON\
+	-DFEATURE_gui=ON \
+	-DFEATURE_freetype=ON \
+	-DFEATURE_png=ON\
+	-DFEATURE_system_png=ON \
+	-DFEATURE_gui=ON \
+	-DFEATURE_freetype=ON \
+	-DFEATURE_vulkan=OFF \
+	-DFEATURE_dbus=ON"
+
+}
+
+make_host() {
+  ninja ${NINJA_OPTS}
+}

--- a/packages/graphics/qt6/qt6tools/package.mk
+++ b/packages/graphics/qt6/qt6tools/package.mk
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2023-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+
+PKG_NAME="qt6tools"
+PKG_MAJOR_VERSION="6.6"
+PKG_VERSION="${PKG_MAJOR_VERSION}.1"
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://download.qt.io"
+PKG_URL="${PKG_SITE}/archive/qt/${PKG_MAJOR_VERSION}/${PKG_VERSION}/submodules/qttools-everywhere-src-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_HOST="toolchain:host qt6base"
+PKG_DEPENDS_TARGET="toolchain qt6tools:host qt6base"
+PKG_LONGDESC="QT6 Tools package"
+
+pre_configure_host() {
+ PKG_CMAKE_OPTS_HOST+="		-GNinja \
+				-DQT_FEATURE_linguist=ON \
+				-DQT_FEATURE_qdbus=OFF \
+				-DQT_FEATURE_qtattributionsscanner=ON \
+				-DQT_FEATURE_qtdiag=ON \
+				-DQT_FEATURE_qtplugininfo=ON \
+				-DCMAKE_CROSSCOMPILING=OFF"
+}
+
+pre_configure_target() {
+  PKG_CMAKE_OPTS_TARGET+="	-GNinja \
+				-DQT_HOST_PATH=${PKG_BUILD}/.x86_64-linux-gnu \
+				-DQT_FEATURE_linguist=ON \
+				-DQT_FEATURE_qdbus=ON \
+				-DQT_DEBUG_FIND_PACKAGE=ON
+				-DQT_FEATURE_qtattributionsscanner=ON \
+				-DQT_FEATURE_qtdiag=ON \
+				-DQT_FEATURE_qtplugininfo=ON \
+				-DQT_BUILD_TESTS_BY_DEFAULT=OFF \
+				-DQT_BUILD_EXAMPLES_BY_DEFAULT=OFF \
+				-DQT_FEATURE_LinguistTools=OFF"
+}
+
+
+make_host() {
+  ninja ${NINJA_OPTS}
+}

--- a/packages/graphics/qt6/qt6wayland/package.mk
+++ b/packages/graphics/qt6/qt6wayland/package.mk
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2023-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+
+PKG_NAME="qt6wayland"
+PKG_MAJOR_VERSION="6.6"
+PKG_VERSION="${PKG_MAJOR_VERSION}.1"
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://download.qt.io"
+PKG_URL="${PKG_SITE}/archive/qt/${PKG_MAJOR_VERSION}/${PKG_VERSION}/submodules/qtwayland-everywhere-src-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_HOST="toolchain:host qt6base"
+PKG_DEPENDS_TARGET="toolchain qt6wayland:host qt6base"
+PKG_LONGDESC="QT6 wayland"
+
+pre_configure_host() {
+  PKG_CMAKE_OPTS_HOST+="	-GNinja \
+				-DBUILD_WITH_PCH=OFF \
+				-DQT_BUILD_EXAMPLES=OFF \
+				-DQT_BUILD_TESTS=OFF \
+				-DCMAKE_CROSSCOMPILING=OFF"
+}
+
+pre_configure_target() {
+  PKG_CMAKE_OPTS_TARGET+="	-GNinja \
+				-DQT_HOST_PATH=${PKG_BUILD}/.x86_64-linux-gnu \
+				-DQT_DEBUG_FIND_PACKAGE=ON \
+				-DBUILD_WITH_PCH=OFF \
+				-DQT_BUILD_EXAMPLES=OFF \
+				-DQT_BUILD_TESTS=OFF"
+}
+
+make_host() {
+  ninja ${NINJA_OPTS}
+}


### PR DESCRIPTION
Qt6base builds but qt6 tools and wayland both fail with the follow error:
```

CMake Error at CMakeLists.txt:26 (find_package):
  Found package configuration file:

    /media/storage/JELOS/build.JELOS-AMD64.x86_64/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/cmake/Qt6/Qt6Config.cmake

  but it set Qt6_FOUND to FALSE so package "Qt6" is considered to be NOT
  FOUND.  Reason given by package:

  Failed to find required Qt component "Core".

  Expected Config file at
  "/media/storage/JELOS/build.JELOS-AMD64.x86_64/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/cmake/Qt6Core/Qt6CoreConfig.cmake"
  exists



  Configuring with --debug-find-pkg=Qt6Core might reveal details why the
  package was not found.

```