### PR TITLE
Fix multiple startup bugs

### DIFF
--- a/packages/jelos/profile.d/001-functions
+++ b/packages/jelos/profile.d/001-functions
@@ -108,6 +108,16 @@ function sort_settings() {
 }
 
 function set_setting() {
+
+  if [ ! -d "/storage/.config/system/configs" ]
+  then
+    mkdir -p /storage/.config/system/configs
+  fi
+  if [ ! -e "/storage/.config/system/configs/system.cfg" ]
+  then
+    cp -f /usr/config/system/configs/system.cfg /storage/.config/system/configs/system.cfg
+  fi
+
   if [[ "${1}" =~ ^[[:alnum:]] ]]
   then
     del_setting "${1}"

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -74,7 +74,17 @@ pre_configure() {
 
 post_makeinstall_target() {
   make -C lib/et LIBMODE=644 DESTDIR=${SYSROOT_PREFIX} install
+
+  rm -rf ${INSTALL}/usr/sbin/badblocks
+  rm -rf ${INSTALL}/usr/sbin/blkid
+  rm -rf ${INSTALL}/usr/sbin/dumpe2fs
+  rm -rf ${INSTALL}/usr/sbin/e2freefrag
+  rm -rf ${INSTALL}/usr/sbin/e2undo
+  rm -rf ${INSTALL}/usr/sbin/e4defrag
+  #rm -rf ${INSTALL}/usr/sbin/filefrag
   rm -rf ${INSTALL}/usr/sbin/fsck
+  rm -rf ${INSTALL}/usr/sbin/logsave
+  rm -rf ${INSTALL}/usr/sbin/mklost+found
 }
 
 makeinstall_init() {

--- a/packages/sysutils/systemd/scripts/userconfig-setup
+++ b/packages/sysutils/systemd/scripts/userconfig-setup
@@ -10,16 +10,16 @@ if [ ! -e "/storage/.configured" ]
 then
   tocon "Initializing configuration..."
   # Copy config files
-  rsync -a --exclude={es_features.cfg,es_systems.cfg} /usr/config/* /storage/.config/ >/var/log/configure.log 2>&1
+  rsync -a --ignore-existing --exclude={es_features.cfg,es_systems.cfg} /usr/config/* /storage/.config/ >/var/log/configure.log 2>&1
 
   if [ -d "/usr/lib/autostart/quirks/platforms/${HW_DEVICE}/config" ]
   then
-    rsync -a --exclude={es_features.cfg,es_systems.cfg} /usr/lib/autostart/quirks/platforms/"${HW_DEVICE}"/config/* /storage/.config/ >>/var/log/configure.log 2>&1
+    rsync -a /usr/lib/autostart/quirks/platforms/"${HW_DEVICE}"/config/* /storage/.config/ >>/var/log/configure.log 2>&1
   fi
 
   if [ -d "/usr/lib/autostart/quirks/devices/${QUIRK_DEVICE}/config" ]
   then
-    rsync -a --exclude={es_features.cfg,es_systems.cfg} /usr/lib/autostart/quirks/devices/"${QUIRK_DEVICE}"/config/* /storage/.config/ >>/var/log/configure.log 2>&1
+    rsync -a /usr/lib/autostart/quirks/devices/"${QUIRK_DEVICE}"/config/* /storage/.config/ >>/var/log/configure.log 2>&1
   fi
 
   if [ -e "/usr/bin/emulationstation" ]
@@ -38,11 +38,11 @@ then
     do
       ln -s /usr/config/emulationstation/${es_cfg} /storage/.config/emulationstation/${es_cfg}  >/dev/null 2>&1
     done
-
   fi
 
   mkdir -p /storage/.config/modprobe.d  >/dev/null 2>&1
   touch /storage/.configured  >/dev/null 2>&1
+  sync
 fi
 
 if [ ! -e "/storage/.cache/ld.so.cache" ]

--- a/packages/sysutils/systemd/system.d/usercache.service
+++ b/packages/sysutils/systemd/system.d/usercache.service
@@ -2,6 +2,7 @@
 Description=Setup User cache dir
 DefaultDependencies=no
 After=systemd-tmpfiles-setup.service
+Before=automount.service autostart.service
 
 [Service]
 Type=oneshot

--- a/packages/sysutils/systemd/system.d/userconfig.service
+++ b/packages/sysutils/systemd/system.d/userconfig.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Setup User config dir
 DefaultDependencies=no
-After=systemd-tmpfiles-setup.service jelos-automount.service
+After=systemd-tmpfiles-setup.service
+Before=jelos-automount.service autostart.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
## Description

  * Revert enabling blkid in e2fsprogs, this conflicts with the busybox binary and causes partitions to fail to resize on first boot.
  * Optimize startup order and apply a guard to set_settings to ensure the system configuration exists before writing to it.  This resolves black screen issues that sometimes occur during the initial boot.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Tested on RK3566 devices that were failing to resize and start up correctly.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
