### PR TITLE
LED control and scaling governor improvements.

### DIFF
--- a/packages/hardware/quirks/devices/AYANEO AIR Plus/bin/ledcontrol
+++ b/packages/hardware/quirks/devices/AYANEO AIR Plus/bin/ledcontrol
@@ -361,6 +361,18 @@ case ${1} in
     set_setting led.brightness ${2}
     ledcontrol $(get_setting led.color)
   ;;
+  list)
+    cat <<EOF
+default
+off
+red
+green
+blue
+teal
+purple
+white
+EOF
+  ;;
   *)
     COLOR=$(get_setting led.color)
     if [ ! -z "${COLOR}" ]

--- a/packages/hardware/quirks/devices/AYANEO AIR/bin/ledcontrol
+++ b/packages/hardware/quirks/devices/AYANEO AIR/bin/ledcontrol
@@ -166,6 +166,17 @@ case $1 in
       ledcontrol ${COLOR} ${LEDBRIGHTNESS}
     fi
   ;;
+  list)
+    cat <<EOF
+default
+off
+red
+green
+blue
+teal
+purple
+EOF
+  ;;
   *)
     COLOR=$(get_setting led.color)
     if [ ! -z "${COLOR}" ]

--- a/packages/hardware/quirks/devices/AYANEO AYANEO 2S/bin/ledcontrol
+++ b/packages/hardware/quirks/devices/AYANEO AYANEO 2S/bin/ledcontrol
@@ -174,6 +174,17 @@ case $1 in
       ledcontrol ${COLOR} ${LEDBRIGHTNESS}
     fi
   ;;
+  list)
+    cat <<EOF
+default
+off
+red
+green
+blue
+teal
+purple
+EOF
+  ;;
   *)
     COLOR=$(get_setting led.color)
     if [ ! -z "${COLOR}" ]

--- a/packages/hardware/quirks/devices/ayn Loki Max/bin/ledcontrol
+++ b/packages/hardware/quirks/devices/ayn Loki Max/bin/ledcontrol
@@ -144,12 +144,12 @@ case $1 in
   ;;
   white)
     off
-    COLOR=$(intensity 0x80 ${LEDBRIGHTNESS})
+    COLOR=$(intensity 0xFF ${LEDBRIGHTNESS})
     ec_set ${RGB_RED} ${COLOR}
     ec_set ${RGB_GREEN} ${COLOR}
     ec_set ${RGB_BLUE} ${COLOR}
     ec_save
-    set_setting led.color purple
+    set_setting led.color white
   ;;
   off)
     off
@@ -162,6 +162,18 @@ case $1 in
   brightness)
     set_setting led.brightness ${2}
     ledcontrol $(get_setting led.color)
+  ;;
+  list)
+    cat <<EOF
+default
+off
+red
+green
+blue
+teal
+purple
+white
+EOF
   ;;
   *)
     COLOR=$(get_setting led.color)

--- a/packages/hardware/quirks/devices/ayn Loki Zero/bin/ledcontrol
+++ b/packages/hardware/quirks/devices/ayn Loki Zero/bin/ledcontrol
@@ -144,12 +144,12 @@ case $1 in
   ;;
   white)
     off
-    COLOR=$(intensity 0x80 ${LEDBRIGHTNESS})
+    COLOR=$(intensity 0xFF ${LEDBRIGHTNESS})
     ec_set ${RGB_RED} ${COLOR}
     ec_set ${RGB_GREEN} ${COLOR}
     ec_set ${RGB_BLUE} ${COLOR}
     ec_save
-    set_setting led.color purple
+    set_setting led.color white
   ;;
   off)
     off
@@ -162,6 +162,18 @@ case $1 in
   brightness)
     set_setting led.brightness ${2}
     ledcontrol $(get_setting led.color)
+  ;;
+  list)
+    cat <<EOF
+default
+off
+red
+green
+blue
+teal
+purple
+white
+EOF
   ;;
   *)
     COLOR=$(get_setting led.color)

--- a/packages/jelos/autostart/008-perfmode
+++ b/packages/jelos/autostart/008-perfmode
@@ -20,10 +20,17 @@ else
 fi
 
 ### If we don't have a default governor set, set it
-### to schedutil but don't enable it.
+### to schedutil if the device supports it, otherwise
+### set to performance, but don't enable it.
 if [ -z "$(get_setting system.cpugovernor)" ]
 then
-  set_setting system.cpugovernor schedutil
+  GOVTEST="$(awk '/schedutil/ {print $1}' /sys/devices/system/cpu/cpufreq/policy0/scaling_available_governors)"
+  if [ -n "${GOVTEST}" ]
+  then
+    set_setting system.cpugovernor schedutil
+  else
+    set_setting system.cpugovernor performance
+  fi
 fi
 
 ### Set the default GPU performance mode

--- a/packages/jelos/config/system/configs/system.cfg
+++ b/packages/jelos/config/system/configs/system.cfg
@@ -172,7 +172,6 @@ syncthing.enabled=0
 system.autohotkeys=1
 system.automount=1
 system.battery.warning=1
-system.cpugovernor=schedutil
 system.hostname=@DEVICENAME@
 system.language=en_US
 system.loglevel=none


### PR DESCRIPTION
## Description

* LED Control should produce a list of colors for ES to consume.
* Fix white output on some devices that support it.
* Newer devices don't support schedutil so we should test before setting it on a fresh flash.

PR with emulation station update to follow.