### PR TITLE
Bug fixes (mkcontroller and SDL2)

### DIFF
--- a/packages/graphics/SDL2/package.mk
+++ b/packages/graphics/SDL2/package.mk
@@ -3,10 +3,10 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="SDL2"
-PKG_VERSION="2.30.0"
+PKG_VERSION="2.28.5"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libsdl.org/"
-PKG_URL="${PKG_SITE}/release/SDL2-${PKG_VERSION}.tar.gz"
+PKG_URL="https://www.libsdl.org/release/SDL2-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="toolchain"
 PKG_DEPENDS_TARGET="toolchain alsa-lib systemd dbus pulseaudio libdrm SDL2:host"
 PKG_LONGDESC="Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware."

--- a/packages/graphics/SDL2/patches/RK3566/0006-limit-rga-buffering-when-egl.patch
+++ b/packages/graphics/SDL2/patches/RK3566/0006-limit-rga-buffering-when-egl.patch
@@ -1,7 +1,7 @@
-diff -rupN SDL2-2.30.0.orig/src/video/kmsdrm/SDL_kmsdrmopengles.c SDL2-2.30.0/src/video/kmsdrm/SDL_kmsdrmopengles.c
---- SDL2-2.30.0.orig/src/video/kmsdrm/SDL_kmsdrmopengles.c	2024-02-03 11:28:45.509212112 +0000
-+++ SDL2-2.30.0/src/video/kmsdrm/SDL_kmsdrmopengles.c	2024-02-03 11:39:16.953104142 +0000
-@@ -30,11 +30,15 @@
+diff -rupN SDL2-2.28.5.orig/src/video/kmsdrm/SDL_kmsdrmopengles.c SDL2-2.28.5/src/video/kmsdrm/SDL_kmsdrmopengles.c
+--- SDL2-2.28.5.orig/src/video/kmsdrm/SDL_kmsdrmopengles.c	2024-01-30 16:22:00.475039122 +0000
++++ SDL2-2.28.5/src/video/kmsdrm/SDL_kmsdrmopengles.c	2024-01-30 17:56:52.799111194 +0000
+@@ -29,11 +29,15 @@
  #include "SDL_kmsdrmopengles.h"
  #include "SDL_kmsdrmdyn.h"
  #include <errno.h>
@@ -17,7 +17,7 @@ diff -rupN SDL2-2.30.0.orig/src/video/kmsdrm/SDL_kmsdrmopengles.c SDL2-2.30.0/sr
  /* EGL implementation of SDL OpenGL support */
  
  void KMSDRM_GLES_DefaultProfileConfig(_THIS, int *mask, int *major, int *minor)
-@@ -93,6 +97,7 @@ int KMSDRM_GLES_SwapWindow(_THIS, SDL_Wi
+@@ -92,6 +96,7 @@ int KMSDRM_GLES_SwapWindow(_THIS, SDL_Wi
      SDL_VideoData *viddata = ((SDL_VideoData *)_this->driverdata);
      KMSDRM_FBInfo *fb_info;
      int ret = 0;
@@ -25,14 +25,11 @@ diff -rupN SDL2-2.30.0.orig/src/video/kmsdrm/SDL_kmsdrmopengles.c SDL2-2.30.0/sr
  
      /* Always wait for the previous issued flip before issuing a new one,
         even if you do async flips. */
-@@ -143,10 +148,28 @@ int KMSDRM_GLES_SwapWindow(_THIS, SDL_Wi
+@@ -135,7 +140,30 @@ int KMSDRM_GLES_SwapWindow(_THIS, SDL_Wi
      }
  
      /* Get an actual usable fb for the next front buffer. */
 -    fb_info = KMSDRM_FBFromBO(_this, windata->next_bo);
--    if (!fb_info) {
--        SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "Could not get a framebuffer");
--        return 0;
 +    if (dispdata->orientation == 0) {
 +      fb_info = KMSDRM_FBFromBO(_this, windata->next_bo);
 +    } else {
@@ -45,7 +42,7 @@ diff -rupN SDL2-2.30.0.orig/src/video/kmsdrm/SDL_kmsdrmopengles.c SDL2-2.30.0/sr
 +          SDL_LogError(SDL_LOG_CATEGORY_VIDEO,
 +              "Failed to rga blit\n");
 +      }
-+    
++
 +      rga_buffer = viddata->rga_buffers[viddata->rga_buffer_index];
 +      fb_info = KMSDRM_FBFromBO(_this, rga_buffer);
 +
@@ -55,6 +52,8 @@ diff -rupN SDL2-2.30.0.orig/src/video/kmsdrm/SDL_kmsdrmopengles.c SDL2-2.30.0/sr
 +      }
 +
 +      viddata->rga_buffer_index = (viddata->rga_buffer_index + 1) % RGA_BUFFERS_MAX;
-     }
- 
-     if (!windata->bo) {
++    }
++
+     if (fb_info == NULL) {
+         SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "Could not get a framebuffer");
+         return 0;

--- a/packages/virtual/emulators/scripts/mkcontroller
+++ b/packages/virtual/emulators/scripts/mkcontroller
@@ -5,9 +5,9 @@
 TMPFILE=$(uuidgen)
 OUTFILE=$(uuidgen)
 
-CONTROLLER=$(grep -b4 js0 /proc/bus/input/devices | awk 'BEGIN {FS="\""}; /Name/ {printf $2}')
+CONTROLLER=$(control-gen | awk 'BEGIN {FS="\""} /^DEVICE/ {print $2;exit}')
 xmlstarlet sel -t \
-               -m "/inputList/inputConfig[@deviceName='${CONTROLLER}']/input" \
+               -m "/inputList/inputConfig[@deviceGUID='${CONTROLLER}']/input" \
                -v "concat(@name,'|',@type,'|',@id,'|',@value)" \
                -n /storage/.config/emulationstation/es_input.cfg >/tmp/${TMPFILE}
 


### PR DESCRIPTION
## Description

* mkcontroller should match the controller guid rather than the name.
* Revert SDL to 2.28.5 to correct issues with ES (and possibly other software).

Corrects issues mapping controls for mednafen and other standalone emulators, and slow down issues with EmulationStation and possibly other SDL2 software.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Verified on Loki Zero (AMD64), and RGB10 Max 3.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
