### PR TITLE
Ensure the roms directory is always created.

### DIFF
--- a/packages/audio/flac/package.mk
+++ b/packages/audio/flac/package.mk
@@ -8,28 +8,13 @@ PKG_SITE="https://xiph.org/flac/"
 PKG_URL="http://downloads.xiph.org/releases/flac/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libogg"
 PKG_LONGDESC="An Free Lossless Audio Codec."
-PKG_TOOLCHAIN="autotools"
-# flac-1.3.1 dont build with LTO support
-PKG_BUILD_FLAGS="+pic"
 
-# package specific configure options
-PKG_CONFIGURE_OPTS_TARGET="--enable-shared \
-                           --disable-static \
-                           --disable-rpath \
-                           --disable-altivec \
-                           --disable-doxygen-docs \
-                           --disable-thorough-tests \
-                           --disable-cpplibs \
-                           --disable-xmms-plugin \
-                           --disable-oggtest \
-                           --with-ogg=${SYSROOT_PREFIX}/usr \
-                           --with-gnu-ld"
-
-if target_has_feature sse; then
-  PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_TARGET} --enable-sse"
-else
-  PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_TARGET} --disable-sse"
-fi
+pre_configure_target() {
+  PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=ON \
+                         -DWITH_STACK_PROTECTOR=OFF \
+                         -DINSTALL_MANPAGES=OFF \
+                         -DNDEBUG=OFF"
+}
 
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/bin

--- a/packages/jelos/sources/scripts/automount
+++ b/packages/jelos/sources/scripts/automount
@@ -40,6 +40,15 @@ function start_ms() {
     ;;
   esac
 
+  for GAME_PATH in internal external
+  do
+    if [ ! -d "/storage/games-${GAME_PATH}/roms" ]
+    then
+      log $0 "Create /storage/games-${GAME_PATH}/roms."
+      mkdir -p "/storage/games-${GAME_PATH}/roms"
+    fi
+  done
+
   MS_ENABLED=$(get_setting system.merged.storage)
   if [ -e "/storage/.ms_unsupported" ] || \
      [ ! "${MS_ENABLED}" = 1 ]


### PR DESCRIPTION
## Description

This change ensures the games-internal/roms and games-external/roms directories are always created so users don't have to create them themselves.   This directory is a prerequisite for the create game directories function in EmulationStation.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)