### PR TITLE
Wireless firmware coming from linux-firmware.  Added rtl_nic back in for usb-ethernet adapters.

### DIFF
--- a/packages/kernel/linux-firmware/kernel-firmware/firmwares/any.dat
+++ b/packages/kernel/linux-firmware/kernel-firmware/firmwares/any.dat
@@ -21,3 +21,5 @@ brcm/*
 rtl_bt/*
 rtlwifi/*
 rtw*/*
+
+rtl_nic/*

--- a/projects/Rockchip/devices/RK3566-ML/options
+++ b/projects/Rockchip/devices/RK3566-ML/options
@@ -83,13 +83,13 @@
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,
   # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
-    FIRMWARE="misc-firmware wlan-firmware RTL8821CS-firmware"
+    FIRMWARE="misc-firmware"
 
   # additional drivers to install:
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="RTL8821AU RTL8821CU RTL88x2BU jelos-gamepad"
+    ADDITIONAL_DRIVERS="jelos-gamepad"
 
   # build and install driver addons (yes / no)
     DRIVER_ADDONS_SUPPORT="no"


### PR DESCRIPTION
Simple change to the RK3566-ML device options to remove old WLAN firmware

Simple change to the definition of kernel firmware to include rtl_nic

Confirmed that the new firmware seems to be in residence in a running implementation.

That's the good part.  The less good part is that the WiFi connect / disconnect problem seems to remain.
