### PR TITLE
Fix copyright headers to be consistent with our documentation.

### DIFF
--- a/packages/apps/oga_controls/package.mk
+++ b/packages/apps/oga_controls/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="oga_controls"
 PKG_VERSION="1604ee24150c1c5bb7c66bc4670919c2ad8f0064"

--- a/packages/apps/portmaster/package.mk
+++ b/packages/apps/portmaster/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="portmaster"
 PKG_VERSION="8.5.13_1130"

--- a/packages/apps/portmaster/scripts/portmaster_compatibility.sh
+++ b/packages/apps/portmaster/scripts/portmaster_compatibility.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/apps/portmaster/scripts/start_portmaster.sh
+++ b/packages/apps/portmaster/scripts/start_portmaster.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 jslisten set "PortMaster"

--- a/packages/apps/portmaster/sources/control.txt
+++ b/packages/apps/portmaster/sources/control.txt
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2023-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2023-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 # This file can and should be sourced by ports for various parameters to
 # minimize script customizations and allow for easier future updates

--- a/packages/compat/wine-wayland/package.mk
+++ b/packages/compat/wine-wayland/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="wine-wayland"
 PKG_VERSION="8.2.1"

--- a/packages/devel/ecm/package.mk
+++ b/packages/devel/ecm/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="ecm"
 PKG_VERSION="v5.112.0"

--- a/packages/devel/libdatrie/package.mk
+++ b/packages/devel/libdatrie/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="libdatrie"
 PKG_VERSION="0.2.13"

--- a/packages/devel/libp11-kit/package.mk
+++ b/packages/devel/libp11-kit/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="libp11-kit"
 PKG_VERSION="3f6233d70ed81fdbc81b9bff345ea90ec2496b3b"

--- a/packages/devel/libthai/package.mk
+++ b/packages/devel/libthai/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="libthai"
 PKG_VERSION="0.1.29"

--- a/packages/emulators/libretro/arduous-lr/package.mk
+++ b/packages/emulators/libretro/arduous-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="arduous-lr"
 PKG_VERSION="aed50506962df6f965748e888b3fe7027ddb410d"

--- a/packages/emulators/libretro/beetle-psx-lr/package.mk
+++ b/packages/emulators/libretro/beetle-psx-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="beetle-psx-lr"
 PKG_VERSION="05fda4c7e4e98392aca86198644b0c0153369771"

--- a/packages/emulators/libretro/beetle-saturn-lr/package.mk
+++ b/packages/emulators/libretro/beetle-saturn-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="beetle-saturn-lr"
 PKG_VERSION="cd395e9e3ee407608450ebc565e871b24e7ffed6"

--- a/packages/emulators/libretro/boom3-lr/package.mk
+++ b/packages/emulators/libretro/boom3-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="boom3-lr"
 PKG_VERSION="0bea79abf5ec8262dfe9af73cb8c54ea6e2aeb98"

--- a/packages/emulators/libretro/boom3-lr/scripts/Doom 3 - Resurrection of Evil.sh
+++ b/packages/emulators/libretro/boom3-lr/scripts/Doom 3 - Resurrection of Evil.sh
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 /usr/bin/retroarch -L /usr/lib/libretro/boom3_xp_libretro.so /storage/roms/idtech/doom3/d3xp/pak000.pk4

--- a/packages/emulators/libretro/boom3-lr/scripts/Doom 3.sh
+++ b/packages/emulators/libretro/boom3-lr/scripts/Doom 3.sh
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 /usr/bin/retroarch -L /usr/lib/libretro/boom3_libretro.so /storage/roms/idtech/doom3/base/pak000.pk4

--- a/packages/emulators/libretro/bsnes-lr/package.mk
+++ b/packages/emulators/libretro/bsnes-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="bsnes-lr"
 PKG_VERSION="370a8642b1ec06d60d65467f4db1b098e4cb49f1"

