### PR TITLE
Revert gcc to 12.3.x

### DIFF
--- a/packages/emulators/standalone/dolphin-sa/package.mk
+++ b/packages/emulators/standalone/dolphin-sa/package.mk
@@ -48,15 +48,10 @@ then
 fi
 
 pre_configure_target() {
-  sed -i 's~#include <cstdlib>~#include <cstdlib>\n#include <cstdint>~g' ${PKG_BUILD}/Externals/VulkanMemoryAllocator/include/vk_mem_alloc.h
-  sed -i 's~#include <cstdint>~#include <cstdint>\n#include <string>~g' ${PKG_BUILD}/Externals/VulkanMemoryAllocator/include/vk_mem_alloc.h
-}
-
-PKG_CMAKE_OPTS_TARGET+=" -DENABLE_HEADLESS=ON \
+  PKG_CMAKE_OPTS_TARGET+=" -DENABLE_HEADLESS=ON \
                          -DENABLE_EVDEV=ON \
                          -DUSE_DISCORD_PRESENCE=OFF \
                          -DBUILD_SHARED_LIBS=OFF \
-                         -DUSE_MGBA=OFF \
                          -DLINUX_LOCAL_DEV=ON \
                          -DENABLE_PULSEAUDIO=ON \
                          -DENABLE_ALSA=ON \
@@ -67,7 +62,10 @@ PKG_CMAKE_OPTS_TARGET+=" -DENABLE_HEADLESS=ON \
                          -DENABLE_QT=OFF \
                          -DENCODE_FRAMEDUMPS=OFF \
                          -DENABLE_CLI_TOOL=OFF"
+  sed -i 's~#include <cstdlib>~#include <cstdlib>\n#include <cstdint>~g' ${PKG_BUILD}/Externals/VulkanMemoryAllocator/include/vk_mem_alloc.h
+  sed -i 's~#include <cstdint>~#include <cstdint>\n#include <string>~g' ${PKG_BUILD}/Externals/VulkanMemoryAllocator/include/vk_mem_alloc.h
 
+}
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="gcc"
-PKG_VERSION="13.2.0"
+PKG_VERSION="12.3.0"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://gcc.gnu.org/"
 PKG_URL="https://ftp.gnu.org/gnu/gcc/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -54,6 +54,7 @@ GCC_COMMON_CONFIGURE_OPTS="--target=${TARGET_NAME} \
                            --disable-libssp \
                            --disable-static \
                            --enable-shared \
+                           --disable-werror \
                            --enable-__cxa_atexit"
 
 PKG_CONFIGURE_OPTS_BOOTSTRAP="${GCC_COMMON_CONFIGURE_OPTS} \
@@ -68,7 +69,6 @@ PKG_CONFIGURE_OPTS_BOOTSTRAP="${GCC_COMMON_CONFIGURE_OPTS} \
                               --disable-threads \
                               --without-headers \
                               --with-newlib \
-                              --disable-werror \
                               ${GCC_OPTS}"
 
 PKG_CONFIGURE_OPTS_HOST="${GCC_COMMON_CONFIGURE_OPTS} \
@@ -84,8 +84,6 @@ PKG_CONFIGURE_OPTS_HOST="${GCC_COMMON_CONFIGURE_OPTS} \
                          --enable-libstdcxx-time \
                          --enable-clocale=gnu \
                          ${GCC_OPTS}"
-
-PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_HOST}"
 
 post_makeinstall_bootstrap() {
   GCC_VERSION=$(${TOOLCHAIN}/bin/${TARGET_NAME}-gcc -dumpversion)


### PR DESCRIPTION
## Description

Reverts our gcc 13.2.0 update as it causes segmentation faults with Dolphin standalone and possibly other emulators, updating to 13.2 latest did not resolve.

Note: This change requires a full clean.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Change is still being tested, merging to push to the builder for a clean world build.
