### PR TITLE
Bump Mesa to 23.3.1, Bump Linux to 6.1.68, RG552 DTS cleanup

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -22,7 +22,7 @@ case ${DEVICE} in
 	PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"
   ;;
   *)
-	PKG_VERSION="23.3.0"
+	PKG_VERSION="23.3.1"
 	PKG_SITE="http://www.mesa3d.org/"
 	PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"
   ;;
@@ -49,14 +49,23 @@ PKG_MESON_OPTS_TARGET="-Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
 if [ "${DISPLAYSERVER}" = "x11" ]; then
   PKG_DEPENDS_TARGET+=" xorgproto libXext libXdamage libXfixes libXxf86vm libxcb libX11 libxshmfence libXrandr libglvnd glfw"
   export X11_INCLUDES=
-  PKG_MESON_OPTS_TARGET+=" -Dplatforms=x11 -Ddri3=enabled -Dglx=dri -Dglvnd=true"
+  PKG_MESON_OPTS_TARGET+="	-Dplatforms=x11 \
+				-Ddri3=enabled \
+				-Dglx=dri \
+				-Dglvnd=true"
 elif [ "${DISPLAYSERVER}" = "wl" ]; then
   PKG_DEPENDS_TARGET+=" wayland wayland-protocols libglvnd glfw"
-  PKG_MESON_OPTS_TARGET+=" -Dplatforms=wayland,x11 -Ddri3=enabled -Dglx=dri -Dglvnd=true"
+  PKG_MESON_OPTS_TARGET+=" 	-Dplatforms=wayland,x11 \
+				-Ddri3=enabled \
+				-Dglx=dri \
+				-Dglvnd=true"
   PKG_DEPENDS_TARGET+=" xorgproto libXext libXdamage libXfixes libXxf86vm libxcb libX11 libxshmfence libXrandr libglvnd"
   export X11_INCLUDES=
 else
-  PKG_MESON_OPTS_TARGET+=" -Dplatforms="" -Ddri3=disabled -Dglx=disabled -Dglvnd=false"
+  PKG_MESON_OPTS_TARGET+="	-Dplatforms="" \
+				-Ddri3=disabled \
+				-Dglx=disabled \
+				-Dglvnd=false"
 fi
 
 if [ "${LLVM_SUPPORT}" = "yes" ]; then

--- a/projects/Amlogic/packages/linux/package.mk
+++ b/projects/Amlogic/packages/linux/package.mk
@@ -18,7 +18,7 @@ PKG_PATCH_DIRS+="${DEVICE}"
 
 case ${DEVICE} in
   S922X*)
-    PKG_VERSION="6.1.65"
+    PKG_VERSION="6.1.68"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v6.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
   ;;
 esac

--- a/projects/Rockchip/packages/linux/package.mk
+++ b/projects/Rockchip/packages/linux/package.mk
@@ -36,7 +36,7 @@ case ${DEVICE} in
     PKG_GIT_CLONE_BRANCH="main"
   ;;
   RK33*)
-    PKG_VERSION="6.1.65"
+    PKG_VERSION="6.1.68"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v6.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
   ;;
 esac

--- a/projects/Rockchip/packages/linux/patches/RK3399/000-rk3399-devices.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3399/000-rk3399-devices.patch
@@ -1,6 +1,6 @@
 diff -rupN linux.orig/Makefile linux/Makefile
