### PR TITLE
Gzdoom res fix

### DIFF
--- a/packages/emulators/standalone/gzdoom-sa/scripts/start_gzdoom.sh
+++ b/packages/emulators/standalone/gzdoom-sa/scripts/start_gzdoom.sh
@@ -12,17 +12,15 @@ SAVE_DIR="/storage/roms/gzdoom"
 
 if [ ! -d "/storage/.config/gzdoom/" ]; then
   cp -rf /usr/config/gzdoom /storage/.config/
-  # set user resolution
-  sed -i '/vid_defheight=/c\vid_defheight='$(fbheight) /storage/.config/gzdoom/gzdoom.ini
-  sed -i '/vid_defwidth=/c\vid_defwidth='$(fbwidth) /storage/.config/gzdoom/gzdoom.ini
 fi
 
 if [ ! -f "/storage/.config/gzdoom/gzdoom.ini" ]; then
   cp -rf /usr/config/gzdoom/gzdoom.ini /storage/.config/gzdoom/
-  # set user resolution
-  sed -i '/vid_defheight=/c\vid_defheight='$(fbheight) /storage/.config/gzdoom/gzdoom.ini
-  sed -i '/vid_defwidth=/c\vid_defwidth='$(fbwidth) /storage/.config/gzdoom/gzdoom.ini
 fi
+
+# set resolution
+sed -i '/vid_defheight=/c\vid_defheight='$(fbheight) /storage/.config/gzdoom/gzdoom.ini
+sed -i '/vid_defwidth=/c\vid_defwidth='$(fbwidth) /storage/.config/gzdoom/gzdoom.ini
 
 if [ ! -d "/storage/roms/doom/iwads" ]; then
   mkdir /storage/roms/doom/iwads

--- a/packages/emulators/standalone/gzdoom-sa/scripts/start_gzdoom.sh
+++ b/packages/emulators/standalone/gzdoom-sa/scripts/start_gzdoom.sh
@@ -12,10 +12,16 @@ SAVE_DIR="/storage/roms/gzdoom"
 
 if [ ! -d "/storage/.config/gzdoom/" ]; then
   cp -rf /usr/config/gzdoom /storage/.config/
+  # set user resolution
+  sed -i '/vid_defheight=/c\vid_defheight='$(fbheight) /storage/.config/gzdoom/gzdoom.ini
+  sed -i '/vid_defwidth=/c\vid_defwidth='$(fbwidth) /storage/.config/gzdoom/gzdoom.ini
 fi
 
 if [ ! -f "/storage/.config/gzdoom/gzdoom.ini" ]; then
   cp -rf /usr/config/gzdoom/gzdoom.ini /storage/.config/gzdoom/
+  # set user resolution
+  sed -i '/vid_defheight=/c\vid_defheight='$(fbheight) /storage/.config/gzdoom/gzdoom.ini
+  sed -i '/vid_defwidth=/c\vid_defwidth='$(fbwidth) /storage/.config/gzdoom/gzdoom.ini
 fi
 
 if [ ! -d "/storage/roms/doom/iwads" ]; then

--- a/packages/hardware/quirks/devices/Anbernic RG503/050-game_configs
+++ b/packages/hardware/quirks/devices/Anbernic RG503/050-game_configs
@@ -1,9 +1,0 @@
-
-# SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
-
-. /etc/profile
-
-#Set gzdoom resolution
-sed -i '/vid_defheight=/c\vid_defheight=544;
-        /vid_defwidth=/c\vid_defwidth=960' /storage/.config/gzdoom/gzdoom.ini

--- a/packages/hardware/quirks/devices/MagicX XU10/004-game-configs
+++ b/packages/hardware/quirks/devices/MagicX XU10/004-game-configs
@@ -24,12 +24,6 @@ if [ -f "/storage/.config/drastic/config/drastic.cfg.xut" ]; then
   mv /storage/.config/drastic/config/drastic.cfg.xut /storage/.config/drastic/config/drastic.cfg
 fi
 
-#Set up gzdoom
-if [ ! -d "/storage/.config/gzdoom/" ]; then
-  sed -i '/vid_defheight=/c\vid_defheight=480' /storage/.config/gzdoom/gzdoom.ini
-  sed -i '/vid_defwidth=/c\vid_defwidth=640' /storage/.config/gzdoom/gzdoom.ini
-fi
-
 #Map ppsspp controls
 if  grep XU10 -q "/storage/.config/ppsspp/PSP/SYSTEM/controls.ini"
 then

