### PR TITLE
RG351M: Adding dumby hotkey to prevent false inputs

### DIFF
--- a/packages/hardware/quirks/devices/Anbernic RG351M/100-jslisten-hotkey
+++ b/packages/hardware/quirks/devices/Anbernic RG351M/100-jslisten-hotkey
@@ -1,0 +1,8 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+#Set dummy key for RG351M/P
+cat <<EOF >/storage/.config/profile.d/100-jslisten-hotkey
+BTN_VOLBRIGHT_HOTKEY=999 # Select
+EOF


### PR DESCRIPTION
The RG351P/M does not have physical volume keys. So this causes false inputs. 

Will look into adding real hotkey support later. 