### PR TITLE
PR for release

### DIFF
--- a/packages/jelos/profile.d/001-functions
+++ b/packages/jelos/profile.d/001-functions
@@ -108,6 +108,16 @@ function sort_settings() {
 }
 
 function set_setting() {
+
+  if [ ! -d "/storage/.config/system/configs" ]
+  then
+    mkdir -p /storage/.config/system/configs
+  fi
+  if [ ! -e "/storage/.config/system/configs/system.cfg" ]
+  then
+    cp -f /usr/config/system/configs/system.cfg /storage/.config/system/configs/system.cfg
+  fi
+
   if [[ "${1}" =~ ^[[:alnum:]] ]]
   then
     del_setting "${1}"

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -74,7 +74,17 @@ pre_configure() {
 
 post_makeinstall_target() {
   make -C lib/et LIBMODE=644 DESTDIR=${SYSROOT_PREFIX} install
+
+  rm -rf ${INSTALL}/usr/sbin/badblocks
+  rm -rf ${INSTALL}/usr/sbin/blkid
+  rm -rf ${INSTALL}/usr/sbin/dumpe2fs
+  rm -rf ${INSTALL}/usr/sbin/e2freefrag
+  rm -rf ${INSTALL}/usr/sbin/e2undo
+  rm -rf ${INSTALL}/usr/sbin/e4defrag
+  #rm -rf ${INSTALL}/usr/sbin/filefrag
   rm -rf ${INSTALL}/usr/sbin/fsck
+  rm -rf ${INSTALL}/usr/sbin/logsave
+  rm -rf ${INSTALL}/usr/sbin/mklost+found
 }
 
 makeinstall_init() {

--- a/packages/sysutils/systemd/scripts/userconfig-setup
+++ b/packages/sysutils/systemd/scripts/userconfig-setup
@@ -10,16 +10,16 @@ if [ ! -e "/storage/.configured" ]
 then
   tocon "Initializing configuration..."
   # Copy config files
-  rsync -a --exclude={es_features.cfg,es_systems.cfg} /usr/config/* /storage/.config/ >/var/log/configure.log 2>&1
+  rsync -a --ignore-existing --exclude={es_features.cfg,es_systems.cfg} /usr/config/* /storage/.config/ >/var/log/configure.log 2>&1
 
   if [ -d "/usr/lib/autostart/quirks/platforms/${HW_DEVICE}/config" ]
   then
-    rsync -a --exclude={es_features.cfg,es_systems.cfg} /usr/lib/autostart/quirks/platforms/"${HW_DEVICE}"/config/* /storage/.config/ >>/var/log/configure.log 2>&1
+    rsync -a /usr/lib/autostart/quirks/platforms/"${HW_DEVICE}"/config/* /storage/.config/ >>/var/log/configure.log 2>&1
   fi
 
   if [ -d "/usr/lib/autostart/quirks/devices/${QUIRK_DEVICE}/config" ]
   then
-    rsync -a --exclude={es_features.cfg,es_systems.cfg} /usr/lib/autostart/quirks/devices/"${QUIRK_DEVICE}"/config/* /storage/.config/ >>/var/log/configure.log 2>&1
+    rsync -a /usr/lib/autostart/quirks/devices/"${QUIRK_DEVICE}"/config/* /storage/.config/ >>/var/log/configure.log 2>&1
   fi
 
   if [ -e "/usr/bin/emulationstation" ]
@@ -38,11 +38,11 @@ then
     do
       ln -s /usr/config/emulationstation/${es_cfg} /storage/.config/emulationstation/${es_cfg}  >/dev/null 2>&1
     done
-
   fi
 
   mkdir -p /storage/.config/modprobe.d  >/dev/null 2>&1
   touch /storage/.configured  >/dev/null 2>&1
+  sync
 fi
 
 if [ ! -e "/storage/.cache/ld.so.cache" ]

--- a/packages/sysutils/systemd/system.d/usercache.service
+++ b/packages/sysutils/systemd/system.d/usercache.service
@@ -2,6 +2,7 @@
 Description=Setup User cache dir
 DefaultDependencies=no
 After=systemd-tmpfiles-setup.service
+Before=automount.service autostart.service
 
 [Service]
 Type=oneshot

--- a/packages/sysutils/systemd/system.d/userconfig.service
+++ b/packages/sysutils/systemd/system.d/userconfig.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Setup User config dir
 DefaultDependencies=no
-After=systemd-tmpfiles-setup.service jelos-automount.service
+After=systemd-tmpfiles-setup.service
+Before=jelos-automount.service autostart.service
 
 [Service]
 Type=oneshot

--- a/projects/Rockchip/packages/u-boot/package.mk
+++ b/projects/Rockchip/packages/u-boot/package.mk
@@ -22,7 +22,7 @@ case ${DEVICE} in
     PKG_VERSION="88b2f26"
   ;;
   RK3399)
-    PKG_DEPENDS_TARGET+=" atf"
+    PKG_DEPENDS_TARGET+=" atf openssl:host"
     PKG_VERSION="2024.01"
     PKG_URL="https://ftp.denx.de/pub/u-boot/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
   ;;
@@ -81,7 +81,11 @@ setup_pkg_config_host
       fi
       DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm make mrproper
       DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm make ${UBOOT_CONFIG}
-      DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm _python_sysroot="${TOOLCHAIN}" _python_prefix=/ _python_exec_prefix=/ make HOSTCC="$HOST_CC" HOSTLDFLAGS="-L${TOOLCHAIN}/lib" HOSTSTRIP="true" CONFIG_MKIMAGE_DTC_PATH="scripts/dtc/dtc"
+      if [[ "${PKG_SOC}" =~ "rk3399" ]]; then
+        DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm _python_sysroot="${TOOLCHAIN}" _python_prefix=/ _python_exec_prefix=/ make HOSTCC="${HOST_CC}" HOSTCFLAGS="-I${TOOLCHAIN}/include" HOSTLDFLAGS="${HOST_LDFLAGS}" CONFIG_MKIMAGE_DTC_PATH="scripts/dtc/dtc"
+      else
+        DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm _python_sysroot="${TOOLCHAIN}" _python_prefix=/ _python_exec_prefix=/ make HOSTCC="$HOST_CC" HOSTLDFLAGS="-L${TOOLCHAIN}/lib" HOSTSTRIP="true" CONFIG_MKIMAGE_DTC_PATH="scripts/dtc/dtc"
+      fi
     fi
   fi
 }


### PR DESCRIPTION
## Change Log
### New Features
* JELOS now supports installing to EMMC on ARM!
  * On Weston devices, select the installer from the tools menu and choose your EMMC.
  * For RK3566, execute `installer` over an ssh connection to install JELOS to your EMMC.
  * An external keyboard is required to step through the installation menu.
  * Some devices are not configured to make the EMMC available to JELOS.
  * Not yet supported: Powkiddy x55, Anbernic RG552.
* Volume and brightness can now be controlled via R3 and the d-pad on the RGB10.
* System Information now displays internal/external storage utilization.
* Adds Portmaster controller layout support via EmulationStation.
* New software available: nvtop (panfrost only), weston-debug.
* JELOS now has initial support for MTP, thanks to @citral23!
  * Requires configuration over SSH as ES integration is still work in progress.
* LED control has been improved, including adding the color white on supported devices.
* Adds sorting of shaders, filters, and overlays in ES.  Thanks to @nayasis!
* JELOS now utilizes the Panfrost forcepack feature to offload texture compression to the GPU on supported devices.  Thanks to @chealy!
* Automount now places a readme in /storage/roms with instructions to create game directories. 
### Updates
* Our RK3399 and RK3326 platforms have been migrated to Linux kernel 6.7.0!
* RK3399 now uses mainline u-boot with arm trusted firmware, thanks to @LibreElec!
* Mesa 23.3.3.
* Mednafen 1.32.0.
* Systemd 255.2.
* Tailscale 1.56.1.
* Updated root certificates.
* Emulator updates (Citra-SA, Yuzu-SA).
### Bug Fixes
* Fix AYANEO 2S display remaining on when put to sleep.
* Primehack has been deprecated and removed from the project.
* Fixes a full factory reset issue on weston devices.
* Ensure userconfig setup runs after automount to correct a potential conflict during the initialization (first) boot.
* Pico 8 autostart script no longer creates the directory by default.  It is created when `Create Game Directories` is selected in System Settings.
* Fixes a bug preventing the eject option from appearing in EmulationStation when Merged Storage is disabled.
* Revert enabling blkid in e2fsprogs, this conflicts with the busybox binary and causes partitions to fail to resize on first boot.
* Optimize startup order and apply a guard to set_settings to ensure the system configuration exists before writing to it.  This resolves black screen issues that sometimes occur during the initial boot.