### PR TITLE
Switch back to the g13 driver, as we're still able to recreate the crash.

### DIFF
--- a/projects/Rockchip/devices/RK3566-X55/options
+++ b/projects/Rockchip/devices/RK3566-X55/options
@@ -51,7 +51,7 @@
  
   # Mali GPU family
     MALI_FAMILY="bifrost-g52"
-    MALI_VERSION="g2p0"
+    MALI_VERSION="g13p0"
     OPENGLES="libmali"
     VULKAN_SUPPORT="no"
 

--- a/projects/Rockchip/devices/RK3566/options
+++ b/projects/Rockchip/devices/RK3566/options
@@ -51,7 +51,7 @@
  
   # Mali GPU family
     MALI_FAMILY="bifrost-g52"
-    MALI_VERSION="g2p0"
+    MALI_VERSION="g13p0"
     OPENGLES="libmali"
     VULKAN_SUPPORT="no"
 


### PR DESCRIPTION
This may be a hardware flaw as there is no indication of anything at all in the log that anything is wrong.
