### PR TITLE
Unifying input mappings for fileman tool

### DIFF
--- a/packages/misc/modules/sources/fileman.sh
+++ b/packages/misc/modules/sources/fileman.sh
@@ -4,7 +4,11 @@
 # Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
+gptokeyb fileman textinput &
+
 . /etc/profile
 jslisten set "FileMan"
 
 fileman
+
+killall gptokeyb &


### PR DESCRIPTION

# Pull Request Template

## Description

Updating the fileman bash script to bind gptokeyb prior to launching fileman. This will allow all devices to automatically bind to the same inputs as long as they have SDL2 entries for their gamepad.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Ran initial fileman test, resulting in improper input mappings due to the controls being mapped at the chipset level.  
Created initial changes in sources and generated a patch to apply to def.h, and updated fileman.sh to spin up gptokeyb
verified controls now worked

**Test Configuration**:
* Build OS name and version: ubuntu 22.04
* Docker (Y/N): y
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
