### PR TITLE
update bdf2psf

### DIFF
--- a/packages/textproc/bdf2psf/package.mk
+++ b/packages/textproc/bdf2psf/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="bdf2psf"
-PKG_VERSION="1.223"
+PKG_VERSION="1.226"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://packages.debian.org/unstable/${PKG_NAME}"
 PKG_URL="https://deb.debian.org/debian/pool/main/c/console-setup/${PKG_NAME}_${PKG_VERSION}_all.deb"


### PR DESCRIPTION
1.223 no longer exists on debian's site, use 1.226