### PR TITLE
Simple http server

### DIFF
--- a/config/show_config
+++ b/config/show_config
@@ -105,6 +105,7 @@ show_config() {
   config_message="${config_message}\n - SAMBA mounting support:\t\t $SAMBA_SUPPORT"
   config_message="${config_message}\n - SAMBA server support:\t\t $SAMBA_SERVER"
   config_message="${config_message}\n - SFTP server support:\t\t\t $SFTP_SERVER"
+  config_message="${config_message}\n - HTTP server support:\t\t\t $SIMPLE_HTTP_SERVER"
   config_message="${config_message}\n - OpenVPN support:\t\t\t $OPENVPN_SUPPORT"
   config_message="${config_message}\n - WireGuard support:\t\t\t $WIREGUARD_SUPPORT"
   config_message="${config_message}\n - ZeroTier support:\t\t\t $ZEROTIER_SUPPORT"

--- a/distributions/JELOS/options
+++ b/distributions/JELOS/options
@@ -77,6 +77,9 @@
 # build and install SFTP Server (yes / no)
   SFTP_SERVER="yes"
 
+# build and install Simple HTTP Server (yes / no)
+  SIMPLE_HTTP_SERVER="no"
+
 # build and install OpenVPN support (yes / no)
   OPENVPN_SUPPORT="no"
 

--- a/packages/network/simple-http-server/package.mk
+++ b/packages/network/simple-http-server/package.mk
@@ -13,6 +13,7 @@ PKG_LONGDESC="Simple http server in Rust"
 PKG_TOOLCHAIN="manual"
 
 unpack() {
+	mkdir -p ${PKG_BUILD}
 	case $ARCH in
 	x86_64)
 		PKG_URL=$PKG_URL_X86_64
@@ -23,12 +24,18 @@ unpack() {
 	aarch64)
 		PKG_URL=$PKG_URL_AARCH64
 		;;
+	*)
+		echo "Unsupported architecture!"
+		;;
 	esac
 
-	curl -L $PKG_URL -o ${PKG_DIR}/simple-http-server
+	curl -L $PKG_URL -o ${PKG_BUILD}/simple-http-server
 }
 
 makeinstall_target() {
 	mkdir -p ${INSTALL}/usr/bin
-	install -Dm755 ${PKG_DIR}/simple-http-server ${INSTALL}/usr/bin/
+	mkdir -p ${INSTALL}/usr/lib/systemd/system
+
+	install -Dm755 ${PKG_BUILD}/simple-http-server ${INSTALL}/usr/bin/
+	install -Dm644 ${PKG_DIR}/system.d/simple-http-server.service ${INSTALL}/usr/lib/systemd/system/
 }

--- a/packages/network/simple-http-server/package.mk
+++ b/packages/network/simple-http-server/package.mk
@@ -1,0 +1,34 @@
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2023-present NeoTheFox (https://github.com/NeoTheFox)
+
+PKG_NAME="simple-http-server"
+PKG_VERSION="0.6.7"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/TheWaWaR/simple-http-server"
+PKG_URL_ARM="https://github.com/TheWaWaR/simple-http-server/releases/download/v${PKG_VERSION}/armv7-unknown-linux-musleabihf-simple-http-server"
+PKG_URL_AARCH64="https://github.com/TheWaWaR/simple-http-server/releases/download/v${PKG_VERSION}/aarch64-unknown-linux-musl-simple-http-server"
+PKG_URL_X86_64="https://github.com/TheWaWaR/simple-http-server/releases/download/v${PKG_VERSION}/x86_64-unknown-linux-musl-simple-http-server"
+PKG_LONGDESC="Simple http server in Rust"
+PKG_TOOLCHAIN="manual"
+
+unpack() {
+	case $ARCH in
+	x86_64)
+		PKG_URL=$PKG_URL_X86_64
+		;;
+	arm)
+		PKG_URL=$PKG_URL_ARM
+		;;
+	aarch64)
+		PKG_URL=$PKG_URL_AARCH64
+		;;
+	esac
+
+	curl -L $PKG_URL -o ${PKG_DIR}/simple-http-server
+}
+
+makeinstall_target() {
+	mkdir -p ${INSTALL}/usr/bin
+	install -Dm755 ${PKG_DIR}/simple-http-server ${INSTALL}/usr/bin/
+}

--- a/packages/network/simple-http-server/system.d/simple-http-server.service
+++ b/packages/network/simple-http-server/system.d/simple-http-server.service
@@ -4,7 +4,7 @@ Wants=network-pre.target
 After=network-pre.target
 
 [Service]
-ExecStart=/usr/bin/simple-http-server -i -s -u /storage
+ExecStart=/usr/bin/simple-http-server -i -p 80 -a root:$(get_setting root.password) -s -u /storage
 Restart=always
 KillMode=process
 Restart=on-failure

