### PR TITLE
Disable 2S fan when entering sleep mode

### DIFF
--- a/packages/hardware/quirks/devices/AYANEO AYANEO 2S/sleep.d/post/001-fan
+++ b/packages/hardware/quirks/devices/AYANEO AYANEO 2S/sleep.d/post/001-fan
@@ -1,0 +1,7 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+. /etc/profile
+
+systemctl restart fancontrol

--- a/packages/hardware/quirks/devices/AYANEO AYANEO 2S/sleep.d/post/002-freq
+++ b/packages/hardware/quirks/devices/AYANEO AYANEO 2S/sleep.d/post/002-freq
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+### Restore previous governors before going to sleep
+
+. /etc/profile
+
+### Grab the old governors.
+OLD_CPU_FREQ=$(get_setting "sleep.cpugovernor")
+if [ ! -n "${OLD_CPU_FREQ}" ]; then
+  OLD_CPU_FREQ="schedutil"
+fi
+
+OLD_GPU_LEVEL=$(get_setting "sleep.gpulevel")
+if [ ! -n "${OLD_GPU_LEVEL}" ]; then
+  OLD_GPU_LEVEL="balanced"
+fi 
+
+# Restore old governors.
+set_cpu_gov "${OLD_CPU_FREQ}"
+gpu_performance_level "${OLD_GPU_LEVEL}"

--- a/packages/hardware/quirks/devices/AYANEO AYANEO 2S/sleep.d/pre/001-fan
+++ b/packages/hardware/quirks/devices/AYANEO AYANEO 2S/sleep.d/pre/001-fan
@@ -1,0 +1,8 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+. /etc/profile
+
+echo 1 >${DEVICE_PWM_FAN}
+echo 0 >${DEVICE_FAN_INPUT}

--- a/packages/hardware/quirks/devices/AYANEO AYANEO 2S/sleep.d/pre/002-freq
+++ b/packages/hardware/quirks/devices/AYANEO AYANEO 2S/sleep.d/pre/002-freq
@@ -1,0 +1,17 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+# Store current freq governors and set governors to powersave.
+
+. /etc/profile
+
+### Get the current cpu and gpu governor, save for when the device wakes from sleep.
+CUR_CPU_FREQ="$(cat ${CPU_FREQ}/scaling_governor)"
+CUR_GPU_LEVEL="$(get_gpu_performance_level)"
+set_setting sleep.cpugovernor "${CUR_CPU_FREQ}"
+set_setting sleep.gpulevel "${CUR_GPU_LEVEL}"
+
+### Set all governors to powersave
+set_cpu_gov powersave
+gpu_performance_level low


### PR DESCRIPTION
## Description

Disable 2S fan in sleep mode, and put the device into power saving mode since sleep is really freeze. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

After 8 minutes the core temp remained at 35c tested immediately after wake.  Longer testing needed.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
