### PR TITLE
add wifi partial firmware fix [rk3566-ml]

### DIFF
--- a/projects/Rockchip/patches/linux/RK3566/003-fix-ps-vs-dts-aliases.patch
+++ b/projects/Rockchip/patches/linux/RK3566/003-fix-ps-vs-dts-aliases.patch
@@ -1,0 +1,34 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rg353ps.dts b/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rg353ps.dts
+index b211973e36c2..1eb16af26291 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rg353ps.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rg353ps.dts
+@@ -12,9 +12,9 @@ / {
+ 	compatible = "anbernic,rg353ps", "rockchip,rk3566";
+
+ 	aliases {
+-		mmc0 = &sdmmc0;
+-		mmc1 = &sdmmc1;
+-		mmc2 = &sdmmc2;
++		mmc1 = &sdmmc0;
++		mmc2 = &sdmmc1;
++		mmc3 = &sdmmc2;
+ 	};
+
+ 	battery: battery {
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rg353vs.dts b/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rg353vs.dts
+index a7dc462fe21f..0675c79d1f3a 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rg353vs.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rg353vs.dts
+@@ -12,9 +12,9 @@ / {
+ 	compatible = "anbernic,rg353vs", "rockchip,rk3566";
+
+ 	aliases {
+-		mmc0 = &sdmmc0;
+-		mmc1 = &sdmmc1;
+-		mmc2 = &sdmmc2;
++		mmc1 = &sdmmc0;
++		mmc2 = &sdmmc1;
++		mmc3 = &sdmmc2;
+ 	};
+
+ 	battery: battery {

--- a/projects/Rockchip/patches/linux/RK3566/004-fix-8821cs-sdio-errors.patch
+++ b/projects/Rockchip/patches/linux/RK3566/004-fix-8821cs-sdio-errors.patch
@@ -1,0 +1,25 @@
+From a0e01b2bb51a032af5e95e4acd9081f33afd9884 Mon Sep 17 00:00:00 2001
+From: brrrrrrrrrr <brrrrrrrrrr@brrrrrrrrrr>
+Date: Fri, 16 Feb 2024 13:00:59 -0500
+Subject: [PATCH] Fix 8821cs sdio errors
+
+---
+ arch/arm64/boot/dts/rockchip/rk3566-anbernic-rgxx3.dtsi | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rgxx3.dtsi b/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rgxx3.dtsi
+index abf7dea167c2..5cd11e962c81 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rgxx3.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rgxx3.dtsi
+@@ -636,6 +636,9 @@ &sdmmc2 {
+ 	pinctrl-names = "default";
+ 	vmmc-supply = <&vcc_wifi>;
+ 	vqmmc-supply = <&vcca1v8_pmu>;
++	no-mmc;
++	no-sd;
++	sd-uhs-sdr50;
+ 	status = "okay";
+ };
+
+--
+2.43.1


### PR DESCRIPTION
## Description

Adding a few patches to get a partial wifi fix.
Thanks to @brooksytech for finding the ps/vs alias mismatch.
Thanks to active.egg for the partial wifi fix. (https://gitlab.com/iii1111/brrrrrrrrrr/-/commit/31f3f8f75e532c11fb13958498916200dd2ca1b2)

Fixes # (issue)
Before
```
dmesg | grep rtw
[    7.509060] rtw_8821cs mmc2:0001:1: Firmware version 24.11.0, H2C version 12
[    7.869891] rtw_8821cs mmc2:0001:1: sdio read32 failed (0x11080): -110
[    7.873638] rtw_8821cs mmc2:0001:1: sdio write32 failed (0x11080): -110
[    7.878424] rtw_8821cs mmc2:0001:1: sdio read32 failed (0x10080): -110
[    7.889493] rtw_8821cs mmc2:0001:1: sdio write32 failed (0x10080): -110
[    7.899061] rtw_8821cs mmc2:0001:1: sdio read32 failed (0x10040): -110
[    7.903362] rtw_8821cs mmc2:0001:1: sdio write32 failed (0x10040): -110
[    7.905517] rtw_8821cs mmc2:0001:1: sdio read32 failed (0x11700): -110
[    7.912645] rtw_8821cs mmc2:0001:1: sdio write32 failed (0x11700): -110
[    7.917005] rtw_8821cs mmc2:0001:1: sdio read32 failed (0x11708): -110
[    7.922280] rtw_8821cs mmc2:0001:1: sdio write32 failed (0x11330): -110
[    7.925640] rtw_8821cs mmc2:0001:1: sdio read32 failed (0x1022c): -110
[    7.929648] rtw_8821cs mmc2:0001:1: sdio write32 failed (0x1022c): -110
[    7.934031] rtw_8821cs mmc2:0001:1: sdio read32 failed (0x20): -110
[    7.939857] rtw_8821cs mmc2:0001:1: sdio read32 failed (0x11208): -110
[    7.945916] rtw_8821cs mmc2:0001:1: sdio write32 failed (0x11208): -110
[    7.949149] rtw_8821cs mmc2:0001:1: sdio read32 failed (0x20): -110
[    7.951170] rtw_8821cs mmc2:0001:1: sdio read32 failed (0x24): -110
[    7.952921] rtw_8821cs mmc2:0001:1: sdio read32 failed (0x28): -110
[    7.955845] rtw_8821cs mmc2:0001:1: Failed to write 4608 byte(s) to SDIO port 0x0000840c
[    7.957839] rtw_8821cs mmc2:0001:1: failed to write data to rsvd page
[    7.967229] rtw_8821cs mmc2:0001:1: failed to download rsvd page
[    7.970006] rtw_8821cs mmc2:0001:1: failed to download firmware
[    7.971926] rtw_8821cs mmc2:0001:1: failed to setup chip efuse info
[    7.977093] rtw_8821cs mmc2:0001:1: failed to setup chip information
[    7.980326] rtw_8821cs: probe of mmc2:0001:1 failed with error -110
```
After
```
RK3566:~# dmesg | grep mmc3
[    1.267053] mmc_host mmc3: card is non-removable.
[    1.490150] mmc_host mmc3: Bus speed (slot 0) = 375000Hz (slot req 400000Hz, actual 375000HZ div = 0)
[    1.539759] mmc_host mmc3: Bus speed (slot 0) = 50000000Hz (slot req 100000000Hz, actual 50000000HZ div = 0)
[    1.718386] mmc3: new ultra high speed SDR50 SDIO card at address 0001
[   17.373411] rtw_8821cs mmc3:0001:1: sdio read32 failed (0xf0): -110
[   17.375512] rtw_8821cs mmc3:0001:1: sdio write8 failed (0x1c): -110
[   17.387294] rtw_8821cs mmc3:0001:1: Firmware version 24.11.0, H2C version 12
RK3566:~ # dmesg | grep wlan0
[   97.475410] wlan0: authenticate with 7a:83:c2:9b:a6:2a (local address=60:fb:00:72:0f:10)
[   97.510856] wlan0: send auth to 7a:83:c2:9b:a6:2a (try 1/3)
[   97.516324] wlan0: authenticated
[   97.518526] wlan0: associate with 7a:83:c2:9b:a6:2a (try 1/3)
[   97.526861] wlan0: RX AssocResp from 7a:83:c2:9b:a6:2a (capab=0x1511 status=0 aid=9)
[   97.588293] wlan0: associated
[   97.674755] wlan0: Limiting TX power to 21 (24 - 3) dBm as advertised by 7a:83:c2:9b:a6:2a
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

It is working on my 353VS, along with active.egg's 353m?, but @fewtarius is reporting kernel panics with it on 353v. Testing is needed on more devices.