---- linux.orig/Makefile	2023-11-28 13:54:58.570108474 +0000
-+++ linux/Makefile	2023-11-28 19:50:16.215638386 +0000
+--- linux.orig/Makefile	2023-12-15 19:18:50.704700106 +0000
++++ linux/Makefile	2023-12-15 19:20:05.987107578 +0000
 @@ -826,6 +826,8 @@ KBUILD_CFLAGS	+= $(call cc-disable-warni
  KBUILD_CFLAGS	+= $(call cc-disable-warning, format-truncation)
  KBUILD_CFLAGS	+= $(call cc-disable-warning, format-overflow)
@@ -20,8 +20,8 @@ diff -rupN linux.orig/Makefile linux/Makefile
  # Require designated initializers for all marked structures
  KBUILD_CFLAGS   += $(call cc-option,-Werror=designated-init)
 diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/Makefile linux/arch/arm64/boot/dts/rockchip/Makefile
---- linux.orig/arch/arm64/boot/dts/rockchip/Makefile	2023-11-28 13:54:59.138120459 +0000
-+++ linux/arch/arm64/boot/dts/rockchip/Makefile	2023-11-28 19:50:16.215638386 +0000
+--- linux.orig/arch/arm64/boot/dts/rockchip/Makefile	2023-12-15 19:18:53.540790831 +0000
++++ linux/arch/arm64/boot/dts/rockchip/Makefile	2023-12-15 19:20:05.987107578 +0000
 @@ -21,6 +21,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-li
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-orion-r68-meta.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-px5-evb.dtb
@@ -32,8 +32,8 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/Makefile linux/arch/arm64/boo
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-ficus.dtb
 diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552-opp.dtsi linux/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552-opp.dtsi
 --- linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552-opp.dtsi	1970-01-01 00:00:00.000000000 +0000
-+++ linux/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552-opp.dtsi	2023-11-28 23:23:39.023319423 +0000
-@@ -0,0 +1,141 @@
++++ linux/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552-opp.dtsi	2023-12-15 21:01:28.016763624 +0000
+@@ -0,0 +1,139 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2016-2017 Fuzhou Rockchip Electronics Co., Ltd
@@ -48,6 +48,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552-opp.dts
 +		opp00 {
 +			opp-hz = /bits/ 64 <600000000>;
 +			opp-microvolt = <825000>;
++			clock-latency-ns = <40000>;
 +		};
 +		opp01 {
 +			opp-hz = /bits/ 64 <1008000000>;
@@ -78,6 +79,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552-opp.dts
 +		opp00 {
 +			opp-hz = /bits/ 64 <600000000>;
 +			opp-microvolt = <825000>;
++			clock-latency-ns = <40000>;
 +		};
 +		opp01 {
 +			opp-hz = /bits/ 64 <1008000000>;
@@ -100,10 +102,6 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552-opp.dts
 +			opp-microvolt = <1150000>;
 +		};
 +		opp06 {
-+			opp-hz = /bits/ 64 <1992000000>;
-+			opp-microvolt = <1250000>;
-+		};
-+		opp07 {
 +			opp-hz = /bits/ 64 <2088000000>;
 +			opp-microvolt = <1250000>;
 +		};
@@ -177,7 +175,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552-opp.dts
 +};
 diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts linux/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts
 --- linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts	1970-01-01 00:00:00.000000000 +0000
-+++ linux/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts	2023-11-28 19:50:16.215638386 +0000
++++ linux/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts	2023-12-15 19:20:05.987107578 +0000
 @@ -0,0 +1,1329 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
@@ -1509,9 +1507,9 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts lin
 +	status = "okay";
 +};
 diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399.dtsi linux/arch/arm64/boot/dts/rockchip/rk3399.dtsi
---- linux.orig/arch/arm64/boot/dts/rockchip/rk3399.dtsi	2023-11-28 13:54:59.142120544 +0000
-+++ linux/arch/arm64/boot/dts/rockchip/rk3399.dtsi	2023-11-28 19:50:16.215638386 +0000
-@@ -1469,7 +1469,7 @@
+--- linux.orig/arch/arm64/boot/dts/rockchip/rk3399.dtsi	2023-12-15 19:18:53.548791087 +0000
++++ linux/arch/arm64/boot/dts/rockchip/rk3399.dtsi	2023-12-15 19:20:05.987107578 +0000
+@@ -1471,7 +1471,7 @@
  			<1000000000>,
  			 <150000000>,   <75000000>,
  			  <37500000>,