--- a/packages/hardware/quirks/devices/ODROID-GO Advance Black Edition/050-game_configs
+++ b/packages/hardware/quirks/devices/ODROID-GO Advance Black Edition/050-game_configs
@@ -22,10 +22,6 @@ if [ -f "/storage/.config/drastic/config/drastic.cfg.ogabe" ]; then
   mv /storage/.config/drastic/config/drastic.cfg.ogabe /storage/.config/drastic/config/drastic.cfg
 fi
 
-#Set gzdoom resolution
-sed -i '/vid_defheight=/c\vid_defheight=320' /storage/.config/gzdoom/gzdoom.ini
-sed -i '/vid_defwidth=/c\vid_defwidth=480' /storage/.config/gzdoom/gzdoom.ini
-
 #Set ppsspp config for OGA
 if [ ! -d "/storage/.config/ppsspp" ]; then
     mkdir -p "/storage/.config/ppsspp"

--- a/packages/hardware/quirks/devices/ODROID-GO Advance/050-game_configs
+++ b/packages/hardware/quirks/devices/ODROID-GO Advance/050-game_configs
@@ -23,10 +23,6 @@ if [ -f "/storage/.config/drastic/config/drastic.cfg.oga" ]; then
   mv /storage/.config/drastic/config/drastic.cfg.oga /storage/.config/drastic/config/drastic.cfg
 fi
 
-#Set gzdoom resolution
-sed -i '/vid_defheight=/c\vid_defheight=320' /storage/.config/gzdoom/gzdoom.ini
-sed -i '/vid_defwidth=/c\vid_defwidth=480' /storage/.config/gzdoom/gzdoom.ini
-
 #Map ppsspp controls
 if  grep OGA-1.0 -q "/storage/.config/ppsspp/PSP/SYSTEM/controls.ini"
 then

--- a/packages/hardware/quirks/devices/ODROID-GO Super/050-game_configs
+++ b/packages/hardware/quirks/devices/ODROID-GO Super/050-game_configs
@@ -24,12 +24,6 @@ if [ -f "/storage/.config/drastic/config/drastic.cfg.ogs" ]; then
   mv /storage/.config/drastic/config/drastic.cfg.ogs /storage/.config/drastic/config/drastic.cfg
 fi
 
-#Set up gzdoom
-if [ ! -d "/storage/.config/gzdoom/" ]; then
-  sed -i '/vid_defheight=/c\vid_defheight=480' /storage/.config/gzdoom/gzdoom.ini
-  sed -i '/vid_defwidth=/c\vid_defwidth=854' /storage/.config/gzdoom/gzdoom.ini
-fi
-
 #Map ppsspp controls
 if  grep OGS -q "/storage/.config/ppsspp/PSP/SYSTEM/controls.ini"
 then

--- a/packages/hardware/quirks/devices/Powkiddy RGB20S/050-game-configs
+++ b/packages/hardware/quirks/devices/Powkiddy RGB20S/050-game-configs
@@ -24,12 +24,6 @@ if [ -f "/storage/.config/drastic/config/drastic.cfg.rgb20s" ]; then
   mv /storage/.config/drastic/config/drastic.cfg.rgb20s /storage/.config/drastic/config/drastic.cfg
 fi
 
-#Set up gzdoom
-if [ ! -d "/storage/.config/gzdoom/" ]; then
-  sed -i '/vid_defheight=/c\vid_defheight=640' /storage/.config/gzdoom/gzdoom.ini
-  sed -i '/vid_defwidth=/c\vid_defwidth=478' /storage/.config/gzdoom/gzdoom.ini
-fi
-
 #Map ppsspp controls
 if  grep RGB20S -q "/storage/.config/ppsspp/PSP/SYSTEM/controls.ini"
 then

--- a/packages/virtual/emulators/package.mk
+++ b/packages/virtual/emulators/package.mk
@@ -1086,7 +1086,7 @@ makeinstall_target() {
       add_emu_core snesh mednafen snes_faust false
     ;;
     RK33*)
-      add_emu_core snes mednafen snes_faust false
+      add_emu_core snesh mednafen snes_faust false
 	;;
   esac
   add_es_system snesh


### PR DESCRIPTION
* Set resolution in gzdoom on startup, fixes resolution on devices without device quirks e.g. rg552 this also eliminates the need of a quirk to set the resolution.
* Clean up some of the quirks setting the resolution
* correcting minor typo in virtual/emulators
