### PR TITLE
hotkey bugfix

### DIFF
--- a/packages/jelos/sources/post-update
+++ b/packages/jelos/sources/post-update
@@ -137,3 +137,9 @@ then
 fi
 
 systemctl restart jelos-automount
+
+### 20240111 - Add new jslisten hotkey
+if [ -e "/storage/.config/jslisten_hotkeys" ]
+then
+   grep BTN_VOLBRIGHT_HOTKEY /storage/.config/jslisten_hotkeys || echo "BTN_VOLBRIGHT_HOTKEY=999" >>/storage/.config/jslisten_hotkeys
+fi

--- a/packages/tools/jslisten/config/jslisten_hotkeys
+++ b/packages/tools/jslisten/config/jslisten_hotkeys
@@ -22,3 +22,9 @@ BTN_QUIT_SELECT=${DEVICE_BTN_START}
 BTN_KILL_HOTKEY=${DEVICE_BTN_TL}
 BTN_KILL_SELECTA=${DEVICE_BTN_SELECT}
 BTN_KILL_SELECTB=${DEVICE_BTN_START}
+
+###
+### Define BTN_VOLBRIGHT_HOTKEY as an impossible value by default so it doesn't get used unless redefined.
+###
+
+BTN_VOLBRIGHT_HOTKEY=999


### PR DESCRIPTION
## Description

Add a bogus value for BTN_VOLBRIGHT_HOTKEY by default, and update /storage/.config/jslisten_hotkeys to include it if it doesn't exist during post-update.