### PR TITLE
Rgb10max3 inital support

### DIFF
--- a/packages/hardware/quirks/devices/Powkiddy RGB10MAX3/050-game_configs
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10MAX3/050-game_configs
@@ -1,0 +1,14 @@
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
+
+. /etc/profile
+
+#Set up gzdoom
+if [ ! -d "/storage/.config/gzdoom/" ]; then
+  cp -rf /usr/config/gzdoom /storage/.config/
+  sed -i '/Joy10=/c\Joy10=togglemap;
+          /Joy9=/c\Joy9=menu_main;
+          /vid_defheight=/c\vid_defheight=720;
+          /vid_defwidth=/c\vid_defwidth=1280' /storage/.config/gzdoom/gzdoom.ini
+fi

--- a/projects/Rockchip/devices/RK3566/options
+++ b/projects/Rockchip/devices/RK3566/options
@@ -32,7 +32,7 @@
     PARTITION_TABLE="gpt"
     UBOOT_LABEL="uboot"
     TRUST_LABEL="trust"
-    DEVICE_DTB=("rk3566-anbernic-rg353ps" "rk3566-anbernic-rg353vs" "rk3566-anbernic-rg503" "rk3566-anbernic-rg353p" "rk3566-anbernic-rg353v" "rk3566-powkiddy-rk2023" "rk3566-powkiddy-rgb30")
+    DEVICE_DTB=("rk3566-anbernic-rg353ps" "rk3566-anbernic-rg353vs" "rk3566-anbernic-rg503" "rk3566-anbernic-rg353p" "rk3566-anbernic-rg353v" "rk3566-powkiddy-rk2023" "rk3566-powkiddy-rgb30" "rk3566-powkiddy-rgb10max3")
     UBOOT_DTB="rk3566"
     UBOOT_CONFIG="anbernic-rgxx3-rk3566_defconfig"
     PKG_SOC="rk3568"

--- a/projects/Rockchip/packages/linux/patches/RK3566/010-powkiddy-rgb10max3.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3566/010-powkiddy-rgb10max3.patch
@@ -47,7 +47,7 @@ index 000000000000..26884dfda818
 +		reset-gpios = <&gpio4 RK_PA0 GPIO_ACTIVE_LOW>;
 +		vcc-supply = <&vcc3v3_lcd0_n>;
 +		iovcc-supply = <&vcc3v3_lcd0_n>;
-+		rotation = <270>;
++		rotation = <90>;
 +
 +		port {
 +			mipi_in_panel: endpoint {
@@ -57,7 +57,7 @@ index 000000000000..26884dfda818
 +	};
 +};
 diff --git a/drivers/gpu/drm/panel/panel-sitronix-st7703.c b/drivers/gpu/drm/panel/panel-sitronix-st7703.c
