### PR TITLE
Adding support for r36s panel driver

### DIFF
--- a/projects/Rockchip/packages/linux/patches/RK3326/001-panel-updates.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3326/001-panel-updates.patch
@@ -64,7 +64,7 @@ diff -rupN linux.orig/drivers/gpu/drm/panel/panel-newvision-nv3051d.c linux/driv
  };
  MODULE_DEVICE_TABLE(of, newvision_nv3051d_of_match);
 --- linux.orig/drivers/gpu/drm/panel/panel-sitronix-st7703.c	2024-01-17 13:11:54.938356637 -0500
-+++ linux/drivers/gpu/drm/panel/panel-sitronix-st7703.c	2024-01-17 12:48:04.770060000 -0500
++++ linux/drivers/gpu/drm/panel/panel-sitronix-st7703.c	2024-01-21 10:26:31.549710031 -0500
 @@ -13,7 +13,7 @@
  #include <linux/media-bus-format.h>
  #include <linux/mod_devicetable.h>
@@ -404,7 +404,7 @@ diff -rupN linux.orig/drivers/gpu/drm/panel/panel-newvision-nv3051d.c linux/driv
  	.hdisplay	= 640,
  	.hsync_start	= 640 + 40,
  	.hsync_end	= 640 + 40 + 2,
-@@ -424,15 +452,117 @@ static const struct drm_display_mode rg3
+@@ -424,15 +452,210 @@ static const struct drm_display_mode rg3
  	.height_mm	= 57,
  };
  
@@ -500,8 +500,8 @@ diff -rupN linux.orig/drivers/gpu/drm/panel/panel-newvision-nv3051d.c linux/driv
 +	.vtotal		= 480 + 17 + 4 + 13,
 +	.clock		= 30000,
 +	.flags		= DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC,
-+	.width_mm	= 70,
-+	.height_mm	= 52,
++	.width_mm	= 52,
++	.height_mm	= 70,
 +};
 +
 +static const struct st7703_panel_desc xu10_desc = {
@@ -514,6 +514,99 @@ diff -rupN linux.orig/drivers/gpu/drm/panel/panel-newvision-nv3051d.c linux/driv
 +	.init_sequence = xu10_init_sequence,
  };
  
