### PR TITLE
Initial installation support for ARM devices (currently requires ssh or Weston).

### DIFF
--- a/packages/misc/modules/package.mk
+++ b/packages/misc/modules/package.mk
@@ -35,15 +35,19 @@ post_makeinstall_target() {
       rm -f ${INSTALL}/usr/config/modules/*32bit*
       rm -f ${INSTALL}/usr/config/modules/*Master*
     ;;
-    *)
-      rm -f ${INSTALL}/usr/config/modules/Install*
-    ;;
   esac
+
   case ${DEVICE} in
     S922X*)
       rm -f ${INSTALL}/usr/config/modules/*ScummVM*
       rm -f ${INSTALL}/usr/config/modules/*32bit*
     ;;
   esac
+
+  if [ ! "${INSTALLER_SUPPORT}" = "yes" ] || \
+     [ ! "${DISPLAYSERVER}" = "wl" ]
+  then
+    rm -f ${INSTALL}/usr/config/modules/Install*
+  fi
 }
 

--- a/packages/tools/installer/config/installer.conf
+++ b/packages/tools/installer/config/installer.conf
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 
 # Disklabel for System and Storage partition
-  DISKLABEL_SYSTEM="System"
-  DISKLABEL_STORAGE="Storage"
+  DISKLABEL_SYSTEM="boot"
+  DISKLABEL_STORAGE="storage"
 
 # Default size of system partition, in MB, eg. 512
   PARTSIZE_SYSTEM="@SYSTEM_SIZE@"

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -555,9 +555,10 @@ log_system_status >> $LOGFILE 2>&1
 
 # generate the en_US.UTF-8 locale to enable line drawing
 mkdir -p $TMPDIR/locale
-#localedef -i en_US -f UTF-8 $TMPDIR/locale/en_US.UTF-8
-#export LOCPATH=$TMPDIR/locale
-#export LC_ALL=en_US.UTF-8
+echo "Please wait, configuring en_US.UTF-8."
+localedef -i en_US -f UTF-8 $TMPDIR/locale/en_US.UTF-8
+export LOCPATH=$TMPDIR/locale
+export LC_ALL=en_US.UTF-8
 
 # main
 

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -29,7 +29,12 @@
 # disable Ctrl+C - can be very dangerous
 trap '' 2
 
+# Don't execute if installer.conf doesn't exist
 [ -f /etc/installer.conf ] && . /etc/installer.conf || exit 0
+
+# Bring in OS variables.
+. /etc/os-release
+
 
 dbglg() {
   # Acts just like echo cmd, with automatic redirection
@@ -158,14 +163,21 @@ do_install_quick() {
   INSTALL_DEVICE=$(cat "$TMPDIR/device_for_install")
   INSTALL_DEVICE_FULL=$(echo ${DEVICE_LIST} | sed "s|.*${INSTALL_DEVICE} \([^ ]*\).*|${INSTALL_DEVICE} \1|")
 
-  case ${INSTALL_DEVICE} in
-    "/dev/mmcblk"*|"/dev/nvme"*)
-      PART1="p1"
-      PART2="p2"
-      ;;
+  case ${HW_ARCH} in
+    arm|aarch64)
+      PART1="3"
+      PART2="4"
+    ;;
     *)
       PART1="1"
       PART2="2"
+    ;;
+  esac
+
+  case ${INSTALL_DEVICE} in
+    "/dev/mmcblk"*|"/dev/nvme"*)
+      PART1="p${PART1}"
+      PART2="p${PART2}"
       ;;
   esac
 
@@ -204,12 +216,30 @@ do_install_quick() {
       parted -s ${INSTALL_DEVICE} mklabel msdos >> $LOGFILE 2>&1
     fi
 
-    msg_progress_install "9" "Writing Master Boot Record on ${INSTALL_DEVICE}"
-    if [ "$GPT" = "1" ]; then
-      cat /usr/share/syslinux/gptmbr.bin > ${INSTALL_DEVICE}
-    else
-      cat /usr/share/syslinux/mbr.bin > ${INSTALL_DEVICE}
-    fi
+    case ${HW_ARCH} in
+      arm|aarch64)
+        parted -s "${INSTALL_DEVICE}" unit s mkpart uboot 16384 24575 >> $LOGFILE 2>&1
+        if [ -e "/usr/share/bootloader/trust.img" ]
+        then
+          TRUST_LABEL="trust"
+        elif [ -e "/usr/share/bootloader/resource.img" ]
+        then
+          TRUST_LABEL="resource"
+        fi
+        if [ -n "${TRUST_LABEL}" ]
+        then
+          parted -s "${INSTALL_DEVICE}" unit s mkpart ${TRUST_LABEL} 24576 32767 >> $LOGFILE 2>&1
+        fi
+      ;;
+      *)
+        msg_progress_install "9" "Writing Master Boot Record on ${INSTALL_DEVICE}"
+        if [ "$GPT" = "1" ]; then
+          cat /usr/share/syslinux/gptmbr.bin > ${INSTALL_DEVICE}
+        else
+          cat /usr/share/syslinux/mbr.bin > ${INSTALL_DEVICE}
+        fi
+      ;;
+    esac
 
     partsize_system_start=$PARTSIZE_SYSTEM_OFFSET
     partsize_system_end=$(((PARTSIZE_SYSTEM * 1024 * 1024 / 512) + partsize_system_start - 1))
@@ -227,13 +257,21 @@ do_install_quick() {
     if [ "$GPT" = "1" ]; then
       parted -s ${INSTALL_DEVICE} unit s mkpart $DISKLABEL_STORAGE ext4 -- $partsize_storage_start $partsize_storage_end >> $LOGFILE 2>&1
     else
-      parted -s ${INSTALL_DEVICE} unit s mkpart primary ext4 -- $partsize_storage_start $partsize_storage_end >> $LOGFILE 2>&1
+      parted -s ${INSTALL_DEVICE} unit s mkpart storage ext4 -- $partsize_storage_start $partsize_storage_end >> $LOGFILE 2>&1
     fi
 
     msg_progress_install "16" "Setup bootflag on partition 1 of ${INSTALL_DEVICE}"
     parted -s ${INSTALL_DEVICE} set 1 boot on >> $LOGFILE 2>&1
     if [ "$GPT" = "1" ]; then
-      parted -s ${INSTALL_DEVICE} set 1 legacy_boot on >> $LOGFILE 2>&1
+      case ${HW_ARCH} in
+        arm|aarch64)
+          BOOT_PART=3
+        ;;
+        *)
+          BOOT_PART=1
+        ;;
+      esac
+      parted -s ${INSTALL_DEVICE} set ${BOOT_PART} legacy_boot on >> $LOGFILE 2>&1
     fi
 
     msg_progress_install "20" "Tell the kernel we have a new partition table on ${INSTALL_DEVICE}"
@@ -266,9 +304,34 @@ do_install_quick() {
     msg_progress_install "40" "Mounting ${INSTALL_DEVICE}${PART1} to $TMPDIR/part1"
     mount -t vfat ${INSTALL_DEVICE}${PART1} $TMPDIR/part1 >> $LOGFILE 2>&1
 
-    # installing syslinux
-    msg_progress_install "50" "Installing syslinux to $TMPDIR/part1"
-    syslinux -i ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
+    case ${HW_ARCH} in
+      arm|aarch64)
+        msg_progress_install "50" "Installing bootloader to $TMPDIR/part1"
+        /usr/share/bootloader/update.sh "${INSTALL_DEVICE}" "${TMPDIR}/part1" "$UUID_SYSTEM" "$UUID_STORAGE" "$SYSLINUX_PARAMETERS @EXTRA_CMDLINE@"
+        mount -o remount,rw $TMPDIR/part1
+      ;;
+      i686|x86_64)
+        # installing syslinux
+        msg_progress_install "50" "Installing syslinux to $TMPDIR/part1"
+        syslinux -i ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
+
+        # configuring bootloader
+        msg_progress_install "80" "Setup bootloader with boot label = $DISKLABEL_SYSTEM and disk label = $DISKLABEL_STORAGE"
+        mkdir -p $TMPDIR/part1/EFI/BOOT
+        cat << EOF > $TMPDIR/part1/syslinux.cfg
+DEFAULT linux
+PROMPT 0
+
+LABEL linux
+ KERNEL /KERNEL
+ APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE $SYSLINUX_PARAMETERS @EXTRA_CMDLINE@
+EOF
+        # uefi boot / hybrid mode
+        cp /usr/share/syslinux/bootx64.efi $TMPDIR/part1/EFI/BOOT
+        cp /usr/share/syslinux/ldlinux.e64 $TMPDIR/part1/EFI/BOOT
+        cp /usr/share/grub/bootia32.efi $TMPDIR/part1/EFI/BOOT
+      ;;
+    esac
 
     # install system files
     msg_progress_install "60" "Installing Kernel"
@@ -278,22 +341,6 @@ do_install_quick() {
     cp "/flash/$IMAGE_SYSTEM" $TMPDIR/part1/SYSTEM >> $LOGFILE 2>&1
     sync
 
-    # configuring bootloader
-    msg_progress_install "80" "Setup bootloader with boot label = $DISKLABEL_SYSTEM and disk label = $DISKLABEL_STORAGE"
-    mkdir -p $TMPDIR/part1/EFI/BOOT
-    cat << EOF > $TMPDIR/part1/syslinux.cfg
-DEFAULT linux
-PROMPT 0
-
-LABEL linux
- KERNEL /KERNEL
- APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE $SYSLINUX_PARAMETERS @EXTRA_CMDLINE@
-EOF
-
-    # uefi boot / hybrid mode
-    cp /usr/share/syslinux/bootx64.efi $TMPDIR/part1/EFI/BOOT
-    cp /usr/share/syslinux/ldlinux.e64 $TMPDIR/part1/EFI/BOOT
-    cp /usr/share/grub/bootia32.efi $TMPDIR/part1/EFI/BOOT
     sync
 
     # umount system partition, remove mountpoint
@@ -326,7 +373,7 @@ EOF
   } | whiptail --backtitle "$BACKTITLE" --gauge "Please wait while your system is being setup ..." 6 73 0
 
   # install complete
-  MSG_TITLE="@DISTRONAME@ Install Complete"
+  MSG_TITLE="JELOS Install Complete"
   MSG_DETAIL="You may now remove the install media and reboot.\n"
   whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" --msgbox "$MSG_DETAIL" 7 52
 }
@@ -351,19 +398,36 @@ msg_progress_install() {
 }
 
 prompt_gpt() {
-  GPT="0"
-  UEFI="0"
-  # Get size in GB.
-  # 2^41 bytes is the DOS limit (2199023255552 bytes, 2.2TB). Use GUID Partition Table.>= 2200GB
-  INSTALL_DEVICE_SIZE=$(($(cat /sys/block/${INSTALL_DEVICE#/dev/}/size)*512/1000/1000/1000))
-  if [ "${INSTALL_DEVICE_SIZE}" -ge 2200 ] 2>/dev/null; then
-    GPT="1"
-  fi
-  # force gpt + uefi in uefi boot mode
-  if [ -d /sys/firmware/efi ]; then
-    UEFI="1"
-    GPT="1"
-  fi
+  case ${HW_ARCH} in
+    arm|aarch64)
+      BOOT_DEVICE=$(blkid | awk 'BEGIN {FS=":"} /'$(cat /proc/cmdline | sed -e 's~^.*disk=UUID=~~g; s~\ .*$~~g')'/ {print $1}' | sed 's~p[0-9].*$~~g')
+      BOOT_LABEL="$(blkid ${BOOT_DEVICE} | grep -Eo 'PTTYPE=".*"' | sed 's~PTTYPE=~~g; s~"~~g')"
+      case ${BOOT_LABEL} in
+        gpt)
+          GPT="1"
+        ;;
+        *)
+          GPT="0"
+        ;;
+      esac
+      UEFI="0"
+    ;;
+    *)
+     GPT="0"
+     UEFI="0"
+     # Get size in GB.
+     # 2^41 bytes is the DOS limit (2199023255552 bytes, 2.2TB). Use GUID Partition Table.>= 2200GB
+     INSTALL_DEVICE_SIZE=$(($(cat /sys/block/${INSTALL_DEVICE#/dev/}/size)*512/1000/1000/1000))
+     if [ "${INSTALL_DEVICE_SIZE}" -ge 2200 ] 2>/dev/null; then
+       GPT="1"
+     fi
+     # force gpt + uefi in uefi boot mode
+     if [ -d /sys/firmware/efi ]; then
+       UEFI="1"
+       GPT="1"
+     fi
+    ;;
+  esac
 }
 
 prompt_backup_unpack() {
@@ -385,9 +449,9 @@ prompt_backup_unpack() {
 menu_main() {
   # show the mainmenu
   MSG_TITLE="MAIN MENU"
-  MSG_MENU="\nWelcome to @DISTRONAME@ installation tool! \
+  MSG_MENU="\nWelcome to JELOS installation tool! \
 \n
-This tool is used to copy @DISTRONAME@ from the installation media \
+This tool is used to copy JELOS from the installation media \
 to your disk or other device. You'll be up and running in no time! \
 Please note that the contents of the disk you choose will be wiped \
 out during the installation. \
@@ -396,7 +460,7 @@ out during the installation. \
 
   whiptail --backtitle "$BACKTITLE" --cancel-button "$MSG_CANCEL" \
     --title "$MSG_TITLE" --menu "$MSG_MENU" 18 73 4 \
-      1 "Install @DISTRONAME@" \
+      1 "Install JELOS" \
       2 "View installation log" \
       3 "Save installation log" \
       4 "Reboot" 2> $TMPDIR/mainmenu
@@ -433,7 +497,7 @@ logfile_save() {
 
   mount -o remount,ro /flash
 
-  MSG_TITLE="@DISTRONAME@ Log Saved"
+  MSG_TITLE="JELOS Log Saved"
   MSG_DETAIL="Log location: ${LOGBACKUP}\n"
   whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" --msgbox "$MSG_DETAIL" 7 52
 }
@@ -454,7 +518,7 @@ do_poweroff() {
 
 # setup needed variables
 OS_VERSION=$(lsb_release)
-BACKTITLE="@DISTRONAME@ Installer - ${OS_VERSION}"
+BACKTITLE="JELOS Installer - ${OS_VERSION}"
 
 TMPDIR="/tmp/installer"
 LOGFILE="$TMPDIR/install.log"
@@ -483,7 +547,7 @@ rm -rf $TMPDIR
 mkdir -p $TMPDIR
 
 #create log file
-echo "@DISTRONAME@ Installer - ${OS_VERSION} started at:" > $LOGFILE
+echo "JELOS Installer - ${OS_VERSION} started at:" > $LOGFILE
 date >> $LOGFILE
 
 dbglg "System status"
@@ -491,9 +555,9 @@ log_system_status >> $LOGFILE 2>&1
 
 # generate the en_US.UTF-8 locale to enable line drawing
 mkdir -p $TMPDIR/locale
-localedef -i en_US -f UTF-8 $TMPDIR/locale/en_US.UTF-8
-export LOCPATH=$TMPDIR/locale
-export LC_ALL=en_US.UTF-8
+#localedef -i en_US -f UTF-8 $TMPDIR/locale/en_US.UTF-8
+#export LOCPATH=$TMPDIR/locale
+#export LC_ALL=en_US.UTF-8
 
 # main
 

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -373,7 +373,7 @@ EOF
   } | whiptail --backtitle "$BACKTITLE" --gauge "Please wait while your system is being setup ..." 6 73 0
 
   # install complete
-  MSG_TITLE="JELOS Install Complete"
+  MSG_TITLE="@DISTRONAME@ Install Complete"
   MSG_DETAIL="You may now remove the install media and reboot.\n"
   whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" --msgbox "$MSG_DETAIL" 7 52
 }
@@ -449,9 +449,9 @@ prompt_backup_unpack() {
 menu_main() {
   # show the mainmenu
   MSG_TITLE="MAIN MENU"
-  MSG_MENU="\nWelcome to JELOS installation tool! \
+  MSG_MENU="\nWelcome to @DISTRONAME@ installation tool! \
 \n
-This tool is used to copy JELOS from the installation media \
+This tool is used to copy @DISTRONAME@ from the installation media \
 to your disk or other device. You'll be up and running in no time! \
 Please note that the contents of the disk you choose will be wiped \
 out during the installation. \
@@ -460,7 +460,7 @@ out during the installation. \
 
   whiptail --backtitle "$BACKTITLE" --cancel-button "$MSG_CANCEL" \
     --title "$MSG_TITLE" --menu "$MSG_MENU" 18 73 4 \
-      1 "Install JELOS" \
+      1 "Install @DISTRONAME@" \
       2 "View installation log" \
       3 "Save installation log" \
       4 "Reboot" 2> $TMPDIR/mainmenu
@@ -497,7 +497,7 @@ logfile_save() {
 
   mount -o remount,ro /flash
 
-  MSG_TITLE="JELOS Log Saved"
+  MSG_TITLE="@DISTRONAME@ Log Saved"
   MSG_DETAIL="Log location: ${LOGBACKUP}\n"
   whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" --msgbox "$MSG_DETAIL" 7 52
 }
@@ -518,7 +518,7 @@ do_poweroff() {
 
 # setup needed variables
 OS_VERSION=$(lsb_release)
-BACKTITLE="JELOS Installer - ${OS_VERSION}"
+BACKTITLE="@DISTRONAME@ Installer - ${OS_VERSION}"
 
 TMPDIR="/tmp/installer"
 LOGFILE="$TMPDIR/install.log"
@@ -547,7 +547,7 @@ rm -rf $TMPDIR
 mkdir -p $TMPDIR
 
 #create log file
-echo "JELOS Installer - ${OS_VERSION} started at:" > $LOGFILE
+echo "@DISTRONAME@ Installer - ${OS_VERSION} started at:" > $LOGFILE
 date >> $LOGFILE
 
 dbglg "System status"

--- a/projects/Amlogic/devices/S922X/options
+++ b/projects/Amlogic/devices/S922X/options
@@ -144,6 +144,9 @@
   # swapfile size if SWAP_SUPPORT=yes in MB
     SWAPFILESIZE="384"
 
+  # Some devices have internal storage.
+    INSTALLER_SUPPORT="yes"
+
   # cron support (yes / no)
     CRON_SUPPORT="no"
 

--- a/projects/Rockchip/bootloader/update.sh
+++ b/projects/Rockchip/bootloader/update.sh
@@ -3,62 +3,74 @@
 # Copyright (C) 2017-2021 Team LibreELEC (https://libreelec.tv)
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-[ -z "$SYSTEM_ROOT" ] && SYSTEM_ROOT=""
-[ -z "$BOOT_ROOT" ] && BOOT_ROOT="/flash"
-[ -z "$BOOT_PART" ] && BOOT_PART=$(df "$BOOT_ROOT" | tail -1 | awk {' print $1 '})
-if [ -z "$BOOT_DISK" ]; then
-  case $BOOT_PART in
-    /dev/sd[a-z][0-9]*)
-      BOOT_DISK=$(echo $BOOT_PART | sed -e "s,[0-9]*,,g")
+
+if [ -z "${1}" ]
+then
+  [ -z "$SYSTEM_ROOT" ] && SYSTEM_ROOT=""
+  [ -z "$BOOT_ROOT" ] && BOOT_ROOT="/flash"
+  [ -z "$BOOT_PART" ] && BOOT_PART=$(df "$BOOT_ROOT" | tail -1 | awk {' print $1 '})
+  if [ -z "$BOOT_DISK" ]; then
+    case $BOOT_PART in
+      /dev/sd[a-z][0-9]*)
+        BOOT_DISK=$(echo $BOOT_PART | sed -e "s,[0-9]*,,g")
+        ;;
+      /dev/mmcblk*)
+        BOOT_DISK=$(echo $BOOT_PART | sed -e "s,p[0-9]*,,g")
+        ;;
+    esac
+  fi
+
+  # mount $BOOT_ROOT r/w
+    mount -o remount,rw $BOOT_ROOT
+
+  for arg in $(cat /proc/cmdline); do
+    case $arg in
+      boot=*)
+        boot="${arg#*=}"
+        case $boot in
+          /dev/mmc*)
+            UUID_SYSTEM="$(blkid $boot | sed 's/.* UUID="//;s/".*//g')"
+            ;;
+          UUID=*|LABEL=*)
+            UUID_SYSTEM="$(blkid | sed 's/"//g' | grep -m 1 -i " $boot " | sed 's/.* UUID=//;s/ .*//g')"
+            ;;
+          FOLDER=*)
+            UUID_SYSTEM="$(blkid ${boot#*=} | sed 's/.* UUID="//;s/".*//g')"
+            ;;
+        esac
       ;;