-index b55bafd1a8be..0e80bc8c0d21 100644
+index b55bafd1a8be..99db98f46dcb 100644
 --- a/drivers/gpu/drm/panel/panel-sitronix-st7703.c
 +++ b/drivers/gpu/drm/panel/panel-sitronix-st7703.c
 @@ -59,6 +59,7 @@ struct st7703 {
@@ -151,9 +151,9 @@ index b55bafd1a8be..0e80bc8c0d21 100644
  
 +static const struct drm_display_mode rgb10max3panel_mode = {
 +	.hdisplay	    = 720,
-+	.hsync_start	= 720 + 20,
-+	.hsync_end	    = 720 + 20 + 10,
-+	.htotal		    = 720 + 20 + 10 + 20,
++	.hsync_start	= 720 + 60,
++	.hsync_end	    = 720 + 60 + 10,
++	.htotal		    = 720 + 60 + 10 + 20,
 +	.vdisplay	    = 1280,
 +	.vsync_start	= 1280 + 16,
 +	.vsync_end	    = 1280 + 16 + 4,

--- a/projects/Rockchip/packages/linux/patches/RK3566/010-powkiddy-rgb10max3.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3566/010-powkiddy-rgb10max3.patch
@@ -1,0 +1,232 @@
+diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
+index b7371afb6227..2ee31fc6bd8e 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -79,6 +79,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-anbernic-rg503.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-pinenote-v1.1.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-pinenote-v1.2.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-powkiddy-rgb30.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-powkiddy-rgb10max3.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-powkiddy-rk2023.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-quartz64-a.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-quartz64-b.dtb
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rgb10max3.dts b/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rgb10max3.dts
+new file mode 100644
+index 000000000000..26884dfda818
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rgb10max3.dts
+@@ -0,0 +1,40 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/linux-event-codes.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++#include "rk3566-powkiddy-rk2023.dtsi"
++
++/ {
++	model = "Powkiddy RGB10MAX3";
++	compatible = "powkiddy,rgb10max3", "rockchip,rk3566";
++};
++
++&cru {
++	assigned-clocks = <&pmucru CLK_RTC_32K>, <&cru PLL_GPLL>,
++			  <&pmucru PLL_PPLL>, <&cru PLL_VPLL>;
++	assigned-clock-rates = <32768>, <1200000000>,
++			       <200000000>, <292500000>;
++};
++
++&dsi0 {
++	panel: panel@0 {
++		compatible = "powkiddy,rgb10max3-panel";
++		reg = <0>;
++		backlight = <&backlight>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&lcd_rst>;
++		reset-gpios = <&gpio4 RK_PA0 GPIO_ACTIVE_LOW>;
++		vcc-supply = <&vcc3v3_lcd0_n>;
++		iovcc-supply = <&vcc3v3_lcd0_n>;
++		rotation = <270>;
++
++		port {
++			mipi_in_panel: endpoint {
++				remote-endpoint = <&mipi_out_panel>;
++			};
++		};
++	};
++};
+diff --git a/drivers/gpu/drm/panel/panel-sitronix-st7703.c b/drivers/gpu/drm/panel/panel-sitronix-st7703.c
+index b55bafd1a8be..0e80bc8c0d21 100644
+--- a/drivers/gpu/drm/panel/panel-sitronix-st7703.c
++++ b/drivers/gpu/drm/panel/panel-sitronix-st7703.c
+@@ -59,6 +59,7 @@ struct st7703 {
+ 	struct regulator *vcc;
+ 	struct regulator *iovcc;
+ 	bool prepared;
++	enum drm_panel_orientation orientation;
+ 
+ 	struct dentry *debugfs;
+ 	const struct st7703_panel_desc *desc;
+@@ -493,6 +494,76 @@ static int rgb30panel_init_sequence(struct st7703 *ctx)
+ 			       0x13, 0x15, 0x14, 0x15, 0x10, 0x17, 0x00, 0x0a,
+ 			       0x0f, 0x29, 0x3b, 0x3f, 0x42, 0x39, 0x06, 0x0d,
+ 			       0x10, 0x13, 0x15, 0x14, 0x15, 0x10, 0x17);
++	return 0;
++}
++
++static int rgb10max3_init_sequence(struct st7703 *ctx)
++{
++	struct mipi_dsi_device *dsi = to_mipi_dsi_device(ctx->dev);
++
++	/*
++	 * Init sequence was supplied by the panel vendor.
++	 */
++
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETEXTC, 0xf1, 0x12, 0x83);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETAPID, 0x00, 0x00, 0x00,
++			       0xda, 0x80);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETDISP, 0xc8, 0x02, 0x30);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETRGBIF, 0x10, 0x10, 0x28,
++			       0x28, 0x03, 0xff, 0x00, 0x00, 0x00, 0x00);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETCYC, 0x80);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETBGP, 0x04, 0x04);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETVCOM, 0x78, 0x78);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETPOWER_EXT, 0x25, 0x22, 0xf0,
++			       0x63);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETMIPI, 0x33, 0x81, 0x05, 0xf9,
++			       0x0e, 0x0e, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00,
++			       0x00, 0x00, 0x44, 0x25, 0x00, 0x90, 0x0a, 0x00,
++			       0x00, 0x01, 0x4f, 0x01, 0x00, 0x00, 0x37);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETVDC, 0x47);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_UNKNOWN_BF, 0x02, 0x11, 0x00);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETSCR, 0x73, 0x73, 0x50, 0x50,
++			       0x00, 0x00, 0x12, 0x70, 0x00);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETPOWER, 0x25, 0x00, 0x32,
++			       0x32, 0x77, 0xe1, 0xff, 0xff, 0xcc, 0xcc, 0x77,
++			       0x77);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETECO, 0x82, 0x00, 0xbf, 0xff,
++			       0x00, 0xff);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETIO, 0xb8, 0x00, 0x0a, 0x00,
++			       0x00, 0x00);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETCABC, 0x10, 0x40, 0x1e,
++			       0x02);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETPANEL, 0x0b);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETGAMMA, 0x00, 0x04, 0x07,
++			       0x2a, 0x39, 0x3f, 0x36, 0x31, 0x06, 0x0b, 0x0e,
++			       0x12, 0x14, 0x12, 0x13, 0x0f, 0x17, 0x00, 0x04,
++			       0x07, 0x2a, 0x39, 0x3f, 0x36, 0x31, 0x06, 0x0b,
++			       0x0e, 0x12, 0x14, 0x12, 0x13, 0x0f, 0x17);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETEQ, 0x03, 0x03, 0x03, 0x03,
++			       0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0xff, 0x80,
++			       0xc0, 0x10);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETGIP1, 0xc8, 0x10, 0x08, 0x00,
++			       0x00, 0x41, 0xf8, 0x12, 0x31, 0x23, 0x37, 0x86,
++			       0x11, 0xc8, 0x37, 0x2a, 0x00, 0x00, 0x0c, 0x00,
++			       0x00, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00,
++			       0x88, 0x20, 0x46, 0x02, 0x88, 0x88, 0x88, 0x88,
++			       0x88, 0x88, 0xff, 0x88, 0x31, 0x57, 0x13, 0x88,
++			       0x88, 0x88, 0x88, 0x88, 0x88, 0xff, 0x00, 0x00,
++			       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++			       0x00, 0x00, 0x00);
++	mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_SETGIP2, 0x00, 0x1a, 0x00, 0x00,
++			       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++			       0x8f, 0x13, 0x31, 0x75, 0x88, 0x88, 0x88, 0x88,
++			       0x88, 0x88, 0xf8, 0x8f, 0x02, 0x20, 0x64, 0x88,
++			       0x88, 0x88, 0x88, 0x88, 0x88, 0xf8, 0x00, 0x00,
++			       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++			       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++			       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++			       0x00);
++    mipi_dsi_dcs_write_seq(dsi, ST7703_CMD_UNKNOWN_EF, 0xff, 0xff, 0x01);
++
++
++
+ 
+ 	return 0;
+ }
+@@ -512,6 +583,21 @@ static const struct drm_display_mode rgb30panel_mode = {
+ 	.height_mm	= 76,
+ };
+ 
++static const struct drm_display_mode rgb10max3panel_mode = {
++	.hdisplay	    = 720,
++	.hsync_start	= 720 + 20,
++	.hsync_end	    = 720 + 20 + 10,
++	.htotal		    = 720 + 20 + 10 + 20,
++	.vdisplay	    = 1280,
++	.vsync_start	= 1280 + 16,
++	.vsync_end	    = 1280 + 16 + 4,
++	.vtotal		    = 1280 + 16 + 4 + 14,
++	.clock		= 60000,
++	.flags		= DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC,
++	.width_mm	= 63,
++	.height_mm	= 111,
++};
++
+ static const struct st7703_panel_desc rgb30panel_desc = {
+ 	.mode = &rgb30panel_mode,
+ 	.lanes = 4,
+@@ -521,6 +607,15 @@ static const struct st7703_panel_desc rgb30panel_desc = {
+ 	.init_sequence = rgb30panel_init_sequence,
+ };
+ 
++static const struct st7703_panel_desc rgb10max3panel_desc = {
++	.mode = &rgb10max3panel_mode,
++	.lanes = 4,
++	.mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
++		      MIPI_DSI_MODE_NO_EOT_PACKET | MIPI_DSI_MODE_LPM,
++	.format = MIPI_DSI_FMT_RGB888,
++	.init_sequence = rgb10max3_init_sequence,
++};
++
+ static int st7703_enable(struct drm_panel *panel)
+ {
+ 	struct st7703 *ctx = panel_to_st7703(panel);
+@@ -649,16 +744,25 @@ static int st7703_get_modes(struct drm_panel *panel,
+ 	drm_display_info_set_bus_formats(&connector->display_info,
+ 					 mantix_bus_formats,
+ 					 ARRAY_SIZE(mantix_bus_formats));
++	drm_connector_set_panel_orientation(connector, ctx->orientation);
+ 
+ 	return 1;
+ }
+ 
++static enum drm_panel_orientation st7703_get_orientation(struct drm_panel *panel)
++{
++	struct st7703 *ctx = panel_to_st7703(panel);
++
++	return ctx->orientation;
++}
++
+ static const struct drm_panel_funcs st7703_drm_funcs = {
+ 	.disable   = st7703_disable,
+ 	.unprepare = st7703_unprepare,
+ 	.prepare   = st7703_prepare,
+ 	.enable	   = st7703_enable,
+ 	.get_modes = st7703_get_modes,
++	.get_orientation = st7703_get_orientation,
+ };
+ 
+ static int allpixelson_set(void *data, u64 val)
+@@ -727,6 +831,12 @@ static int st7703_probe(struct mipi_dsi_device *dsi)
+ 		return dev_err_probe(dev, PTR_ERR(ctx->iovcc),
+ 				     "Failed to request iovcc regulator\n");
+ 
++	ret = of_drm_get_panel_orientation(dev->of_node, &ctx->orientation);
++	if (ret < 0) {
++		dev_err(dev, "%pOF: failed to get orientation %d\n", dev->of_node, ret);
++		return ret;
++	}
++
+ 	drm_panel_init(&ctx->panel, dev, &st7703_drm_funcs,
+ 		       DRM_MODE_CONNECTOR_DSI);
+ 
+@@ -785,6 +895,7 @@ static void st7703_remove(struct mipi_dsi_device *dsi)
+ static const struct of_device_id st7703_of_match[] = {
+ 	{ .compatible = "anbernic,rg353v-panel-v2", .data = &rg353v2_desc },
+ 	{ .compatible = "powkiddy,rgb30-panel", .data = &rgb30panel_desc },
++	{ .compatible = "powkiddy,rgb10max3-panel", .data = &rgb10max3panel_desc },
+ 	{ .compatible = "rocktech,jh057n00900", .data = &jh057n00900_panel_desc },
+ 	{ .compatible = "xingbangda,xbd599", .data = &xbd599_desc },
+ 	{ /* sentinel */ }

--- a/projects/Rockchip/packages/u-boot/patches/RK3566/004-rgb10max3.patch
+++ b/projects/Rockchip/packages/u-boot/patches/RK3566/004-rgb10max3.patch
@@ -1,0 +1,26 @@
+diff --git a/board/anbernic/rgxx3_rk3566/rgxx3-rk3566.c b/board/anbernic/rgxx3_rk3566/rgxx3-rk3566.c
+index 194605ff06..ee498631ba 100644
+--- a/board/anbernic/rgxx3_rk3566/rgxx3-rk3566.c
++++ b/board/anbernic/rgxx3_rk3566/rgxx3-rk3566.c
+@@ -49,6 +49,7 @@ enum rgxx3_device_id {
+ 	RG353V,
+ 	RG503,
+ 	RGB30,
++	RGB10MAX3,
+ 	RK2023,
+ 	RGARCD,
+ 	/* Devices with duplicate ADC value */
+@@ -94,6 +95,13 @@ static const struct rg3xx_model rg3xx_model_details[] = {
+ 		.fdtfile = DTB_DIR "rk3566-powkiddy-rgb30.dtb",
+ 		.detect_panel = 0,
+ 	},
++	[RGB10MAX3] = {
++		.adc_value = 765, /* Observed average from device */
++		.board = "rk3566-powkiddy-rgb10max3",
++		.board_name = "RGB10MAX3",
++		.fdtfile = DTB_DIR "rk3566-powkiddy-rgb10max3.dtb",
++		.detect_panel = 0,
++	},
+ 	[RK2023] = {
+ 		.adc_value = 635, /* Observed average from device */
+ 		.board = "rk3566-powkiddy-rk2023",


### PR DESCRIPTION
Thanks to @Oendaril we were able implement support for the rgb10max3 panel in the sitronix-st7703 driver.  Timings are slightly different than stock (stock timings didn't play well in mainline for some reason) and passes my BGR border test image, and looks ok imo. Refresh rate is ~56Hz though, there most likely need to be a new PLL frequency added to reach ~60Hz. 

There is a 180 degree rotation happening outside the kernel, that I haven't been able to track down. Hence I set the rotation to 90 degrees in the dts, but should be 270. This makes ES correctly oriented, but the boot text is upside-down.

For u-boot I just observed my ADC value, mine were always were between 763-767. So I set it to 765, do double check this on your unit. 
For the rest, I think the analog sticks need some work. WiFi does not work properly, but that's an issue we have on all mainline rk3566 devices. 
It seems powkiddy have swapped L1 and L2, and likewise R1 and R2. But this is the case also on the stock image it was delivered with.