### PR TITLE
Fixes and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ JELOS supports a variety of ARM and Intel/AMD based devices.
 | AYANEO | [AYANEO 2S](https://jelos.org/devices/ayaneo/ayaneo-2) | Amd Ryzen 7 7840U / (x86_64) | Mainline Linux | Radeonsi | Weston + Emulation Station |
 | Ayn | [Loki Zero](https://jelos.org/devices/ayn/loki-zero) | AMD Athlon Silver 3050e (x86_64) | Mainline Linux | Radeonsi | Weston + Emulation Station |
 | Ayn | [Loki Max](https://jelos.org/devices/ayn/loki-max) | Amd Ryzen 7 6800U / (x86_64) | Mainline Linux | Radeonsi | Weston + Emulation Station |
-| Game Console | [RG33S](https://jelos.org/gameconsole/r33s) | Rockchip RK3326 (ARM) | Mainline Linux | Panfrost | Weston + Emulation Station |
+| Game Console | [R33S](https://jelos.org/gameconsole/r33s) | Rockchip RK3326 (ARM) | Mainline Linux | Panfrost | Weston + Emulation Station |
 | GPD | [Win 4](https://jelos.org/devices/gpd/win4) | Amd Ryzen 7 6800U / (x86_64) | Mainline Linux | Radeonsi | Weston + Emulation Station |
 | GPD | [Win Max 2 (2022)](https://jelos.org/devices/gpd/win-max-2) | Amd Ryzen 7 6800U / (x86_64) | Mainline Linux| Radeonsi | Weston + Emulation Station |
 | Hardkernel | [Odroid Go Advance](https://jelos.org/devices/hardkernel/odroid-go-advance) | Rockchip RK3326 (ARM) | Mainline Linux | Panfrost | Weston + Emulation Station |

--- a/packages/jelos/sources/scripts/factoryreset
+++ b/packages/jelos/sources/scripts/factoryreset
@@ -21,6 +21,11 @@ case "${1}" in
     sync
     systemctl reboot
   ;;
+  "audio")
+    systemctl stop pipewire-pulse pipewire-pulse.socket pipewire pipewire.socket wireplumber
+    rm -rf /storage/.local/state /storage/.config/pulse /storage/asound*
+    systemctl reboot
+  ;;
   "ALL")
     swapoff -a 2>/dev/null
     umount /storage/roms 2>/dev/null ||:

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="cd21ce8bba392132f4611a38d5174c9173c176f6"
+PKG_VERSION="0d4edf882f27f258e2913e2c69b11531bd87cac6"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"
@@ -33,7 +33,12 @@ else
   PKG_CMAKE_OPTS_TARGET+=" -DENABLE_UPDATES=0"
 fi
 
-PKG_CMAKE_OPTS_TARGET+=" -DENABLE_EMUELEC=1 -DDISABLE_KODI=1 -DENABLE_FILEMANAGER=0 -DCEC=0 -DENABLE_PULSE=1"
+PKG_CMAKE_OPTS_TARGET+=" -DENABLE_EMUELEC=1 \
+                         -DDISABLE_KODI=1 \
+                         -DENABLE_FILEMANAGER=0 \
+                         -DCEC=0 \
+                         -DENABLE_PULSE=1 \
+                         -DUSE_SYSTEM_PUGIXML=1"
 
 ##########################################################################################################
 # The following allows building Emulation station from local copy by using EMULATIONSTATION_SRC.


### PR DESCRIPTION
## Description

* RetroAchievements are now available again in the main menu when enabled.
* Audio Reset is now available in system management and reset options.
* Correct R33S listing in the readme.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Tested on AYANEO 2S

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
