### PR TITLE
* New Danger Zone options - Overlay and Full Retroarch Reset.

### DIFF
--- a/packages/jelos/sources/scripts/factoryreset
+++ b/packages/jelos/sources/scripts/factoryreset
@@ -9,8 +9,17 @@ case "${1}" in
     rm -f /storage/.config/retroarch/retroarch.cfg
     cp -rf /usr/config/retroarch/retroarch.cfg /storage/.config/retroarch/retroarch.cfg
   ;;
+  "retroarch-full")
+    rm -rf /storage/.config/retroarch
+    cp -rf /usr/config/retroarch /storage/.config/
+  ;;
   "mednafen")
     rm -f /storage/.config/mednafen/mednafen.cfg
+  ;;
+  "overlays")
+    rm -rf $(cat /usr/lib/systemd/system/tmp-*.mount | grep -Eo 'upperdir=.*,' | sed -e 's~upperdir=~~g; s~,~~g')
+    sync
+    systemctl reboot
   ;;
   "ALL")
     systemctl stop ${UI_SERVICE}

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="0fac4e7b9dbd27f9d71f388d41f706951677c304"
+PKG_VERSION="d5fe1df364cca1ee4a22de493014ca4918b8afec"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
## Description

This change adds two new danger zone options:

* An Overlay reset which deletes overlays from /storage and reboots.  This will be useful for cleaning up broken joypad configurations or fixing scenarios where users have used the retroarch update tool.
* A full retroarch reset which deletes the entire retroarch directory and all overlay directories and then reboots.  Useful for cleaning up when other resets don't resolve issues, and users don't want to factory reset.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Executed on an Air Plus after making settings changes and adding configurations known to break JELOS.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
