### PR TITLE
Reverts x55 GPU driver, bump ES for new features.

### DIFF
--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="cfde2673887187514afaf391f7d59622360201df"
+PKG_VERSION="98a084c805f8429a8d446251f7c21f1f46d56a53"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"

--- a/projects/Rockchip/devices/RK3566-X55/options
+++ b/projects/Rockchip/devices/RK3566-X55/options
@@ -51,7 +51,7 @@
  
   # Mali GPU family
     MALI_FAMILY="bifrost-g52"
-    MALI_VERSION="g13p0"
+    MALI_VERSION="g2p0"
     OPENGLES="libmali"
     VULKAN_SUPPORT="no"
 


### PR DESCRIPTION
## Description

* Revert x55 GPU driver to g2p0 to try and resolve the GPU hang condition until mainlined.
* Update EmulationStation with @GlaZedBelmont's changes (Add Rotation and Overlays, disable width and height).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)