### PR TITLE
Better display mode for rk2023

### DIFF
--- a/projects/Rockchip/packages/linux/patches/RK3566/007-rk2023-display-mode.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3566/007-rk2023-display-mode.patch
@@ -1,0 +1,32 @@
+diff --git a/drivers/gpu/drm/panel/panel-newvision-nv3051d.c b/drivers/gpu/drm/panel/panel-newvision-nv3051d.c
+index 94d89ffd596..923e4df1420 100644
+--- a/drivers/gpu/drm/panel/panel-newvision-nv3051d.c
++++ b/drivers/gpu/drm/panel/panel-newvision-nv3051d.c
+@@ -477,18 +477,18 @@ static const struct drm_display_mode nv3051d_rgxx3_modes[] = {
+ };
+ 
+ static const struct drm_display_mode nv3051d_rk2023_modes[] = {
+-	{
++    {
+ 		.hdisplay       = 640,
+-		.hsync_start    = 640 + 40,
+-		.hsync_end      = 640 + 40 + 2,
+-		.htotal         = 640 + 40 + 2 + 80,
++		.hsync_start    = 640 + 48,
++		.hsync_end      = 640 + 48 + 2,
++		.htotal         = 640 + 48 + 2 + 47,
+ 		.vdisplay       = 480,
+-		.vsync_start    = 480 + 18,
+-		.vsync_end      = 480 + 18 + 2,
+-		.vtotal         = 480 + 18 + 2 + 4,
+-		.clock          = 24150,
++		.vsync_start    = 480 + 2,
++		.vsync_end      = 480 + 2 + 4,
++		.vtotal         = 480 + 2 + 4 + 3,
++		.clock          = 21600,
+ 		.flags          = DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC,
+-	},
++	}
+ };
+ 
+ static const struct nv3051d_panel_info nv3051d_rg351v_info = {


### PR DESCRIPTION
Better display mode for rk2023, 478 visible lines according to test image. 59.93Hz refresh rate.