### PR TITLE
Enabling the fn button on r36s

### DIFF
--- a/projects/Rockchip/packages/linux/patches/RK3326/000-rk3326-dts.patch
+++ b/projects/Rockchip/packages/linux/patches/RK3326/000-rk3326-dts.patch
@@ -561,12 +561,12 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-gameconsole-r36s.dts l
 +                        label = "GPIO F4";
 +                        linux,code = <BTN_TRIGGER_HAPPY4>; // 0x2c3
 +                };
-+                /*sw13 {
++                sw13 {
 +                        gpios = <&gpio2 RK_PA4 GPIO_ACTIVE_LOW>;
 +                        label = "GPIO F5";
 +                        linux,code = <BTN_TRIGGER_HAPPY5>; // 0x2c4
 +                };
-+                sw14 {
++                /*sw14 {
 +                        gpios = <&gpio2 RK_PA5 GPIO_ACTIVE_LOW>;
 +                        label = "GPIO F6";
 +                        linux,code = <BTN_TRIGGER_HAPPY6>; // 0x13c


### PR DESCRIPTION
# Pull Request Template

## Description

The dts originally used for r36s had this commented out but is available on the device now as it probably copied from an odroid dts (thanks to ArkOS team for helping point where it is)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Verified mappings on dts

**Test Configuration**:
* Build OS name and version:
* Docker (Y/N):
* JELOS Branch:
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
