### PR TITLE
Disable virtualcontroller rk3566

### DIFF
--- a/projects/Rockchip/devices/RK3566/options
+++ b/projects/Rockchip/devices/RK3566/options
@@ -77,7 +77,7 @@
     EXTRA_CMDLINE="quiet rootwait earlycon=uart8250,mmio32,0xfe660000 console=ttyS2,1500000n8 console=tty1 ssh consoleblank=0 systemd.show_status=0 loglevel=0 panic=20"
 
   # additional packages to install
-    ADDITIONAL_PACKAGES="virtualcontroller"
+    #ADDITIONAL_PACKAGES=""
 
   # additional Firmware to use ( )
   # Space separated list is supported,


### PR DESCRIPTION
Cuts away some added boot time, it's still long due to some other reason though.