### PR TITLE
Rgb10 new hotkey schema

### DIFF
--- a/packages/hardware/quirks/devices/Powkiddy RGB10/050-modifiers
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10/050-modifiers
@@ -1,0 +1,8 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+cat <<EOF >/storage/.config/profile.d/050-modifiers
+DEVICE_FUNC_KEYA_MODIFIER="BTN_THUMBL"
+DEVICE_FUNC_KEYB_MODIFIER="BTN_THUMBR"
+EOF

--- a/packages/hardware/quirks/devices/Powkiddy RGB10/110-retroarch-joypad
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10/110-retroarch-joypad
@@ -1,0 +1,11 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
+
+# Adapt retroarch joypad config for rgb10
+
+if [ ! -f "/storage/joypads/odroidgo2_v11_joypad.cfg" ]; then
+    cp /usr/share/libretro/autoconfig/odroidgo2_v11_joypad.cfg /storage/joypads/
+    sed -i -r 's/input_enable_hotkey_btn.*/input_enable_hotkey_btn = "13"/' /storage/joypads/odroidgo2_v11_joypad.cfg
+fi
+

--- a/packages/jelos/sources/scripts/setsettings.sh
+++ b/packages/jelos/sources/scripts/setsettings.sh
@@ -361,8 +361,13 @@ function configure_hotkeys() {
                 clear_setting "${HKEYSETTING}"
             done
             flush_settings
+            if [ -z ${input_enable_hotkey_btn+x} ]
+            then
+                echo 'input_enable_hotkey_btn = '\"${input_select_btn}\" >>${RETROARCH_CONFIG}
+            else
+                echo 'input_enable_hotkey_btn = '\"${input_enable_hotkey_btn}\" >>${RETROARCH_CONFIG}
+            fi
             cat <<EOF >>${RETROARCH_CONFIG}
-input_enable_hotkey_btn = "${input_select_btn}"
 input_bind_hold = "${input_select_btn}"
 input_exit_emulator_btn = "${input_start_btn}"
 input_fps_toggle_btn = "${input_y_btn}"

--- a/projects/Rockchip/packages/linux/patches/RK3326/000-rk3326-dts.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3326/000-rk3326-dts.patch
@@ -1269,7 +1269,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-odroid-go3.dts linux/a
 diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-powkiddy-rgb10.dts linux/arch/arm64/boot/dts/rockchip/rk3326-powkiddy-rgb10.dts
 --- linux.orig/arch/arm64/boot/dts/rockchip/rk3326-powkiddy-rgb10.dts	1970-01-01 00:00:00.000000000 +0000
 +++ linux/arch/arm64/boot/dts/rockchip/rk3326-powkiddy-rgb10.dts	2024-01-10 20:02:43.061559086 +0000
-@@ -0,0 +1,299 @@
+@@ -0,0 +1,280 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2019 Hardkernel Co., Ltd
@@ -1286,25 +1286,6 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-powkiddy-rgb10.dts lin
 +
 +	aliases {
 +		mmc1 = &sdio;
-+	};
-+
-+	gpio_keys: volume-keys {
-+		compatible = "gpio-keys-polled";
-+		poll-interval = <5>;
-+		autorepeat;
-+
-+		volume-up-button {
-+			label = "VOLUME-UP";
-+			linux,code = <KEY_VOLUMEUP>;
-+			gpios = <&gpio2 RK_PA4 GPIO_ACTIVE_LOW>;
-+
-+		};
-+		volume-down-button {
-+			label = "VOLUME-DOWN";
-+			linux,code = <KEY_VOLUMEDOWN>;
-+			gpios = <&gpio2 RK_PA1 GPIO_ACTIVE_LOW>;
-+
-+		};
 +	};
 +
 +	joypad: odroidgo2-joypad {
@@ -1375,7 +1356,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-powkiddy-rgb10.dts lin
 +		| sw15                                      sw16 |
 +		|        sw20                         sw21       |
 +		|------------------------------------------------|
-+		|    sw1  vol- |-------------------| vol+ sw8    |
++		|    sw1  sw10 |-------------------| sw13 sw8    |
 +		|  sw3   sw4   |                   |   sw7   sw5 |
 +		|     sw2      |    LCD Display    |      sw6    |
 +		|              |                   |             |
@@ -1432,12 +1413,12 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-powkiddy-rgb10.dts lin
 +                        linux,code = <BTN_TRIGGER_HAPPY1>; // 0x2c0
 +                };
 +                sw10 {
-+                        gpios = <&gpio3 RK_PB2 GPIO_ACTIVE_LOW>;
++                        gpios = <&gpio2 RK_PA1 GPIO_ACTIVE_LOW>;
 +                        label = "GPIO F2";
 +                        linux,code = <BTN_TRIGGER_HAPPY2>; // 0x2c1
 +                };
 +                sw13 {
-+                        gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
++                        gpios = <&gpio2 RK_PA4 GPIO_ACTIVE_LOW>;
 +                        label = "GPIO F5";
 +                        linux,code = <BTN_TRIGGER_HAPPY5>; // 0x2c4
 +                };


### PR DESCRIPTION
## Description

RGB10 related:
1. make '-' and '+' buttons part of controller in dts, instead of being the volume keys. aligned with oga_v11 this maked them THUMBL./L3 and THUMBR/R3. oga_v11 controllers are now identical to userspace.
2. Define the aforementioned buttons the preferred DEVICE_FUNC_KEYX_MODIFIERs. Not used yet, but I will update mednafen to use these modfiiers instead of using hardcoded buttons for hotkey purposes.
3. BUGFIX in setsettings: check if a controller has a hotkey_enable buttons defined and if so use that, and if not use select.
4. Quirk that modifies the oga_v11 retroarch controller so that '-' buttons is used as hotkey instead of select.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?
 
- [ x] This has been tested on rgb10
- [ ] MUST also be tested on a device which doesn't have the hotkey_enable button defined 