@@ -1521,8 +1519,8 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399.dtsi linux/arch/arm64/
  			 <100000000>,   <50000000>,
  			 <400000000>, <400000000>,
 diff -rupN linux.orig/drivers/gpio/gpio-rockchip.c linux/drivers/gpio/gpio-rockchip.c
---- linux.orig/drivers/gpio/gpio-rockchip.c	2023-11-28 13:55:00.750154472 +0000
-+++ linux/drivers/gpio/gpio-rockchip.c	2023-11-28 19:50:16.215638386 +0000
+--- linux.orig/drivers/gpio/gpio-rockchip.c	2023-12-15 19:18:55.020838176 +0000
++++ linux/drivers/gpio/gpio-rockchip.c	2023-12-15 19:20:05.987107578 +0000
 @@ -335,13 +335,13 @@ static void rockchip_irq_demux(struct ir
  	unsigned long pending;
  	unsigned int irq;
@@ -1540,8 +1538,8 @@ diff -rupN linux.orig/drivers/gpio/gpio-rockchip.c linux/drivers/gpio/gpio-rockc
  		/*
  		 * Triggering IRQ on both rising and falling edge
 diff -rupN linux.orig/drivers/gpu/drm/panel/Kconfig linux/drivers/gpu/drm/panel/Kconfig
---- linux.orig/drivers/gpu/drm/panel/Kconfig	2023-11-28 13:55:02.030181481 +0000
-+++ linux/drivers/gpu/drm/panel/Kconfig	2023-11-28 19:50:16.215638386 +0000
+--- linux.orig/drivers/gpu/drm/panel/Kconfig	2023-12-15 19:18:56.948899851 +0000
++++ linux/drivers/gpu/drm/panel/Kconfig	2023-12-15 19:20:05.987107578 +0000
 @@ -588,6 +588,15 @@ config DRM_PANEL_SHARP_LS043T1LE01
  	  Say Y here if you want to enable support for Sharp LS043T1LE01 qHD
  	  (540x960) DSI panel as found on the Qualcomm APQ8074 Dragonboard
@@ -1559,8 +1557,8 @@ diff -rupN linux.orig/drivers/gpu/drm/panel/Kconfig linux/drivers/gpu/drm/panel/
  	tristate "Sharp LS060T1SX01 FullHD video mode panel"
  	depends on OF
 diff -rupN linux.orig/drivers/gpu/drm/panel/Makefile linux/drivers/gpu/drm/panel/Makefile
---- linux.orig/drivers/gpu/drm/panel/Makefile	2023-11-28 13:55:02.030181481 +0000
-+++ linux/drivers/gpu/drm/panel/Makefile	2023-11-28 19:50:16.215638386 +0000
+--- linux.orig/drivers/gpu/drm/panel/Makefile	2023-12-15 19:18:56.948899851 +0000
++++ linux/drivers/gpu/drm/panel/Makefile	2023-12-15 19:20:05.987107578 +0000
 @@ -59,6 +59,7 @@ obj-$(CONFIG_DRM_PANEL_SEIKO_43WVF1G) +=
  obj-$(CONFIG_DRM_PANEL_SHARP_LQ101R1SX01) += panel-sharp-lq101r1sx01.o
  obj-$(CONFIG_DRM_PANEL_SHARP_LS037V7DW01) += panel-sharp-ls037v7dw01.o
@@ -1571,7 +1569,7 @@ diff -rupN linux.orig/drivers/gpu/drm/panel/Makefile linux/drivers/gpu/drm/panel
  obj-$(CONFIG_DRM_PANEL_SITRONIX_ST7703) += panel-sitronix-st7703.o
 diff -rupN linux.orig/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c linux/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c
 --- linux.orig/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c	1970-01-01 00:00:00.000000000 +0000
-+++ linux/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c	2023-11-28 19:50:16.215638386 +0000
++++ linux/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c	2023-12-15 19:20:05.987107578 +0000
 @@ -0,0 +1,360 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
@@ -1934,8 +1932,8 @@ diff -rupN linux.orig/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c linux/driv
 +MODULE_DESCRIPTION("Panel driver for Sharp LS054B3SX01 1152x1920 Video Mode DSI Panel");
 +MODULE_LICENSE("GPL v2");
 diff -rupN linux.orig/drivers/input/Kconfig linux/drivers/input/Kconfig
---- linux.orig/drivers/input/Kconfig	2023-11-28 13:55:02.446190257 +0000
-+++ linux/drivers/input/Kconfig	2023-11-28 19:50:16.215638386 +0000
+--- linux.orig/drivers/input/Kconfig	2023-12-15 19:18:57.320911751 +0000
++++ linux/drivers/input/Kconfig	2023-12-15 19:20:05.987107578 +0000
 @@ -51,6 +51,19 @@ config INPUT_FF_MEMLESS
  	  To compile this driver as a module, choose M here: the
  	  module will be called ff-memless.
@@ -1957,8 +1955,8 @@ diff -rupN linux.orig/drivers/input/Kconfig linux/drivers/input/Kconfig
  	tristate "Sparse keymap support library"
  	help
 diff -rupN linux.orig/drivers/input/Makefile linux/drivers/input/Makefile
---- linux.orig/drivers/input/Makefile	2023-11-28 13:55:02.446190257 +0000
-+++ linux/drivers/input/Makefile	2023-11-28 19:50:16.215638386 +0000
+--- linux.orig/drivers/input/Makefile	2023-12-15 19:18:57.320911751 +0000
++++ linux/drivers/input/Makefile	2023-12-15 19:20:05.987107578 +0000
 @@ -10,6 +10,7 @@ input-core-y := input.o input-compat.o i
  input-core-y += touchscreen.o
  
@@ -1969,7 +1967,7 @@ diff -rupN linux.orig/drivers/input/Makefile linux/drivers/input/Makefile
  obj-$(CONFIG_INPUT_VIVALDIFMAP)	+= vivaldi-fmap.o
 diff -rupN linux.orig/drivers/input/input-polldev.c linux/drivers/input/input-polldev.c
 --- linux.orig/drivers/input/input-polldev.c	1970-01-01 00:00:00.000000000 +0000
-+++ linux/drivers/input/input-polldev.c	2023-11-28 19:50:16.215638386 +0000
++++ linux/drivers/input/input-polldev.c	2023-12-15 19:20:05.987107578 +0000
 @@ -0,0 +1,362 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
@@ -2334,8 +2332,8 @@ diff -rupN linux.orig/drivers/input/input-polldev.c linux/drivers/input/input-po
 +}
 +EXPORT_SYMBOL(input_unregister_polled_device);
 diff -rupN linux.orig/drivers/input/joystick/Kconfig linux/drivers/input/joystick/Kconfig
---- linux.orig/drivers/input/joystick/Kconfig	2023-11-28 13:55:02.446190257 +0000
-+++ linux/drivers/input/joystick/Kconfig	2023-11-28 19:50:16.215638386 +0000
+--- linux.orig/drivers/input/joystick/Kconfig	2023-12-15 19:18:57.324911879 +0000
++++ linux/drivers/input/joystick/Kconfig	2023-12-15 19:20:05.987107578 +0000
 @@ -393,6 +393,12 @@ config JOYSTICK_FSIA6B
  	  To compile this driver as a module, choose M here: the
  	  module will be called fsia6b.
@@ -2350,8 +2348,8 @@ diff -rupN linux.orig/drivers/input/joystick/Kconfig linux/drivers/input/joystic
  	bool "N64 controller"
  	depends on MACH_NINTENDO64
 diff -rupN linux.orig/drivers/input/joystick/Makefile linux/drivers/input/joystick/Makefile
---- linux.orig/drivers/input/joystick/Makefile	2023-11-28 13:55:02.446190257 +0000
-+++ linux/drivers/input/joystick/Makefile	2023-11-28 19:50:16.215638386 +0000
+--- linux.orig/drivers/input/joystick/Makefile	2023-12-15 19:18:57.324911879 +0000
++++ linux/drivers/input/joystick/Makefile	2023-12-15 19:20:05.987107578 +0000
 @@ -30,6 +30,7 @@ obj-$(CONFIG_JOYSTICK_PXRC)		+= pxrc.o
  obj-$(CONFIG_JOYSTICK_QWIIC)		+= qwiic-joystick.o
  obj-$(CONFIG_JOYSTICK_SENSEHAT)	+= sensehat-joystick.o
@@ -2362,7 +2360,7 @@ diff -rupN linux.orig/drivers/input/joystick/Makefile linux/drivers/input/joysti
  obj-$(CONFIG_JOYSTICK_STINGER)		+= stinger.o
 diff -rupN linux.orig/drivers/input/joystick/singleadcjoy.c linux/drivers/input/joystick/singleadcjoy.c
 --- linux.orig/drivers/input/joystick/singleadcjoy.c	1970-01-01 00:00:00.000000000 +0000
-+++ linux/drivers/input/joystick/singleadcjoy.c	2023-11-28 19:50:16.215638386 +0000
++++ linux/drivers/input/joystick/singleadcjoy.c	2023-12-15 19:36:26.739762439 +0000
 @@ -0,0 +1,1416 @@
 +/*----------------------------------------------------------------------------*/
 +
@@ -2463,7 +2461,7 @@ diff -rupN linux.orig/drivers/input/joystick/singleadcjoy.c linux/drivers/input/
 +	bool invert_absy;
 +	bool invert_absrx;
 +	bool invert_absry;
-+	
++
 +	/* report interval (ms) */
 +	int bt_gpio_count;
 +	struct bt_gpio *gpios;
@@ -2903,7 +2901,7 @@ diff -rupN linux.orig/drivers/input/joystick/singleadcjoy.c linux/drivers/input/
 +{
 +	struct platform_device *pdev  = to_platform_device(dev);
 +	struct joypad *joypad = platform_get_drvdata(pdev);
-+	
++
 +	return sprintf(buf, "%d\n", pwm_get_period(joypad->pwm));
 +}
 +
@@ -3019,10 +3017,10 @@ diff -rupN linux.orig/drivers/input/joystick/singleadcjoy.c linux/drivers/input/
 +	ssize_t pos=0;
 +	if(gpio_get_value(54)==1)
 +	{
-+		pos += sprintf(&buf[pos], "disconnected\n");		
++		pos += sprintf(&buf[pos], "disconnected\n");
 +	}else{
 +		pos += sprintf(&buf[pos], "connected\n");
-+	}				
++	}
 +	return pos;
 +}
 +
