### PR TITLE
Fix setsettings, and cemu controller generation.  Add additional controllers to es_input.

### DIFF
--- a/packages/emulators/standalone/cemu-sa/scripts/start_cemu.sh
+++ b/packages/emulators/standalone/cemu-sa/scripts/start_cemu.sh
@@ -105,7 +105,7 @@ do
 done
 
 UUID0="0_$(control-gen | awk 'BEGIN {FS="\""} /^DEVICE/ {print $2;exit}')"
-CONTROLLER0=$(cat /storage/.controller)
+CONTROLLER0=$(grep -b4 js0 /proc/bus/input/devices | awk 'BEGIN {FS="\""}; /Name/ {printf $2}')
 
 xmlstarlet ed --inplace -u "//Account/OnlineEnabled" -v "${ONLINE}" ${CEMU_CONFIG_ROOT}/settings.xml
 xmlstarlet ed --inplace -u "//Overlay/Position" -v "${FPS}" ${CEMU_CONFIG_ROOT}/settings.xml

--- a/packages/jelos/sources/scripts/setsettings.sh
+++ b/packages/jelos/sources/scripts/setsettings.sh
@@ -339,7 +339,7 @@ EOF
 ### Configure retroarch hotkeys
 function configure_hotkeys() {
     log "Configure hotkeys..."
-    local MY_CONTROLLER=$(cat /storage/.controller)
+    local MY_CONTROLLER=$(grep -b4 js0 /proc/bus/input/devices | awk 'BEGIN {FS="\""}; /Name/ {printf $2}')
 
     ### Remove any input settings retroarch may have added.
     sed -i '/input_player[0-9]/d' ${RETROARCH_CONFIG}

--- a/packages/ui/emulationstation/config/common/es_input.cfg
+++ b/packages/ui/emulationstation/config/common/es_input.cfg
@@ -27,6 +27,33 @@
 		<input name="x" type="button" id="3" value="1" />
 		<input name="y" type="button" id="2" value="1" />
 	</inputConfig>
+	<inputConfig type="joystick" deviceName="Xbox 360 Controller" deviceGUID="030003f05e0400008e02000010010000">
+		<input name="a" type="button" id="1" value="1" />
+		<input name="b" type="button" id="0" value="1" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkeyenable" type="button" id="6" value="1" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="leftanalogdown" type="axis" id="1" value="1" />
+		<input name="leftanalogleft" type="axis" id="0" value="-1" />
+		<input name="leftanalogright" type="axis" id="0" value="1" />
+		<input name="leftanalogup" type="axis" id="1" value="-1" />
+		<input name="leftshoulder" type="button" id="4" value="1" />
+		<input name="leftthumb" type="button" id="9" value="1" />
+		<input name="lefttrigger" type="axis" id="2" value="1" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="rightanalogdown" type="axis" id="4" value="1" />
+		<input name="rightanalogleft" type="axis" id="3" value="-1" />
+		<input name="rightanalogright" type="axis" id="3" value="1" />
+		<input name="rightanalogup" type="axis" id="4" value="-1" />
+		<input name="rightshoulder" type="button" id="5" value="1" />
+		<input name="rightthumb" type="button" id="10" value="1" />
+		<input name="righttrigger" type="axis" id="5" value="1" />
+		<input name="select" type="button" id="6" value="1" />
+		<input name="start" type="button" id="7" value="1" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="3" value="1" />
+		<input name="y" type="button" id="2" value="1" />
+	</inputConfig>
 	<inputConfig type="joystick" deviceName="Atari Classic Controller" deviceGUID="03000000503200000110000000000000">
 		<input name="a" type="button" id="0" value="1" />
 		<input name="b" type="button" id="1" value="1" />
@@ -1240,6 +1267,33 @@
                 <input name="x" type="button" id="2" value="1" />
                 <input name="y" type="button" id="3" value="1" />
         </inputConfig>
+	<inputConfig type="joystick" deviceName="retrogame_joypad" deviceGUID="19009b4d4b4800000111000000010000">
+		<input name="a" type="button" id="1" value="1" />
+		<input name="b" type="button" id="0" value="1" />
+		<input name="down" type="button" id="14" value="1" />
+		<input name="hotkeyenable" type="button" id="8" value="1" />
+		<input name="left" type="button" id="15" value="1" />
+		<input name="leftanalogdown" type="axis" id="1" value="1" />
+		<input name="leftanalogleft" type="axis" id="0" value="-1" />
+		<input name="leftanalogright" type="axis" id="0" value="1" />
+		<input name="leftanalogup" type="axis" id="1" value="-1" />
+		<input name="leftshoulder" type="button" id="4" value="1" />
+		<input name="leftthumb" type="button" id="11" value="1" />
+		<input name="lefttrigger" type="button" id="6" value="1" />
+		<input name="right" type="button" id="16" value="1" />
+		<input name="rightanalogdown" type="axis" id="3" value="1" />
+		<input name="rightanalogleft" type="axis" id="2" value="-1" />
+		<input name="rightanalogright" type="axis" id="2" value="1" />
+		<input name="rightanalogup" type="axis" id="3" value="-1" />
+		<input name="rightshoulder" type="button" id="5" value="1" />
+		<input name="rightthumb" type="button" id="12" value="1" />
+		<input name="righttrigger" type="button" id="7" value="1" />
+		<input name="select" type="button" id="8" value="1" />
+		<input name="start" type="button" id="9" value="1" />
+		<input name="up" type="button" id="13" value="1" />
+		<input name="x" type="button" id="2" value="1" />
+		<input name="y" type="button" id="3" value="1" />
+	</inputConfig>
         <inputConfig type="joystick" deviceName="zed_joystick" deviceGUID="1900fcf27a65645f6a6f797374696300">
                 <input name="a" type="button" id="0" value="1" />
                 <input name="b" type="button" id="1" value="1" />

--- a/packages/virtual/emulators/scripts/mkcontroller
+++ b/packages/virtual/emulators/scripts/mkcontroller
@@ -55,8 +55,6 @@ rm -f /tmp/${TMPFILE}
 
 source /tmp/${OUTFILE}
 
-echo "${CONTROLLER}" >/storage/.controller
-
 cat <<EOF >/storage/.config/profile.d/098-controller
 DEVICE_BTN_SOUTH="${b}"
 DEVICE_BTN_EAST="${a}"


### PR DESCRIPTION
## Description

Changing mkcontroller to search for the guid rather than the name breaks setsettings, as retroarch controls are found by name.  Additionally, several controller guids were missing from EmulationStation's es_input.cfg, this is the beginning of that correction.  More to come.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Tested on Air Pro, Air Plus, Loki Zero, Loki Max, Ayaneo 2S, and Powkiddy RGB10 Max 3.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
