### PR TITLE
Pipewire + update verbosity

### DIFF
--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="0.3.84"
+PKG_VERSION="1.0.0"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/audio/pipewire/patches/001-pipewire-pulse.patch
+++ b/packages/audio/pipewire/patches/001-pipewire-pulse.patch
@@ -1,7 +1,7 @@
-diff -rupN pipewire-0.3.84.orig/src/daemon/pipewire-pulse.conf.in pipewire-0.3.84/src/daemon/pipewire-pulse.conf.in
---- pipewire-0.3.84.orig/src/daemon/pipewire-pulse.conf.in	2023-11-13 16:35:56.502690919 +0000
-+++ pipewire-0.3.84/src/daemon/pipewire-pulse.conf.in	2023-11-13 16:36:28.096495134 +0000
-@@ -90,11 +90,11 @@ pulse.properties = {
+diff -rupN pipewire-1.0.0.orig/src/daemon/pipewire-pulse.conf.in pipewire-1.0.0/src/daemon/pipewire-pulse.conf.in
+--- pipewire-1.0.0.orig/src/daemon/pipewire-pulse.conf.in	2023-12-29 13:41:35.329947857 +0000
++++ pipewire-1.0.0/src/daemon/pipewire-pulse.conf.in	2023-12-29 13:41:46.850669838 +0000
+@@ -92,11 +92,11 @@ pulse.properties = {
          #"tcp:[::]:9999"                    # IPv6 on all addresses
          #"tcp:127.0.0.1:8888"               # IPv4 on a single address
          #
@@ -18,23 +18,17 @@ diff -rupN pipewire-0.3.84.orig/src/daemon/pipewire-pulse.conf.in pipewire-0.3.8
      ]
      #server.dbus-name       = "org.pulseaudio.Server"
      #pulse.min.req          = 128/48000     # 2.7ms
-diff -rupN pipewire-0.3.84.orig/src/daemon/systemd/system/pipewire.service.in pipewire-0.3.84/src/daemon/systemd/system/pipewire.service.in
---- pipewire-0.3.84.orig/src/daemon/systemd/system/pipewire.service.in	2023-11-13 16:35:56.502690919 +0000
-+++ pipewire-0.3.84/src/daemon/systemd/system/pipewire.service.in	2023-11-13 16:36:28.096495134 +0000
-@@ -15,21 +15,24 @@ Description=PipeWire Multimedia Service
- Requires=pipewire.socket
- 
- [Service]
--LockPersonality=yes
--MemoryDenyWriteExecute=yes
--NoNewPrivileges=yes
--RestrictNamespaces=yes
--SystemCallArchitectures=native
--SystemCallFilter=@system-service
+diff -rupN pipewire-1.0.0.orig/src/daemon/systemd/system/pipewire.service.in pipewire-1.0.0/src/daemon/systemd/system/pipewire.service.in
+--- pipewire-1.0.0.orig/src/daemon/systemd/system/pipewire.service.in	2023-12-29 13:41:35.329947857 +0000
++++ pipewire-1.0.0/src/daemon/systemd/system/pipewire.service.in	2023-12-29 13:43:32.217227049 +0000
+@@ -21,15 +21,25 @@ NoNewPrivileges=yes
+ RestrictNamespaces=yes
+ SystemCallArchitectures=native
+ SystemCallFilter=@system-service
 +Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
 +User=root
  Type=simple
--AmbientCapabilities=CAP_SYS_NICE
+ AmbientCapabilities=CAP_SYS_NICE
 -ExecStart=@PW_BINARY@
 +ExecStart=/usr/bin/pipewire
  Restart=on-failure
@@ -53,16 +47,16 @@ diff -rupN pipewire-0.3.84.orig/src/daemon/systemd/system/pipewire.service.in pi
 +Environment=HOME=/storage
  
  [Install]
--Also=pipewire.socket
-+Also=pipewire-pulse.socket
+-Also=pipewire.socket pipewire-manager.socket
++Also=pipewire.socket pipewire-pulse.socket pipewire-manager.socket
  WantedBy=default.target
-diff -rupN pipewire-0.3.84.orig/src/daemon/systemd/system/pipewire.socket pipewire-0.3.84/src/daemon/systemd/system/pipewire.socket
---- pipewire-0.3.84.orig/src/daemon/systemd/system/pipewire.socket	2023-11-13 16:35:56.502690919 +0000
-+++ pipewire-0.3.84/src/daemon/systemd/system/pipewire.socket	2023-11-13 16:36:58.434228383 +0000
-@@ -5,8 +5,8 @@ Description=PipeWire Multimedia System S
+diff -rupN pipewire-1.0.0.orig/src/daemon/systemd/system/pipewire.socket pipewire-1.0.0/src/daemon/systemd/system/pipewire.socket
+--- pipewire-1.0.0.orig/src/daemon/systemd/system/pipewire.socket	2023-12-29 13:41:35.329947857 +0000
++++ pipewire-1.0.0/src/daemon/systemd/system/pipewire.socket	2023-12-29 13:44:04.291208172 +0000
+@@ -4,8 +4,8 @@ Description=PipeWire Multimedia System S
+ [Socket]
  Priority=6
  ListenStream=%t/pipewire/pipewire-0
- ListenStream=%t/pipewire/pipewire-0-manager
 -SocketUser=pipewire
 -SocketGroup=pipewire
 +SocketUser=root

--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireplumber"
-PKG_VERSION="0.4.15"
+PKG_VERSION="0.4.17"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/pipewire/wireplumber"
 PKG_URL="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/audio/wireplumber/patches/002-optimize-auto-connect.patch
+++ b/packages/audio/wireplumber/patches/002-optimize-auto-connect.patch
@@ -1,0 +1,11 @@
+diff -rupN wireplumber-0.4.15.orig/src/config/bluetooth.lua.d/50-bluez-config.lua wireplumber-0.4.15/src/config/bluetooth.lua.d/50-bluez-config.lua
+--- wireplumber-0.4.15.orig/src/config/bluetooth.lua.d/50-bluez-config.lua	2023-11-13 16:40:22.581908134 +0000
++++ wireplumber-0.4.15/src/config/bluetooth.lua.d/50-bluez-config.lua	2023-12-29 13:00:57.296239132 +0000
+@@ -85,6 +85,7 @@ bluez_monitor.rules = {
+       -- profiles have connected. Disabled by default if the property
+       -- is not specified.
+       --["bluez5.auto-connect"] = "[ hfp_hf hsp_hs a2dp_sink hfp_ag hsp_ag a2dp_source ]",
++      ["bluez5.auto-connect"]  = "[ hfp_hf hsp_hs a2dp_sink ]",
+ 
+       -- Hardware volume control (default: [ hfp_ag hsp_ag a2dp_source ])
+       --["bluez5.hw-volume"] = "[ hfp_hf hsp_hs a2dp_sink hfp_ag hsp_ag a2dp_source ]",

--- a/packages/jelos/sources/post-update
+++ b/packages/jelos/sources/post-update
@@ -13,11 +13,13 @@ LOG="/var/log/boot.log"
 ################################################################################
 
 echo "Rebuild library cache..." >>${LOG}
+tocon "Rebuilding library cache..."
 ### Rebuild the library cache
 rm -f /storage/.cache/ld.so.cache
 ldconfig -X
 
 echo "Sync configuration files..." >>${LOG}
+tocon "Re-sync configuration files..."
 ### Sync configurations
 if [ -d "/storage/.config/system/configs" ]
 then
@@ -41,6 +43,7 @@ then
 fi
 
 echo "Sync modules..." >>${LOG}
+tocon "Update tool modules..."
 rsync -a /usr/config/modules/* /storage/.config/modules/
 cp -f /usr/config/retroarch/retroarch-core-options.cfg /storage/.config/retroarch/retroarch-core-options.cfg
 
@@ -48,6 +51,7 @@ cp -f /usr/config/retroarch/retroarch-core-options.cfg /storage/.config/retroarc
 echo "Apply dev keys if available..." >>${LOG}
 if [ -e /usr/config/ssh/authorized_keys ]
 then
+  tocon "Update developer keys..."
   cp /usr/config/ssh/authorized_keys /storage/.ssh
 fi
 
@@ -57,6 +61,7 @@ rsync --ignore-existing /usr/config/rsync-rules.conf /storage/.config/
 rsync --ignore-existing /usr/config/rsync.conf /storage/.config/
 
 ### Sync locale data
+tocon "Re-sync locale data..."
 rsync -a --delete /usr/config/locale/* /storage/.config/locale/ >>/var/log/configure.log 2>&1
 rm -rf /storage/.config/emulationstation/locale >>/var/log/configure.log 2>&1 ||:
 ln -sf /usr/share/locale /storage/.config/emulationstation/locale >>/var/log/configure.log 2>&1 ||:
@@ -78,6 +83,7 @@ if [ "${GAMECOUNT}" -gt 20 ] && \
    [ ! -e "/storage/.migrated_games" ]
 then
   echo "Migrating games to overlayfs" >>${LOG}
+  tocon "Migrate games to new storage model..."
   if [ -d "/storage/games-internal" ]
   then
     echo "Backing up games-internal" >>${LOG}
@@ -99,6 +105,7 @@ then
     then
       mkdir -p "${GAMES}/roms" 2>/dev/null
     fi
+    tocon "Migrate games to new storage model..."
     mv "${GAMES}"/* "${GAMES}/roms/" 
   done
   touch /storage/.migrated_games2

--- a/packages/sysutils/systemd/scripts/userconfig-setup
+++ b/packages/sysutils/systemd/scripts/userconfig-setup
@@ -9,8 +9,8 @@
 if [ ! -e "/storage/.configured" ]
 then
   tocon "Initializing configuration..."
-  # Copy config files, but don't overwrite.  Only run if /storage is fresh
-  rsync -a --ignore-existing --exclude={es_features.cfg,es_systems.cfg} /usr/config/* /storage/.config/ >/var/log/configure.log 2>&1
+  # Copy config files
+  rsync -a --exclude={es_features.cfg,es_systems.cfg} /usr/config/* /storage/.config/ >/var/log/configure.log 2>&1
 
   if [ -d "/usr/lib/autostart/quirks/platforms/${HW_DEVICE}/config" ]
   then


### PR DESCRIPTION
* Post-update notices should go to the console and the logs.
* Update pipewire and wireplumber.
* Optimize wireplumber BT auto connect.
* When provisining JELOS for the first time overwrite any existing configs unless explicitly excluded.