@@ -3190,7 +3188,7 @@ diff -rupN linux.orig/drivers/input/joystick/singleadcjoy.c linux/drivers/input/
 +	mutex_lock(&joypad->lock);
 +	joypad->enable = false;
 +	mutex_unlock(&joypad->lock);
-+	
++
 +	cancel_work_sync(&joypad->play_work);
 +	pwm_vibrator_stop(joypad);
 +
@@ -3292,7 +3290,7 @@ diff -rupN linux.orig/drivers/input/joystick/singleadcjoy.c linux/drivers/input/
 +		struct bt_adc *adc = &joypad->adcs[nbtn];
 +
 +		adc->scale = joypad->bt_adc_scale;
-+		
++
 +		adc->max = (ADC_MAX_VOLTAGE / 2);
 +		adc->min = (ADC_MAX_VOLTAGE / 2) * (-1);
 +		if (adc->scale) {
@@ -3464,7 +3462,7 @@ diff -rupN linux.orig/drivers/input/joystick/singleadcjoy.c linux/drivers/input/
 +		boosted_level = effect->u.rumble.weak_magnitude + joypad->boost_weak;
 +
 +	joypad->level = (u16)CLAMP(boosted_level, 0, 0xffff);
-+	
++
 +	dev_info(joypad->dev,"joypad->level = %d",  joypad->level);
 +	schedule_work(&joypad->play_work);
 +	return 0;
@@ -3520,7 +3518,7 @@ diff -rupN linux.orig/drivers/input/joystick/singleadcjoy.c linux/drivers/input/
 +
 +	input = poll_dev->input;
 +	joypad->input = poll_dev->input;
-+	
++
 +	device_property_read_string(dev, "joypad-name", &input->name);
 +	input->phys = DRV_NAME"/input0";
 +
@@ -3563,7 +3561,7 @@ diff -rupN linux.orig/drivers/input/joystick/singleadcjoy.c linux/drivers/input/
 +			error);
 +		return error;
 +	}