++static int r36s_init_sequence(struct st7703 *ctx)
++{
++	struct mipi_dsi_device *dsi = to_mipi_dsi_device(ctx->dev);
++
++	/*
++	 * Init sequence was supplied by the panel vendor.
++	 */
++
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETEXTC, 0xf1, 0x12, 0x83);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETAPID, 0x00, 0x00, 0x00,
++			       0xda, 0x80);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETDISP, 0x00, 0x13, 0x70);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETRGBIF, 0x10, 0x10, 0x28,
++			       0x28, 0x03, 0xff, 0x00, 0x00, 0x00, 0x00);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETCYC, 0x80);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETBGP, 0x0a, 0x0a);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETVCOM, 0x7f, 0x7f);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETPOWER_EXT, 0x26, 0x62,
++			       0xf0, 0x63);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETMIPI, 0x33, 0x81, 0x05,
++			       0xf9, 0x0e, 0x0e, 0x20, 0x00, 0x00, 0x00, 0x00,
++			       0x00, 0x00, 0x00, 0x44, 0x25, 0x00, 0x90, 0x0a,
++			       0x00, 0x00, 0x01, 0x4f, 0x01, 0x00, 0x00, 0x37);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETVDC, 0x47);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_UNKNOWN_BF, 0x02, 0x11, 0x00);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETSCR, 0x73, 0x73, 0x50, 0x50,
++			       0x00, 0x00, 0x12, 0x50, 0x00);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETPOWER, 0x53, 0xc0, 0x32,
++			       0x32, 0x77, 0xe1, 0xdd, 0xdd, 0x77, 0x77, 0x33,
++			       0x33);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETECO, 0x82, 0x00, 0xbf, 0xff,
++			       0x00, 0xff);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETIO, 0xb8, 0x00, 0x0a, 0x00,
++			       0x00, 0x00);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETCABC, 0x10, 0x40, 0x1e,
++			       0x02);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETPANEL, 0x0b);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETGAMMA, 0x00, 0x07, 0x0d,
++			       0x37, 0x35, 0x3f, 0x41, 0x44, 0x06, 0x0c, 0x0d,
++			       0x0f, 0x11, 0x10, 0x12, 0x14, 0x1a, 0x00, 0x07,
++			       0x0d, 0x37, 0x35, 0x3f, 0x41, 0x44, 0x06, 0x0c,
++			       0x0d, 0x0f, 0x11, 0x10, 0x12, 0x14, 0x1a);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETEQ, 0x07, 0x07, 0x0b, 0x0b,
++			       0x0b, 0x0b, 0x00, 0x00, 0x00, 0x00, 0xff, 0x00,
++			       0xc0, 0x10);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETGIP1, 0xc8, 0x10, 0x02, 0x00,
++			       0x00, 0xb0, 0xb1, 0x11, 0x31, 0x23, 0x28, 0x80,
++			       0xb0, 0xb1, 0x27, 0x08, 0x00, 0x04, 0x02, 0x00,
++			       0x00, 0x00, 0x00, 0x04, 0x02, 0x00, 0x00, 0x00,
++			       0x88, 0x88, 0xba, 0x60, 0x24, 0x08, 0x88, 0x88,
++			       0x88, 0x88, 0x88, 0x88, 0x88, 0xba, 0x71, 0x35,
++			       0x18, 0x88, 0x88, 0x88, 0x88, 0x88, 0x00, 0x00,
++			       0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++			       0x00, 0x00, 0x00);
++	dsi_dcs_write_seq(dsi, ST7703_CMD_SETGIP2, 0x97, 0x0a, 0x82, 0x02,
++			       0x03, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++			       0x81, 0x88, 0xba, 0x17, 0x53, 0x88, 0x88, 0x88,
++			       0x88, 0x88, 0x88, 0x80, 0x88, 0xba, 0x06, 0x42,
++			       0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x23, 0x00,
++			       0x00, 0x02, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
++			       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++			       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++			       0x00);
++	
++	dsi_dcs_write_seq(dsi, ST7703_CMD_UNKNOWN_EF, 0xff, 0xff, 0x01, 0x05, 0xc8, 0x01, 0x11, 0x05, 0x32, 0x01, 0x29);
++
++	return 0;
++}
++
++static const struct drm_display_mode r36s_mode = {
++	.hdisplay		= 640,
++	.hsync_start	= 640 + 450,
++	.hsync_end		= 640 + 450 + 70,
++	.htotal			= 640 + 450 + 70 + 450,
++	.vdisplay		= 480,
++	.vsync_start	= 480 + 17,
++	.vsync_end		= 480 + 17 + 5,
++	.vtotal			= 480 + 17 + 5 + 13,
++	.clock			= 50000,
++	.flags			= DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC,
++	.width_mm		= 52,
++	.height_mm		= 70,
++};
++
++static const struct st7703_panel_desc r36s_desc = {
++	.mode = &r36s_mode,
++	.lanes = 4,
++	.mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
++		      MIPI_DSI_MODE_NO_EOT_PACKET | MIPI_DSI_MODE_LPM,
++	.format = MIPI_DSI_FMT_RGB888,
++	.init_sequence = r36s_init_sequence,
++};
++
 +#define dsi_generic_write_seq(dsi, seq...) do {				\
 +		static const u8 d[] = { seq };				\
 +		int ret;						\
