### PR TITLE
busybox: fix resizing nvme parititons on orange pi 5

### DIFF
--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -22,7 +22,7 @@ if [ -e /storage/.please_resize_me ] ; then
 
   # get the disk. /storage on 2nd partition
   PART=$(blkid | awk 'BEGIN {FS=":"} /'$(cat /proc/cmdline | sed -e 's#^.*disk=UUID=##g' -e 's#\ .*$##g')'/ {print $1}')
-  if [ "$(echo ${PART} | awk '/mmcblk/ {print $1}')" ]
+  if [ "$(echo ${PART} | awk '/mmcblk/ || /nvme/ {print $1}')" ]
   then
     DISK=$(echo ${PART} | sed s/p[0-9]//g)
     PARTNUM=$(echo ${PART} | sed "s#^.*[0-9]p##g")


### PR DESCRIPTION
This fixes a specific use case of booting from NVME partitions on the Orange Pi 5

JELOS=/dev/nvme0n1p3
STORAGE=/dev/nvme0n1p4