--- a/packages/emulators/libretro/bsnes-mercury-performance-lr/package.mk
+++ b/packages/emulators/libretro/bsnes-mercury-performance-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="bsnes-mercury-performance-lr"
 PKG_VERSION="60c204ca17941704110885a815a65c740572326f"

--- a/packages/emulators/libretro/citra-lr/package.mk
+++ b/packages/emulators/libretro/citra-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="citra-lr"
 PKG_VERSION="d7e1612c17b1acb5d5eb68bb046820db49aeea5e"

--- a/packages/emulators/libretro/desmume-lr/package.mk
+++ b/packages/emulators/libretro/desmume-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="desmume-lr"
 PKG_VERSION="4ee1bb1d6a6c9695baea49d0c2dff34c10187502"

--- a/packages/emulators/libretro/dolphin-lr/package.mk
+++ b/packages/emulators/libretro/dolphin-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="dolphin-lr"
 PKG_VERSION="2f4b0f7902257d40a054f60b2c670d6e314f2a04"

--- a/packages/emulators/libretro/duckstation-lr/patches/001-fix-gcc12-compile.patch
+++ b/packages/emulators/libretro/duckstation-lr/patches/001-fix-gcc12-compile.patch
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 diff --git a/src/core/cpu_core.h b/src/core/cpu_core.h
 index c9199153..5d82b5c0 100644

--- a/packages/emulators/libretro/ecwolf-lr/package.mk
+++ b/packages/emulators/libretro/ecwolf-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="ecwolf-lr"
 PKG_VERSION="18eca17c2d634b154824e0782c6cbbe0a2c9ea76"

--- a/packages/emulators/libretro/idtech-lr/package.mk
+++ b/packages/emulators/libretro/idtech-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="idtech-lr"
 PKG_LICENSE="Apache-2.0"

--- a/packages/emulators/libretro/melonds-lr/package.mk
+++ b/packages/emulators/libretro/melonds-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="melonds-lr"
 PKG_VERSION="c6488c88cb4c7583dbcd61609e0eef441572fae8"

--- a/packages/emulators/libretro/mesen-lr/package.mk
+++ b/packages/emulators/libretro/mesen-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="mesen-lr"
 PKG_VERSION="d25d60fc190f3f7603a1113ef1e11d9da65b7583"

--- a/packages/emulators/libretro/parallel-n64-lr/package.mk
+++ b/packages/emulators/libretro/parallel-n64-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="parallel-n64-lr"
 PKG_VERSION="49eadb4da85f7e3bd59b60f61e8fd5dbfb9f07d5"

--- a/packages/emulators/libretro/play-lr/package.mk
+++ b/packages/emulators/libretro/play-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="play-lr"
 PKG_VERSION="e0f5091e6eb80d609807fc2a9da3f2516373582f"

--- a/packages/emulators/libretro/prboom-lr/scripts/Doom II.sh
+++ b/packages/emulators/libretro/prboom-lr/scripts/Doom II.sh
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 /usr/bin/retroarch -L /usr/lib/libretro/prboom_libretro.so /storage/roms/idtech/doom2/Doom2.wad

--- a/packages/emulators/libretro/prboom-lr/scripts/Doom.sh
+++ b/packages/emulators/libretro/prboom-lr/scripts/Doom.sh
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 /usr/bin/retroarch -L /usr/lib/libretro/prboom_libretro.so /storage/roms/idtech/doom/Doom.wad