@@ -525,7 +618,7 @@ diff -rupN linux.orig/drivers/gpu/drm/panel/panel-newvision-nv3051d.c linux/driv
  static int rgb30panel_init_sequence(struct st7703 *ctx)
  {
  	struct mipi_dsi_device *dsi = to_mipi_dsi_device(ctx->dev);
-@@ -446,31 +576,31 @@ static int rgb30panel_init_sequence(stru
+@@ -446,31 +669,31 @@ static int rgb30panel_init_sequence(stru
  	mipi_dsi_dcs_exit_sleep_mode(dsi);
  	msleep(250);
  
@@ -572,7 +665,7 @@ diff -rupN linux.orig/drivers/gpu/drm/panel/panel-newvision-nv3051d.c linux/driv
  			       0x0f, 0xa1, 0x80, 0x12, 0x31, 0x23, 0x47, 0x86,
  			       0xa1, 0x80, 0x47, 0x08, 0x00, 0x00, 0x0d, 0x00,
  			       0x00, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00,
-@@ -479,7 +609,7 @@ static int rgb30panel_init_sequence(stru
+@@ -479,7 +702,7 @@ static int rgb30panel_init_sequence(stru
  			       0x13, 0x88, 0x88, 0x88, 0x88, 0x88, 0x00, 0x00,
  			       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
  			       0x00, 0x00, 0x00);
@@ -581,7 +674,7 @@ diff -rupN linux.orig/drivers/gpu/drm/panel/panel-newvision-nv3051d.c linux/driv
  			       0x01, 0x78, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
  			       0x4f, 0x31, 0x8b, 0xa8, 0x31, 0x75, 0x88, 0x88,
  			       0x88, 0x88, 0x88, 0x4f, 0x20, 0x8b, 0xa8, 0x20,
-@@ -488,7 +618,7 @@ static int rgb30panel_init_sequence(stru
+@@ -488,7 +711,7 @@ static int rgb30panel_init_sequence(stru
  			       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
  			       0x00, 0x00, 0x40, 0xa1, 0x80, 0x00, 0x00, 0x00,
  			       0x00);
@@ -590,7 +683,7 @@ diff -rupN linux.orig/drivers/gpu/drm/panel/panel-newvision-nv3051d.c linux/driv
  			       0x29, 0x3b, 0x3f, 0x42, 0x39, 0x06, 0x0d, 0x10,
  			       0x13, 0x15, 0x14, 0x15, 0x10, 0x17, 0x00, 0x0a,
  			       0x0f, 0x29, 0x3b, 0x3f, 0x42, 0x39, 0x06, 0x0d,
-@@ -667,7 +797,7 @@ static int allpixelson_set(void *data, u
+@@ -667,7 +890,7 @@ static int allpixelson_set(void *data, u
  	struct mipi_dsi_device *dsi = to_mipi_dsi_device(ctx->dev);
  
  	dev_dbg(ctx->dev, "Setting all pixels on\n");
@@ -599,17 +692,18 @@ diff -rupN linux.orig/drivers/gpu/drm/panel/panel-newvision-nv3051d.c linux/driv
  	msleep(val * 1000);
  	/* Reset the panel to get video back */
  	drm_panel_disable(&ctx->panel);
-@@ -783,7 +913,8 @@ static void st7703_remove(struct mipi_ds
+@@ -783,7 +1006,9 @@ static void st7703_remove(struct mipi_ds
  }
  
  static const struct of_device_id st7703_of_match[] = {
 -	{ .compatible = "anbernic,rg353v-panel-v2", .data = &rg353v2_desc },
++	{ .compatible = "gameconsole,r36s-panel", .data = &r36s_desc },
 +	{ .compatible = "magicx,xu10-panel", .data = &xu10_desc },
 +	{ .compatible = "anbernic,rg351v-panel-v2", .data = &rg351v2_desc },
  	{ .compatible = "powkiddy,rgb30-panel", .data = &rgb30panel_desc },
  	{ .compatible = "rocktech,jh057n00900", .data = &jh057n00900_panel_desc },
  	{ .compatible = "xingbangda,xbd599", .data = &xbd599_desc },
-@@ -802,6 +933,6 @@ static struct mipi_dsi_driver st7703_dri
+@@ -802,6 +1027,6 @@ static struct mipi_dsi_driver st7703_dri
  };
  module_mipi_dsi_driver(st7703_driver);
  


### PR DESCRIPTION
# Pull Request Template

## Description

R36s has unique initialization and panel display mode information. Adding a new descriptor to the st7703 driver to handle it (as it is not an elida panel as indicated in original dtb).

Also made a small change to the xu10 panel to have the width and height match the original dtb.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

I am unable to directly test this panel change, but I did a formatted diff of the initialization sequence provided in the source dtb versus another st7703 initialization sequence and initialized all parameters based off of that. Then, performed a full build and image to verify the new panel mode does not affect anywhere else.

**Test Configuration**:
* Build OS name and version: Ubuntu 22.04
* Docker (Y/N): Y
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