-+	
++
 +
 +	/* GPIO key setup */
 +	__set_bit(EV_KEY, input->evbit);
@@ -3735,7 +3733,7 @@ diff -rupN linux.orig/drivers/input/joystick/singleadcjoy.c linux/drivers/input/
 +		dev_err(dev, "input setup failed!(err = %d)\n", error);
 +		return error;
 +	}
-+	
++
 +	/* rumble setup */
 +	error = joypad_rumble_setup(dev, joypad);
 +	if (error) {
@@ -3781,8 +3779,8 @@ diff -rupN linux.orig/drivers/input/joystick/singleadcjoy.c linux/drivers/input/
 +late_initcall(joypad_init);
 +module_exit(joypad_exit);
 diff -rupN linux.orig/drivers/input/touchscreen/goodix.c linux/drivers/input/touchscreen/goodix.c
---- linux.orig/drivers/input/touchscreen/goodix.c	2023-11-28 13:55:02.482191017 +0000
-+++ linux/drivers/input/touchscreen/goodix.c	2023-11-28 19:50:16.215638386 +0000
+--- linux.orig/drivers/input/touchscreen/goodix.c	2023-12-15 19:18:57.364913158 +0000
++++ linux/drivers/input/touchscreen/goodix.c	2023-12-15 19:20:05.987107578 +0000
 @@ -1037,7 +1037,7 @@ retry_get_irq_gpio:
  	default:
  		if (ts->gpiod_int && ts->gpiod_rst) {
@@ -3793,8 +3791,8 @@ diff -rupN linux.orig/drivers/input/touchscreen/goodix.c linux/drivers/input/tou
  		}
  	}
 diff -rupN linux.orig/drivers/power/supply/cw2015_battery.c linux/drivers/power/supply/cw2015_battery.c
