### PR TITLE
Bump vulkan to 1.3.274, add new volk dependency

### DIFF
--- a/packages/graphics/vulkan/volk/package.mk
+++ b/packages/graphics/vulkan/volk/package.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="volk"
+PKG_VERSION="1.3.270"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/zeux/volk"
+PKG_URL="https://github.com/zeux/volk/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain vulkan-headers"
+PKG_LONGDESC="Meta loader for Vulkan API"
+
+PKG_CMAKE_OPTS_TARGET="-DVOLK_INSTALL=on"

--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.3.270"
+PKG_VERSION="1.3.274"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.3.270"
+PKG_VERSION="1.3.274"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.3.270"
+PKG_VERSION="1.3.274"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain vulkan-loader glslang:host Python3:host"
+PKG_DEPENDS_TARGET="toolchain vulkan-loader glslang:host Python3:host volk"
 PKG_LONGDESC="This project provides Khronos official Vulkan Tools and Utilities."
 
 configure_package() {


### PR DESCRIPTION
*Yuzu now requires vulkan 1.3.274+ to build. 
*Vulkan tools now requires volk dependency. Thanks @libreelc / @coreelec. 