--- a/packages/emulators/libretro/tyrquake-lr/scripts/Quake.sh
+++ b/packages/emulators/libretro/tyrquake-lr/scripts/Quake.sh
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 /usr/bin/retroarch -L /usr/lib/libretro/tyrquake_libretro.so /storage/roms/idtech/quakepaks/id1/*

--- a/packages/emulators/libretro/vitaquake2-lr/package.mk
+++ b/packages/emulators/libretro/vitaquake2-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="vitaquake2-lr"
 PKG_VERSION="6bb3ee592169694b055e7efd5fa2a4e57875bddd"

--- a/packages/emulators/libretro/vitaquake3-lr/package.mk
+++ b/packages/emulators/libretro/vitaquake3-lr/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="vitaquake3-lr"
 PKG_VERSION="7a633867cf0a35c71701aef6fc9dd9dfab9c33a9"

--- a/packages/emulators/standalone/aethersx2-sa/package.mk
+++ b/packages/emulators/standalone/aethersx2-sa/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="aethersx2-sa"
 PKG_VERSION="v1.5-3606"

--- a/packages/emulators/standalone/aethersx2-sa/scripts/start_aethersx2.sh
+++ b/packages/emulators/standalone/aethersx2-sa/scripts/start_aethersx2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/emulators/standalone/citra-sa/package.mk
+++ b/packages/emulators/standalone/citra-sa/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="citra-sa"
 PKG_LICENSE="MPLv2"

--- a/packages/emulators/standalone/citra-sa/scripts/start_citra.sh
+++ b/packages/emulators/standalone/citra-sa/scripts/start_citra.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 jslisten set "-9 citra"

--- a/packages/emulators/standalone/dolphin-sa/package.mk
+++ b/packages/emulators/standalone/dolphin-sa/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="dolphin-sa"
 PKG_LICENSE="GPLv2"

--- a/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_gc.sh
+++ b/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_gc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 jslisten set "-9 dolphin-emu-nogui"

--- a/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_wii.sh
+++ b/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_wii.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 jslisten set "-9 dolphin-emu-nogui"

--- a/packages/emulators/standalone/drastic-sa/package.mk
+++ b/packages/emulators/standalone/drastic-sa/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="drastic-sa"
 PKG_VERSION="1.0"

--- a/packages/emulators/standalone/drastic-sa/scripts/start_drastic.sh
+++ b/packages/emulators/standalone/drastic-sa/scripts/start_drastic.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/emulators/standalone/duckstation-sa/package.mk
+++ b/packages/emulators/standalone/duckstation-sa/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="duckstation-sa"
 PKG_LICENSE="GPLv3"

--- a/packages/emulators/standalone/duckstation-sa/patches/wayland/aarch64/003-fix-wayland-compile.patch
+++ b/packages/emulators/standalone/duckstation-sa/patches/wayland/aarch64/003-fix-wayland-compile.patch
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 diff --git a/src/util/platform_misc_unix.cpp b/src/util/platform_misc_unix.cpp
 index 1f7ae9ec..e0487476 100644

--- a/packages/emulators/standalone/duckstation-sa/scripts/start_duckstation.sh
+++ b/packages/emulators/standalone/duckstation-sa/scripts/start_duckstation.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 jslisten set "-9 duckstation-nogui"

--- a/packages/emulators/standalone/flycast-sa/package.mk
+++ b/packages/emulators/standalone/flycast-sa/package.mk
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2021-present Shanti Gilbert (https://github.com/shantigilbert)
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="flycast-sa"
 PKG_VERSION="f4f087a6ea83a5483dedf23ad2b38763988eccc5"

--- a/packages/emulators/standalone/flycast-sa/scripts/start_flycast.sh
+++ b/packages/emulators/standalone/flycast-sa/scripts/start_flycast.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 jslisten set "-9 flycast"

--- a/packages/emulators/standalone/melonds-sa/package.mk
+++ b/packages/emulators/standalone/melonds-sa/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="melonds-sa"
 PKG_LICENSE="GPLv3"

--- a/packages/emulators/standalone/melonds-sa/patches/003-fix-audio.patch
+++ b/packages/emulators/standalone/melonds-sa/patches/003-fix-audio.patch
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 diff --git a/src/frontend/qt_sdl/Platform.cpp b/src/frontend/qt_sdl/Platform.cpp
 index f9eaf42..ff4bc03 100644

--- a/packages/emulators/standalone/melonds-sa/scripts/start_melonds.sh
+++ b/packages/emulators/standalone/melonds-sa/scripts/start_melonds.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2021-present 351ELEC (https://github.com/351ELEC)
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/emulators/standalone/nanoboyadvance-sa/package.mk
+++ b/packages/emulators/standalone/nanoboyadvance-sa/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="nanoboyadvance-sa"
 PKG_VERSION="3bb6f478f977dbfd3106508536e5fbce90d1898b"

--- a/packages/emulators/standalone/nanoboyadvance-sa/scripts/start_nanoboyadvance.sh
+++ b/packages/emulators/standalone/nanoboyadvance-sa/scripts/start_nanoboyadvance.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 jslisten set "-9 NanoBoyAdvance"

--- a/packages/emulators/standalone/primehack/package.mk
+++ b/packages/emulators/standalone/primehack/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="primehack"
 PKG_LICENSE="GPLv2"

--- a/packages/emulators/standalone/primehack/scripts/start_primehack.sh
+++ b/packages/emulators/standalone/primehack/scripts/start_primehack.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/emulators/standalone/rpcs3-sa/package.mk
+++ b/packages/emulators/standalone/rpcs3-sa/package.mk
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2019-present Frank Hartung (supervisedthinking (@) gmail.com)
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="rpcs3-sa"
 PKG_VERSION="7081b89e976ad7f931c926022bd93ddd9778347c"

--- a/packages/emulators/standalone/rpcs3-sa/scripts/start_rpcs3.sh
+++ b/packages/emulators/standalone/rpcs3-sa/scripts/start_rpcs3.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/emulators/standalone/ryujinx-sa/package.mk
+++ b/packages/emulators/standalone/ryujinx-sa/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="ryujinx-sa"
 PKG_VERSION="1.1.999"

--- a/packages/emulators/standalone/ryujinx-sa/scripts/start_ryujinx.sh
+++ b/packages/emulators/standalone/ryujinx-sa/scripts/start_ryujinx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 jslisten set "-9 Ryujinx"

--- a/packages/emulators/standalone/vita3k-sa/package.mk
+++ b/packages/emulators/standalone/vita3k-sa/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="vita3k-sa"
 PKG_VERSION="564417b3b6a31296a2a09912c249a0145376e3c8"

--- a/packages/emulators/standalone/vita3k-sa/scripts/start_vita3k.sh
+++ b/packages/emulators/standalone/vita3k-sa/scripts/start_vita3k.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 jslisten set "-9 Vita3K"

--- a/packages/emulators/standalone/xemu-sa/package.mk
+++ b/packages/emulators/standalone/xemu-sa/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="xemu-sa"
 PKG_VERSION="v0.7.117"

--- a/packages/emulators/standalone/xemu-sa/scripts/start_xemu.sh
+++ b/packages/emulators/standalone/xemu-sa/scripts/start_xemu.sh
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 jslisten set "-9 xemu"

--- a/packages/emulators/standalone/yuzu-sa/package.mk
+++ b/packages/emulators/standalone/yuzu-sa/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="yuzu-sa"
 PKG_VERSION="e3578966742aa1e4fd368de35aecce2a0bf45296"

--- a/packages/emulators/standalone/yuzu-sa/scripts/start_yuzu.sh
+++ b/packages/emulators/standalone/yuzu-sa/scripts/start_yuzu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/emulators/tools/control-gen/Makefile
+++ b/packages/emulators/tools/control-gen/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 CXX ?= gcc
 CCFLAGS = -W -Wall -std=c++11 `sdl2-config --cflags`

--- a/packages/emulators/tools/control-gen/control-gen.cpp
+++ b/packages/emulators/tools/control-gen/control-gen.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+// Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 #include <stdio.h>
 #include <SDL.h>

--- a/packages/emulators/tools/control-gen/package.mk
+++ b/packages/emulators/tools/control-gen/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="control-gen"
 PKG_VERSION="16179c655447007c2580243659fc36a34e6a749d"

--- a/packages/emulators/tools/control-gen/scripts/control-gen_init.sh
+++ b/packages/emulators/tools/control-gen/scripts/control-gen_init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 #Check if gptokeyb exists in .config
 if [ ! -d "/storage/.config/gptokeyb" ]; then

--- a/packages/graphics/glew/package.mk
+++ b/packages/graphics/glew/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="glew"
 PKG_VERSION="2.2.0"

--- a/packages/graphics/libegl/package.mk
+++ b/packages/graphics/libegl/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="libegl"
 PKG_VERSION="1.0"

--- a/packages/graphics/libmali-vulkan/package.mk
+++ b/packages/graphics/libmali-vulkan/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="libmali-vulkan"
 PKG_VERSION="r46p0-01eac1"

--- a/packages/graphics/libwebp/package.mk
+++ b/packages/graphics/libwebp/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2023-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2023-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="libwebp"
 PKG_VERSION="89c5b917463c07bfb5b6390b81d258c49d5fe8c6"

--- a/packages/graphics/qt6/package.mk
+++ b/packages/graphics/qt6/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2023-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2023-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="qt6"
 PKG_MAJOR_VERSION="6.6"

--- a/packages/graphics/qt6/qt6base/package.mk
+++ b/packages/graphics/qt6/qt6base/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2023-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2023-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="qt6base"
 PKG_MAJOR_VERSION="6.6"

--- a/packages/graphics/qt6/qt6tools/package.mk
+++ b/packages/graphics/qt6/qt6tools/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2023-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2023-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="qt6tools"
 PKG_MAJOR_VERSION="6.6"

--- a/packages/graphics/qt6/qt6wayland/package.mk
+++ b/packages/graphics/qt6/qt6wayland/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2023-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2023-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="qt6wayland"
 PKG_MAJOR_VERSION="6.6"

--- a/packages/hardware/quirks/devices/Anbernic RG351M/050-game_configs
+++ b/packages/hardware/quirks/devices/Anbernic RG351M/050-game_configs
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/hardware/quirks/devices/Anbernic RG351V/004-game-configs
+++ b/packages/hardware/quirks/devices/Anbernic RG351V/004-game-configs
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/hardware/quirks/devices/Anbernic RG353P/050-game_configs
+++ b/packages/hardware/quirks/devices/Anbernic RG353P/050-game_configs
@@ -1,6 +1,6 @@
 
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/hardware/quirks/devices/Anbernic RG503/050-game_configs
+++ b/packages/hardware/quirks/devices/Anbernic RG503/050-game_configs
@@ -1,6 +1,6 @@
 
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/hardware/quirks/devices/Anbernic RG552/030-enable_wifi
+++ b/packages/hardware/quirks/devices/Anbernic RG552/030-enable_wifi
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile.d/001-functions
 

--- a/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/050-game_configs
+++ b/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/050-game_configs
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/hardware/quirks/devices/ODROID-GO Advance Black Edition/001-device_config
+++ b/packages/hardware/quirks/devices/ODROID-GO Advance Black Edition/001-device_config
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 cat <<EOF >/storage/.config/profile.d/001-device_config
 # Device Features

--- a/packages/hardware/quirks/devices/ODROID-GO Advance Black Edition/050-game_configs
+++ b/packages/hardware/quirks/devices/ODROID-GO Advance Black Edition/050-game_configs
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/hardware/quirks/devices/ODROID-GO Advance/050-game_configs
+++ b/packages/hardware/quirks/devices/ODROID-GO Advance/050-game_configs
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/hardware/quirks/devices/ODROID-GO Super/001-device_config
+++ b/packages/hardware/quirks/devices/ODROID-GO Super/001-device_config
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 cat <<EOF >/storage/.config/profile.d/001-device_config
 # Device Features

--- a/packages/hardware/quirks/devices/ODROID-GO Super/050-game_configs
+++ b/packages/hardware/quirks/devices/ODROID-GO Super/050-game_configs
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3/050-game_configs
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3/050-game_configs
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/hardware/quirks/devices/Powkiddy RGB30/050-game_configs
+++ b/packages/hardware/quirks/devices/Powkiddy RGB30/050-game_configs
@@ -1,6 +1,6 @@
 
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/hardware/quirks/devices/Powkiddy RK2023/050-game_configs
+++ b/packages/hardware/quirks/devices/Powkiddy RK2023/050-game_configs
@@ -1,6 +1,6 @@
 
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/hardware/quirks/devices/Powkiddy x55/050-game_configs
+++ b/packages/hardware/quirks/devices/Powkiddy x55/050-game_configs
@@ -1,6 +1,6 @@
 
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/kernel/linux-firmware/libmali_rk3588/package.mk
+++ b/packages/kernel/linux-firmware/libmali_rk3588/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="libmali_rk3588"
 PKG_VERSION="1.0"

--- a/packages/kernel/linux/package.mk
+++ b/packages/kernel/linux/package.mk
@@ -4,7 +4,7 @@
 
 PKG_NAME="linux"
 PKG_LICENSE="GPL"
-PKG_VERSION="6.6.7"
+PKG_VERSION="6.6.4"
 PKG_URL="https://www.kernel.org/pub/linux/kernel/v6.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_SITE="http://www.kernel.org"
 PKG_DEPENDS_HOST="ccache:host rsync:host openssl:host rdfind:host"

--- a/packages/misc/modules/sources/Start PortMaster.sh
+++ b/packages/misc/modules/sources/Start PortMaster.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS) (https://github.com/brooksytech
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS) (https://github.com/brooksytech
 
 source /etc/profile
 

--- a/packages/sysutils/system-utils/sources/devices/RK3399/headphone_sense
+++ b/packages/sysutils/system-utils/sources/devices/RK3399/headphone_sense
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/sysutils/system-utils/sources/devices/RK3399/video_sense
+++ b/packages/sysutils/system-utils/sources/devices/RK3399/video_sense
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
 

--- a/packages/sysutils/system-utils/sources/devices/S922X/headphone_sense
+++ b/packages/sysutils/system-utils/sources/devices/S922X/headphone_sense
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 # Source predefined functions and variables
 . /etc/profile

--- a/packages/tools/rkbin/package.mk
+++ b/packages/tools/rkbin/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="rkbin"
 PKG_ARCH="arm aarch64"

--- a/projects/Amlogic/bootloader/mkimage
+++ b/projects/Amlogic/bootloader/mkimage
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 mkimage_uboot() {
 if [ -f "${RELEASE_DIR}/3rdparty/bootloader/${SUBDEVICE}_u-boot" ]; then

--- a/projects/Amlogic/bootloader/release
+++ b/projects/Amlogic/bootloader/release
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 mkdir -p ${RELEASE_DIR}/3rdparty/bootloader
   cp -a ${INSTALL}/usr/share/bootloader/* ${RELEASE_DIR}/3rdparty/bootloader

--- a/projects/Amlogic/packages/amlogic-boot-fip/package.mk
+++ b/projects/Amlogic/packages/amlogic-boot-fip/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="amlogic-boot-fip"
 PKG_VERSION="e96b6a694380ff07d5a9e4be644ffe254bd18512"

--- a/projects/Rockchip/packages/linux/patches/RK3399/000-rk3399-devices.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3399/000-rk3399-devices.patch
@@ -37,7 +37,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552-opp.dts
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2016-2017 Fuzhou Rockchip Electronics Co., Ltd
-+ * Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
++ * Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 + */
 +
 +/ {
@@ -182,7 +182,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts lin
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
 + * Copyright (c) 2018 Akash Gajjar <Akash_Gajjar@mentor.com>
 + * Copyright (c) 2022 Maya Matuszczyk <maccraft123mc@gmail.com>
-+ * Copyright (C) 2022-present - The JELOS Project (https://github.com/JustEnoughLinuxOS)
++ * Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 + */
 +
 +


### PR DESCRIPTION
## Description

This change syncs our copyright headers with our README and Wiki.  In addition it rolls back the Linux kernel to 6.6.4 on AMD64 as a troubleshooting step to see if that resolves a condition where the battery disappears on Loki Max.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change is a documentation update