---- linux.orig/drivers/power/supply/cw2015_battery.c	2023-11-28 13:55:04.226227817 +0000
-+++ linux/drivers/power/supply/cw2015_battery.c	2023-11-28 19:50:16.215638386 +0000
+--- linux.orig/drivers/power/supply/cw2015_battery.c	2023-12-15 19:18:59.060967411 +0000
++++ linux/drivers/power/supply/cw2015_battery.c	2023-12-15 19:20:05.987107578 +0000
 @@ -553,7 +553,7 @@ static enum power_supply_property cw_bat
  };
  
@@ -3806,7 +3804,7 @@ diff -rupN linux.orig/drivers/power/supply/cw2015_battery.c linux/drivers/power/
  	.num_properties	= ARRAY_SIZE(cw_battery_properties),
 diff -rupN linux.orig/include/linux/input-polldev.h linux/include/linux/input-polldev.h
 --- linux.orig/include/linux/input-polldev.h	1970-01-01 00:00:00.000000000 +0000
-+++ linux/include/linux/input-polldev.h	2023-11-28 19:50:16.215638386 +0000
++++ linux/include/linux/input-polldev.h	2023-12-15 19:20:05.987107578 +0000
 @@ -0,0 +1,58 @@
 +/* SPDX-License-Identifier: GPL-2.0-only */
 +#ifndef _INPUT_POLLDEV_H


### PR DESCRIPTION
*Bump Mesa to 23.3.1 on supported devices.
*Bump Kernel to 6.1.31 on RK3399, RK3326, S922X devices (tested working on all 3 platforms)
*Remove con conformant clock from RG552 cpu opp table and remove whitespace in input driver. 