--- a/packages/network/simple-http-server/system.d/simple-http-server.service
+++ b/packages/network/simple-http-server/system.d/simple-http-server.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=simple-http-server
+Wants=network-pre.target
+After=network-pre.target
+
+[Service]
+ExecStart=/usr/bin/simple-http-server -i -s -u /storage
+Restart=always
+KillMode=process
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/virtual/network/package.mk
+++ b/packages/virtual/network/package.mk
@@ -19,6 +19,10 @@ if [ "${SAMBA_SERVER}" = "yes" ] || [ "$SAMBA_SUPPORT" = "yes" ]; then
   PKG_DEPENDS_TARGET="${PKG_DEPENDS_TARGET} samba"
 fi
 
+if [ "${SIMPLE_HTTP_SERVER}" = "yes" ]; then
+  PKG_DEPENDS_TARGET="${PKG_DEPENDS_TARGET} simple-http-server"
+fi
+
 if [ "${OPENVPN_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET="${PKG_DEPENDS_TARGET} openvpn"
 fi

--- a/projects/Amlogic/devices/S922X/options
+++ b/projects/Amlogic/devices/S922X/options
@@ -108,6 +108,9 @@
   # build and install SFTP Server (yes / no)
     SFTP_SERVER="yes"
 
+  # build and install Simple HTTP Server (yes / no)
+    SIMPLE_HTTP_SERVER="yes"
+
   # build and install OpenVPN support (yes / no)
     OPENVPN_SUPPORT="no"
 

--- a/projects/PC/devices/AMD64/options
+++ b/projects/PC/devices/AMD64/options
@@ -92,6 +92,9 @@
   # build and install SFTP Server (yes / no)
     SFTP_SERVER="yes"
 
+  # build and install Simple HTTP Server (yes / no)
+    SIMPLE_HTTP_SERVER="yes"
+
   # build and install OpenVPN support (yes / no)
     OPENVPN_SUPPORT="no"
 

--- a/projects/Rockchip/devices/RK3326/options
+++ b/projects/Rockchip/devices/RK3326/options
@@ -118,6 +118,9 @@
   # build and install SFTP Server (yes / no)
     SFTP_SERVER="yes"
 
+  # build and install Simple HTTP Server (yes / no)
+    SIMPLE_HTTP_SERVER="yes"
+
   # build and install OpenVPN support (yes / no)
     OPENVPN_SUPPORT="no"
 

--- a/projects/Rockchip/devices/RK3399/options
+++ b/projects/Rockchip/devices/RK3399/options
@@ -118,6 +118,9 @@
   # build and install SFTP Server (yes / no)
     SFTP_SERVER="yes"
 
+  # build and install Simple HTTP Server (yes / no)
+    SIMPLE_HTTP_SERVER="yes"
+
   # build and install OpenVPN support (yes / no)
     OPENVPN_SUPPORT="no"
 

--- a/projects/Rockchip/devices/RK3566-X55/options
+++ b/projects/Rockchip/devices/RK3566-X55/options
@@ -109,6 +109,9 @@
   # build and install SFTP Server (yes / no)
     SFTP_SERVER="yes"
 
+  # build and install Simple HTTP Server (yes / no)
+    SIMPLE_HTTP_SERVER="yes"
+
   # build and install OpenVPN support (yes / no)
     OPENVPN_SUPPORT="no"
 

--- a/projects/Rockchip/devices/RK3566/options
+++ b/projects/Rockchip/devices/RK3566/options
@@ -109,6 +109,9 @@
   # build and install SFTP Server (yes / no)
     SFTP_SERVER="yes"
 
+  # build and install Simple HTTP Server (yes / no)
+    SIMPLE_HTTP_SERVER="yes"
+
   # build and install OpenVPN support (yes / no)
     OPENVPN_SUPPORT="no"
 

--- a/projects/Rockchip/devices/RK3588/options
+++ b/projects/Rockchip/devices/RK3588/options
@@ -1,4 +1,4 @@
-################################################################################
+/################################################################################
 # setup device defaults
 ################################################################################
 
@@ -118,6 +118,9 @@
 
   # build and install SFTP Server (yes / no)
     SFTP_SERVER="yes"
+
+  # build and install Simple HTTP Server (yes / no)
+    SIMPLE_HTTP_SERVER="yes"
 
   # build and install OpenVPN support (yes / no)
     OPENVPN_SUPPORT="no"


### PR DESCRIPTION
# Simple HTTP Server

## Description

This adds a [Simple HTTP](https://github.com/TheWaWaR/simple-http-server) server for managing files on JELOS devices. 
Enabling it allows anyone with a browser to upload and download files from their device, compared to existing SMB and SFTP methods it requires no additional software or configuration.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested Locally?

Tested operation on an ODROID GO Ultra locally and confirmed the image builds in Docker. 

I'm also going to patch the emulationstation to have a toggle for this soon.