### PR TITLE
Fixing panel flicker and regulator voltages on XU10

### DIFF
--- a/projects/Rockchip/packages/linux/patches/RK3326/000-rk3326-dts.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3326/000-rk3326-dts.patch
@@ -283,7 +283,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts li
 +        };
 +};
 --- linux.orig/arch/arm64/boot/dts/rockchip/rk3326-magicx-xu10.dts	1969-12-31 19:00:00.000000000 -0500
-+++ linux/arch/arm64/boot/dts/rockchip/rk3326-magicx-xu10.dts	2024-01-18 16:30:20.464866143 -0500
++++ linux/arch/arm64/boot/dts/rockchip/rk3326-magicx-xu10.dts	2024-01-19 15:39:57.362135961 -0500
 @@ -0,0 +1,848 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
@@ -322,10 +322,9 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts li
 +
 +    backlight: backlight {
 +       compatible = "pwm-backlight";
-+       power-supply = <&vcc_bl>;
 +       pwms = <&pwm1 0 62745 0>;
 +       brightness-levels = <
-+         0   1   2   3   4   5   6   7
++                 2   3   4   5   6   7
 +         8   9  10  11  12  13  14  15
 +        16  17  18  19  20  21  22  23
 +        24  25  26  27  28  29  30  31
@@ -728,11 +727,11 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts li
 +
 +    internal_display: panel@0 {
 +        compatible = "magicx,xu10-panel", "sitronix,st7703";
-+        iovcc-supply = <&vcc_lcd>;
-+        vdd-supply = <&vcc_lcd>;
++        iovcc-supply = <&vcc18_lcd_n>;
++        vcc-supply = <&vcc18_lcd_n>;
 +        reg = <0>;
 +        backlight = <&backlight>;
-+        reset-gpios = <&gpio3 RK_PC0 GPIO_ACTIVE_LOW>;
++        reset-gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
 +
 +        port {
 +            mipi_in_panel: endpoint {
@@ -785,8 +784,8 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts li
 +    regulators {
 +        vdd_logic: DCDC_REG1 {
 +              regulator-name = "vdd_logic";
-+              regulator-min-microvolt = <950000>;
-+              regulator-max-microvolt = <1150000>;
++              regulator-min-microvolt = <850000>;
++              regulator-max-microvolt = <1350000>;
 +              regulator-ramp-delay = <6001>;
 +              regulator-always-on;
 +              regulator-boot-on;
@@ -799,7 +798,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts li
 +
 +        vdd_arm: DCDC_REG2 {
 +              regulator-name = "vdd_arm";
-+              regulator-min-microvolt = <950000>;
++              regulator-min-microvolt = <850000>;
 +              regulator-max-microvolt = <1350000>;
 +              regulator-ramp-delay = <6001>;
 +              regulator-always-on;
@@ -834,7 +833,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts li
 +              };
 +        };
 +
-+        vcc3v0_dvp:LDO_REG1 {
++        vcc3v0_dvp: LDO_REG1 {
 +              regulator-name = "vcc3v0_dvp";
 +              regulator-always-on;
 +              regulator-boot-on;
@@ -847,8 +846,8 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts li
 +              };
 +        };
 +
-+        vcc_1v8: LDO_REG2 {
-+              regulator-name = "vcc_1v8";
++        vcc1v8_soc: LDO_REG2 {
++              regulator-name = "vcc1v8_soc";
 +              regulator-min-microvolt = <1800000>;
 +              regulator-max-microvolt = <1800000>;
 +              regulator-always-on;
@@ -860,8 +859,8 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts li
 +              };
 +        };
 +
-+        vdd_1v0: LDO_REG3 {
-+              regulator-name = "vdd_1v0";
++        vdd1v0_soc: LDO_REG3 {
++              regulator-name = "vdd_1v0_soc";
 +              regulator-min-microvolt = <1000000>;
 +              regulator-max-microvolt = <1000000>;
 +              regulator-always-on;
@@ -911,25 +910,25 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts li
 +              };
 +        };
 +
-+        vcc_bl: LDO_REG7 {
-+              regulator-name = "vcc_bl";
-+              regulator-min-microvolt = <3300000>;
-+              regulator-max-microvolt = <3300000>;
-+
-+              regulator-state-mem {
-+              regulator-off-in-suspend;
-+                  regulator-suspend-microvolt = <3300000>;
-+              };
-+        };
-+
-+        vcc_lcd: LDO_REG8 {
-+              regulator-name = "vcc_lcd";
++        vcc2v8_dvp: LDO_REG7 {
++              regulator-name = "vcc2v8_dvp";
 +              regulator-min-microvolt = <2800000>;
 +              regulator-max-microvolt = <2800000>;
 +
 +              regulator-state-mem {
-+                  regulator-off-in-suspend;
++              regulator-off-in-suspend;
 +                  regulator-suspend-microvolt = <2800000>;
++              };
++        };
++
++        vcc18_lcd_n: LDO_REG8 {
++              regulator-name = "vcc18_lcd_n";
++              regulator-min-microvolt = <1800000>;
++              regulator-max-microvolt = <1800000>;
++
++              regulator-state-mem {
++                  regulator-off-in-suspend;
++                  regulator-suspend-microvolt = <1800000>;
 +              };
 +        };
 +
@@ -967,7 +966,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts li
 +};
 +
 +&io_domains {
-+    vccio1-supply = <&vcc_1v8>;
++    vccio1-supply = <&vcc1v8_soc>;
 +    vccio2-supply = <&vccio_sd>;
 +    vccio3-supply = <&vcc3v0_dvp>;
 +    vccio4-supply = <&vcc_3v0>;
@@ -999,7 +998,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts li
 +};
 +
 +&saradc {
-+    vref-supply = <&vcc_1v8>;
++    vref-supply = <&vcc1v8_soc>;
 +    status = "okay";
 +};
 +
@@ -1028,6 +1027,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts li
 +    sd-uhs-sdr50;
 +    sd-uhs-sdr104;
 +    vmmc-supply = <&vcc_sd>;
++    vqmmc-supply = <&vccio_sd>;
 +    status = "okay";
 +};
 +

--- a/projects/Rockchip/packages/linux/patches/RK3326/001-panel-updates.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3326/001-panel-updates.patch
@@ -498,7 +498,7 @@ diff -rupN linux.orig/drivers/gpu/drm/panel/panel-newvision-nv3051d.c linux/driv
 +	.vsync_start	= 480 + 17,
 +	.vsync_end	= 480 + 17 + 4,
 +	.vtotal		= 480 + 17 + 4 + 13,
-+	.clock		= 27438,
++	.clock		= 30000,
 +	.flags		= DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC,
 +	.width_mm	= 70,
 +	.height_mm	= 52,


### PR DESCRIPTION


# Pull Request Template

## Description

Reviewing the voltage regulators to match the source tree as possible. 

Panel is actually designed for 1.8v on vcc and vccio, changing regulator to match. Also, changing pixel clock to 30mhz to match original panel device tree

This fixes an issue where the overvoltage on vccio would cause panel abnormalities and flicker after ~30 minutes of screen time, as well as likely some better efficiency on the SOC due to lower min voltages.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

- [ ] Ran different emulators and changed screens, left drastic open on for an hour or so to observe panel flicker degradation. 


**Test Configuration**:
* Build OS name and version: Ubuntu 22.04
* Docker (Y/N): Y
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
