### PR TITLE
Powerstate improvements

### DIFF
--- a/packages/sysutils/system-utils/sources/autostart/AMD64/003-controllerled
+++ b/packages/sysutils/system-utils/sources/autostart/AMD64/003-controllerled
@@ -1,9 +1,0 @@
-#!/bin/sh
-# SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
-
-# Minimal OS variable loading for performance
-. /etc/profile.d/001-functions
-
-tocon "Configuring LEDs..."
-/usr/bin/ledcontrol


### PR DESCRIPTION
## Description

* Update powerstate to manage the power led when the device reaches full charge if it's enabled.
* Drop redundant ledcontrol script for AMD64 devices.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Tested on Powkiddy RGB10 Max 3 and Ayaneo Air Plus.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