-    /dev/mmcblk*)
-      BOOT_DISK=$(echo $BOOT_PART | sed -e "s,p[0-9]*,,g")
+      disk=*)
+        disk="${arg#*=}"
+        case $disk in
+          /dev/mmc*)
+            UUID_STORAGE="$(blkid $disk | sed 's/.* UUID="//;s/".*//g')"
+            ;;
+          UUID=*|LABEL=*)
+            UUID_STORAGE="$(blkid | sed 's/"//g' | grep -m 1 -i " $disk " | sed 's/.* UUID=//;s/ .*//g')"
+            ;;
+          FOLDER=*)
+            UUID_STORAGE="$(blkid ${disk#*=} | sed 's/.* UUID="//;s/".*//g')"
+            ;;
+        esac
       ;;
-  esac
+    esac
+  done
+else
+  BOOT_DISK="${1}"
+  BOOT_ROOT="${2}"
+  UUID_SYSTEM="${3}"
+  UUID_STORAGE="${4}"
 fi
-
-# mount $BOOT_ROOT r/w
-  mount -o remount,rw $BOOT_ROOT
-
-
-for arg in $(cat /proc/cmdline); do
-  case $arg in
-    boot=*)
-      boot="${arg#*=}"
-      case $boot in
-        /dev/mmc*)
-          UUID_SYSTEM="$(blkid $boot | sed 's/.* UUID="//;s/".*//g')"
-          ;;
-        UUID=*|LABEL=*)
-          UUID_SYSTEM="$(blkid | sed 's/"//g' | grep -m 1 -i " $boot " | sed 's/.* UUID=//;s/ .*//g')"
-          ;;
-        FOLDER=*)
-          UUID_SYSTEM="$(blkid ${boot#*=} | sed 's/.* UUID="//;s/".*//g')"
-          ;;
-      esac
-    ;;
-    disk=*)
-      disk="${arg#*=}"
-      case $disk in
-        /dev/mmc*)
-          UUID_STORAGE="$(blkid $disk | sed 's/.* UUID="//;s/".*//g')"
-          ;;
-        UUID=*|LABEL=*)
-          UUID_STORAGE="$(blkid | sed 's/"//g' | grep -m 1 -i " $disk " | sed 's/.* UUID=//;s/ .*//g')"
-          ;;
-        FOLDER=*)
-          UUID_STORAGE="$(blkid ${disk#*=} | sed 's/.* UUID="//;s/".*//g')"
-          ;;
-      esac
-    ;;
-  esac
-done
 
 CONFS=$SYSTEM_ROOT/usr/share/bootloader/extlinux/*.conf
 
 for all_conf in $CONFS; do
   conf="$(basename ${all_conf})"
   echo "Updating ${conf}..."
+  if [ ! -d "${BOOT_ROOT}/extlinux" ]
+  then
+    mkdir "${BOOT_ROOT}/extlinux"
+  fi
   cp -p $SYSTEM_ROOT/usr/share/bootloader/extlinux/${conf} $BOOT_ROOT/extlinux/${conf} &>/dev/null
   sed -e "s/@UUID_SYSTEM@/${UUID_SYSTEM}/" \
       -e "s/@UUID_STORAGE@/${UUID_STORAGE}/" \

--- a/projects/Rockchip/devices/RK3566-X55/options
+++ b/projects/Rockchip/devices/RK3566-X55/options
@@ -145,6 +145,9 @@
   # swapfile size if SWAP_SUPPORT=yes in MB
     SWAPFILESIZE="384"
 
+  # Some devices have internal storage.
+    INSTALLER_SUPPORT="yes"
+
   # cron support (yes / no)
     CRON_SUPPORT="no"
 

--- a/projects/Rockchip/devices/RK3566/options
+++ b/projects/Rockchip/devices/RK3566/options
@@ -139,6 +139,9 @@
   # build with swap support (yes / no)
     SWAP_SUPPORT="yes"
 
+  # Some devices have internal storage.
+    INSTALLER_SUPPORT="yes"
+
   # swap support enabled per default (yes / no)
     SWAP_ENABLED_DEFAULT="yes"
 

--- a/projects/Rockchip/devices/RK3588/options
+++ b/projects/Rockchip/devices/RK3588/options
@@ -155,6 +155,9 @@
   # swapfile size if SWAP_SUPPORT=yes in MB
     SWAPFILESIZE="384"
 
+  # Some devices have internal storage.
+    INSTALLER_SUPPORT="yes"
+
   # cron support (yes / no)
     CRON_SUPPORT="no"
 


### PR DESCRIPTION
## Description

Adds initial support for installing JELOS on internal storage such as EMMC for ARM devices to bring it in line with our x86_64 support.  Note, there currently is no mask for a games card and additional testing on x86 is needed before release.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update (TO DO)

## How Has This Been Tested Locally?

`installer` has been used to install JELOS to the EMMC on two RG353V devices over ssh.  JELOS is successfully installed and the devices boot from internal storage, initialize, and start ES normally.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
