### PR TITLE
Set default scaling governors for RK3588

### DIFF
--- a/packages/hardware/quirks/platforms/RK3588/060-game_settings
+++ b/packages/hardware/quirks/platforms/RK3588/060-game_settings
@@ -1,3 +1,4 @@
+
 #!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
@@ -5,7 +6,7 @@
 . /etc/profile.d/001-functions
 
 ### Set the default performance scaling mode for a few systems.
-for SYSTEM in dreamcast n64 ports psp psx saturn pcfx cdi ps2 gamecube
+for SYSTEM in dreamcast n64 ports psp saturn ps2 gamecube
 do
   CPU_SETTING=$(get_setting ${SYSTEM}.cpugovernor)
   if [ -z "${CPU_SETTING}" ]


### PR DESCRIPTION
Also add back in GC and PS2 for rk3399. Looks like those got deleted. 