### PR TITLE
usbgadget: reorder the write to gadget/UDC to avoid a condition where…

### DIFF
--- a/packages/jelos/sources/scripts/usbgadget
+++ b/packages/jelos/sources/scripts/usbgadget
@@ -46,6 +46,7 @@ usb_start() {
 	echo $VENDOR > gadget/strings/0x409/manufacturer
 	echo $MACHINE > gadget/strings/0x409/product
 	
+	
 	if [ "${USB_MODE}" = mtp ] ; then
 		echo 0x1d6b > gadget/idVendor 
 		echo 0x0100 > gadget/idProduct
@@ -55,19 +56,20 @@ usb_start() {
 		mount mtp -t functionfs /dev/ffs-umtp
 		/usr/sbin/umtprd &
 		sleep 1
+		echo "${UDC_NAME}" > gadget/UDC
 
 	elif [ "${USB_MODE}" = cdc ] ; then
 		echo cdc > gadget/configs/c.1/strings/0x409/configuration
 		echo 0x1d6b > gadget/idVendor	
 		echo 0x104 > gadget/idProduct
 		ln -s gadget/functions/ecm.usb0 gadget/configs/c.1
+		echo "${UDC_NAME}" > gadget/UDC
 		ifconfig usb0 $IP up
 		/usr/sbin/udhcpd -S /storage/.cache/usbgadget/udhcpd.conf
 	else
 		exit 0
 	fi
 
-	echo "${UDC_NAME}" > /sys/kernel/config/usb_gadget/gadget/UDC
 	echo "USB_MODE=$(cat gadget/configs/c.1/strings/0x409/configuration)" > /storage/.cache/usbgadget/usbgadget.conf
 }
 


### PR DESCRIPTION
Depending on the order of enabling/disabling ECM/MTP, I found a bug in my script that would sometimes lead to ifconfig: SIOCSIFADDR: No such device

This should fix it once and for all