### PR TITLE
Updates and bug fixes (Kernel 6.6.7, SyncThing, Rclone, EmulationStation)

### DIFF
--- a/packages/kernel/linux/package.mk
+++ b/packages/kernel/linux/package.mk
@@ -4,7 +4,7 @@
 
 PKG_NAME="linux"
 PKG_LICENSE="GPL"
-PKG_VERSION="6.6.6"
+PKG_VERSION="6.6.7"
 PKG_URL="https://www.kernel.org/pub/linux/kernel/v6.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_SITE="http://www.kernel.org"
 PKG_DEPENDS_HOST="ccache:host rsync:host openssl:host rdfind:host"

--- a/packages/network/rclone/package.mk
+++ b/packages/network/rclone/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="rclone"
-PKG_VERSION="1.64.2"
+PKG_VERSION="1.65.0"
 PKG_DEPENDS_TARGET="toolchain fuse rsync"
 PKG_SECTION="tools"
 PKG_SHORTDESC="rsync for cloud storage"

--- a/packages/network/syncthing/package.mk
+++ b/packages/network/syncthing/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.26.0"
+PKG_VERSION="1.27.1"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"

--- a/packages/network/syncthing/patches/002-no-automatic-upgrade.patch
+++ b/packages/network/syncthing/patches/002-no-automatic-upgrade.patch
@@ -1,0 +1,58 @@
+diff -rupN syncthing.orig/cmd/syncthing/main.go syncthing/cmd/syncthing/main.go
+--- syncthing.orig/cmd/syncthing/main.go	2023-12-16 12:40:52.535043816 +0000
++++ syncthing/cmd/syncthing/main.go	2023-12-16 12:54:23.535684981 +0000
+@@ -600,24 +600,24 @@ func syncthingMain(options serveOptions)
+ 	// upgrade immediately. The auto-upgrade routine can only be started
+ 	// later after App is initialised.
+ 
+-	autoUpgradePossible := autoUpgradePossible(options)
+-	if autoUpgradePossible && cfgWrapper.Options().AutoUpgradeEnabled() {
++	//autoUpgradePossible := autoUpgradePossible(options)
++	//if autoUpgradePossible && cfgWrapper.Options().AutoUpgradeEnabled() {
+ 		// try to do upgrade directly and log the error if relevant.
+-		release, err := initialAutoUpgradeCheck(db.NewMiscDataNamespace(ldb))
+-		if err == nil {
+-			err = upgrade.To(release)
+-		}
+-		if err != nil {
+-			if _, ok := err.(*errNoUpgrade); ok || err == errTooEarlyUpgradeCheck || err == errTooEarlyUpgrade {
+-				l.Debugln("Initial automatic upgrade:", err)
+-			} else {
+-				l.Infoln("Initial automatic upgrade:", err)
+-			}
+-		} else {
+-			l.Infof("Upgraded to %q, exiting now.", release.Tag)
+-			os.Exit(svcutil.ExitUpgrade.AsInt())
+-		}
+-	}
++	//	release, err := initialAutoUpgradeCheck(db.NewMiscDataNamespace(ldb))
++	//	if err == nil {
++	//		err = upgrade.To(release)
++	//	}
++	//	if err != nil {
++	//		if _, ok := err.(*errNoUpgrade); ok || err == errTooEarlyUpgradeCheck || err == errTooEarlyUpgrade {
++	//			l.Debugln("Initial automatic upgrade:", err)
++	//		} else {
++	//			l.Infoln("Initial automatic upgrade:", err)
++	//		}
++	//	} else {
++	//		l.Infof("Upgraded to %q, exiting now.", release.Tag)
++	//		os.Exit(svcutil.ExitUpgrade.AsInt())
++	//	}
++	//}
+ 
+ 	if options.Unpaused {
+ 		setPauseState(cfgWrapper, false)
+@@ -654,9 +654,9 @@ func syncthingMain(options serveOptions)
+ 		os.Exit(svcutil.ExitError.AsInt())
+ 	}
+ 
+-	if autoUpgradePossible {
+-		go autoUpgrade(cfgWrapper, app, evLogger)
+-	}
++	//if autoUpgradePossible {
++	//	go autoUpgrade(cfgWrapper, app, evLogger)
++	//}
+ 
+ 	setupSignalHandling(app)
+ 

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="98a084c805f8429a8d446251f7c21f1f46d56a53"
+PKG_VERSION="fe24e22"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
## Description

Update Linux kernel to 6.6.7, bump SyncThing and Rclone.  Stop SyncThing from spamming automatic update notifications.  Correct an issue with EmulationStation brightness after exiting video screensaver.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] General updates.
