### PR TITLE
Input management schema and dpad volume/brightness

### DIFF
--- a/packages/sysutils/system-utils/sources/scripts/input_sense
+++ b/packages/sysutils/system-utils/sources/scripts/input_sense
@@ -12,18 +12,88 @@ set -o pipefail
 #   This script listens to input events and takes actions.
 ###
 
-DEBUG=false
+### Enable logging
+case $(get_setting system.loglevel) in
+  verbose)
+    DEBUG=true
+  ;;
+  *)
+    DEBUG=false
+  ;;
+esac
 
-### Define matching values from evtest.
-FUNCTION_VOLUME_UP_EVENT='*(KEY_VOLUME*UP), value 1'  # Differentiate 'up' volume event
-FUNCTION_VOLUME_DOWN_EVENT='*(KEY_VOLUME**DOWN), value 1' #Differentiate 'down' volume event
+### Define matching values from evtest, but allow them to be overridden in system.cfg.
+KEY_VOLUME_UP=$(get_setting key.volume.up)
+if [ -z "${KEY_VOLUME_UP}" ]
+then
+  KEY_VOLUME_UP='KEY_VOLUME*UP'
+fi
 
-FUNCTION_MODIFIER_A_EVENT='*('${DEVICE_FUNC_KEYA_MODIFIER}'), value *'
-FUNCTION_MODIFIER_B_EVENT='*('${DEVICE_FUNC_KEYB_MODIFIER}'), value *'
+KEY_VOLUME_DOWN=$(get_setting key.volume.down)
+if [ -z "${KEY_VOLUME_DOWN}" ]
+then
+  KEY_VOLUME_DOWN='KEY_VOLUME*DOWN'
+fi
 
-FUNCTION_HOTKEY_EVENT='*(BTN_TL), value *'
-FUNCTION_SELECT_EVENT='*(BTN_SELECT), value *'
-FUNCTION_START_EVENT='*(BTN_START), value *'
+FUNCTION_VOLUME_UP_EVENT='*('${KEY_VOLUME_UP}'), value 1'
+FUNCTION_VOLUME_DOWN_EVENT='*('${KEY_VOLUME_DOWN}'), value 1'
+
+### Define matching function hotkeys from controller values, but allow them to be overridden in system.cfg.
+KEYA_MODIFIER=$(get_setting key.function.a)
+if [ -z "${KEYA_MODIFIER}" ]
+then
+  KEYA_MODIFIER="${DEVICE_FUNC_KEYA_MODIFIER}"
+fi
+
+KEYB_MODIFIER=$(get_setting key.function.b)
+if [ -z "${KEYB_MODIFIER}" ]
+then
+  KEYB_MODIFIER="${DEVICE_FUNC_KEYB_MODIFIER}"
+fi
+
+FUNCTION_MODIFIER_A_EVENT='*('${KEYA_MODIFIER}'), value *'
+FUNCTION_MODIFIER_B_EVENT='*('${KEYB_MODIFIER}'), value *'
+
+BTN_HOTKEY_A_MODIFIER=$(get_setting key.hotkey.a)
+if [ -z "${BTN_HOTKEY_A_MODIFIER}" ]
+then
+  BTN_HOTKEY_A_MODIFIER="BTN_TL"
+fi
+
+BTN_HOTKEY_B_MODIFIER=$(get_setting key.hotkey.b)
+if [ -z "${BTN_HOTKEY_B_MODIFIER}" ]
+then
+  BTN_HOTKEY_B_MODIFIER="BTN_SELECT"
+fi
+
+BTN_HOTKEY_C_MODIFIER=$(get_setting key.hotkey.c)
+if [ -z "${BTN_HOTKEY_C_MODIFIER}" ]
+then
+  BTN_HOTKEY_C_MODIFIER="BTN_START"
+fi
+
+FUNCTION_HOTKEY_A_EVENT='*('${BTN_HOTKEY_A_MODIFIER}'), value *'
+FUNCTION_HOTKEY_B_EVENT='*('${BTN_HOTKEY_B_MODIFIER}'), value *'
+FUNCTION_HOTKEY_C_EVENT='*('${BTN_HOTKEY_C_MODIFIER}'), value *'
+
+### Define static values for dpad buttons and as a hat.
+FUNCTION_HOTKEY_DPAD_UP_EVENT="*(BTN_DPAD_UP), value 1*"
+FUNCTION_HOTKEY_DPAD_DOWN_EVENT="*(BTN_DPAD_DOWN), value 1*"
+FUNCTION_HOTKEY_DPAD_RIGHT_EVENT="*(BTN_DPAD_RIGHT), value 1*"
+FUNCTION_HOTKEY_DPAD_LEFT_EVENT="*(BTN_DPAD_LEFT), value 1*"
+
+FUNCTION_HOTKEY_HAT_UP_EVENT="*(ABS_HAT0Y), value -1*"
+FUNCTION_HOTKEY_HAT_DOWN_EVENT="*(ABS_HAT0Y), value 1*"
+FUNCTION_HOTKEY_HAT_RIGHT_EVENT="*(ABS_HAT0X), value 1*"
+FUNCTION_HOTKEY_HAT_LEFT_EVENT="*(ABS_HAT0X), value -1*"
+
+DPAD_EVENTS=$(get_setting key.dpad.events)
+if [ -z "${DPAD_EVENTS}" ]
+then
+  DPAD_EVENTS=false
+else
+  DPAD_EVENTS=true
+fi
 
 CONTROLLER_DISCONNECTED="*error reading: No such device"
 DEVICE_DISCONNECTED="*error reading: No such device"
@@ -37,14 +107,14 @@ FN_A_PRESSED=false
 FN_B_PRESSED=false
 
 ### Allow actions to be overriden in system.cfg
-FN_A_ACTION_UP="$(get_setting fn_a.action.up)"
-FN_A_ACTION_DOWN="$(get_setting fn_a.action.down)"
+FN_A_ACTION_UP="$(get_setting key.function.a.up)"
+FN_A_ACTION_DOWN="$(get_setting key.function.a.down)"
 
-FN_B_ACTION_UP="$(get_setting fn_b.action.up)"
-FN_B_ACTION_DOWN="$(get_setting fn_b.action.down)"
+FN_B_ACTION_UP="$(get_setting key.function.b.up)"
+FN_B_ACTION_DOWN="$(get_setting key.function.b.down)"
 
-FN_AB_ACTION_UP="$(get_setting fn_ab.action.up)"
-FN_AB_ACTION_DOWN="$(get_setting fn_ab.action.down)"
+FN_AB_ACTION_UP="$(get_setting key.function.ab.up)"
+FN_AB_ACTION_DOWN="$(get_setting key.function.ab.down)"
 
 ### Set sane defaults to manage volume, brightness, wireless on/off, and led on/off.
 if [ -z "${FN_A_ACTION_UP}" ]
@@ -88,7 +158,7 @@ execute_kill() {
 }
 
 execute_action() {
-    ${DEBUG} && log $0 "FN_A_PRESSED = ${FN_A_PRESSED} | FN_B_PRESSED = ${FN_B_PRESSED} | VAL = ${1}"
+    ${DEBUG} && log $0 "${1}|${FN_A_PRESSED}|${FN_B_PRESSED}|${DPAD_UP_PRESSED}|${DPAD_DOWN_PRESSED}|${DPAD_RIGHT_PRESSED}|${DPAD_LEFT_PRESSED}"
     if [ "${FN_A_PRESSED}" = true ] && \
        [ "${FN_B_PRESSED}" = true ]
     then
@@ -131,9 +201,6 @@ execute_action() {
                 ${FN_B_ACTION_DOWN}
             ;;
         esac
-    else
-        ${DEBUG} && log $0 "Executing Volume action"
-        volume ${1}
     fi
 }
 
@@ -229,54 +296,86 @@ mkcontroller 2>/dev/null ||:
               FN_B_PRESSED=false
            fi
         ;;
-        (${FUNCTION_HOTKEY_EVENT})
+        (${FUNCTION_HOTKEY_A_EVENT})
            if [[ "${line}" =~ ${PRESS} ]]
            then
-              ${DEBUG} && log $0 "${FUNCTION_HOTKEY_EVENT}: Pressed"
-              HOTKEY_PRESSED=true
+              ${DEBUG} && log $0 "${FUNCTION_HOTKEY_A_EVENT}: Pressed"
+              HOTKEY_A_PRESSED=true
            elif [[ "${line}" =~ ${RELEASE} ]]
            then
-              ${DEBUG} && log $0 "${FUNCTION_HOTKEY_EVENT}: Released"
-              HOTKEY_PRESSED=false
+              ${DEBUG} && log $0 "${FUNCTION_HOTKEY_A_EVENT}: Released"
+              HOTKEY_A_PRESSED=false
            fi
         ;;
-        (${FUNCTION_SELECT_EVENT})
+        (${FUNCTION_HOTKEY_B_EVENT})
            if [[ "${line}" =~ ${PRESS} ]]
            then
-              ${DEBUG} && log $0 "${FUNCTION_SELECT_EVENT}: Pressed"
-              SELECT_PRESSED=true
-              if [ "${HOTKEY_PRESSED}" = true ] && \
-                 [ "${START_PRESSED}" = true ]
+              ${DEBUG} && log $0 "${FUNCTION_HOTKEY_B_EVENT}: Pressed"
+              HOTKEY_B_PRESSED=true
+              if [ "${HOTKEY_A_PRESSED}" = true ] && \
+                 [ "${HOTKEY_C_PRESSED}" = true ]
               then
                 execute_kill
               fi
            elif [[ "${line}" =~ ${RELEASE} ]]
            then
-              ${DEBUG} && log $0 "${FUNCTION_SELECT_EVENT}: Released"
-              SELECT_PRESSED=false
+              ${DEBUG} && log $0 "${FUNCTION_HOTKEY_B_EVENT}: Released"
+              HOTKEY_B_PRESSED=false
            fi
         ;;
-        (${FUNCTION_START_EVENT})
+        (${FUNCTION_HOTKEY_C_EVENT})
            if [[ "${line}" =~ ${PRESS} ]]
            then
-              ${DEBUG} && log $0 "${FUNCTION_START_EVENT}: Pressed"
-              START_PRESSED=true
-              if [ "${HOTKEY_PRESSED}" = true ] && \
-                 [ "${SELECT_PRESSED}" = true ]
+              ${DEBUG} && log $0 "${FUNCTION_HOTKEY_C_EVENT}: Pressed"
+              HOTKEY_C_PRESSED=true
+              if [ "${HOTKEY_A_PRESSED}" = true ] && \
+                 [ "${HOTKEY_B_PRESSED}" = true ]
               then
                 execute_kill
               fi
            elif [[ "${line}" =~ ${RELEASE} ]]
            then
-              ${DEBUG} && log $0 "${FUNCTION_START_EVENT}: Released"
-              START_PRESSED=false
+              ${DEBUG} && log $0 "${FUNCTION_HOTKEY_C_EVENT}: Released"
+              HOTKEY_C_PRESSED=false
            fi
+        ;;
+        (${FUNCTION_HOTKEY_DPAD_UP_EVENT}|${FUNCTION_HOTKEY_HAT_UP_EVENT})
+            if [ "${FN_A_PRESSED}" = true ] && \
+               [ "${DPAD_EVENTS}" = true ]
+            then
+              ${DEBUG} && log $0 "${FUNCTION_DPAD_UP_EVENT}${FUNCTION_HOTKEY_HAT_UP_EVENT}: Volume Up"
+              volume up
+            fi
+        ;;
+        (${FUNCTION_HOTKEY_DPAD_DOWN_EVENT}|${FUNCTION_HOTKEY_HAT_DOWN_EVENT})
+            if [ "${FN_A_PRESSED}" = true ] && \
+               [ "${DPAD_EVENTS}" = true ]
+            then
+              ${DEBUG} && log $0 "${FUNCTION_DPAD_DOWN_EVENT}${FUNCTION_HOTKEY_HAT_DOWN_EVENT}: Volume Down"
+              volume down
+            fi
+        ;;
+        (${FUNCTION_HOTKEY_DPAD_RIGHT_EVENT}|${FUNCTION_HOTKEY_HAT_RIGHT_EVENT})
+            if [ "${FN_A_PRESSED}" = true ] && \
+               [ "${DPAD_EVENTS}" = true ]
+            then
+              ${DEBUG} && log $0 "${FUNCTION_DPAD_RIGHT_EVENT}${FUNCTION_HOTKEY_HAT_RIGHT_EVENT}: Brightness Up"
+              brightness up
+            fi
+        ;;
+        (${FUNCTION_HOTKEY_DPAD_LEFT_EVENT}|${FUNCTION_HOTKEY_HAT_LEFT_EVENT})
+            if [ "${FN_A_PRESSED}" = true ] && \
+               [ "${DPAD_EVENTS}" = true ]
+            then
+              ${DEBUG} && log $0 "${FUNCTION_DPAD_LEFT_EVENT}${FUNCTION_HOTKEY_HAT_LEFT_EVENT}: Brightness Down"
+              brightness down
+            fi
         ;;
         (${FUNCTION_VOLUME_UP_EVENT})
-            execute_action up
+            volume up
         ;;
         (${FUNCTION_VOLUME_DOWN_EVENT})
-            execute_action down
+            volume down
         ;;
     esac
 done


### PR DESCRIPTION
## Description

Applies a common schema for hotkey input that can be managed with set_settings/system.cfg, it is defined as follows:

- `key.dpad.events` - Enables use of the dpad for volume and brightness up/down.
- `key.function.a` - Defines the primary function key for an action to be taken when pressed.
- `key.function.a.down` - Executes the defined action when the primary function key + volume down are pressed.
- `key.function.a.up` - Executes the defined action when the primary function key + volume up are pressed.
- `key.function.ab.down` - Executes the defined action when the primary and secondary function keys + volume down are pressed.
- `key.function.ab.up` - Executes the defined action when the primary and secondary function keys + volume up are pressed.
- `key.function.b` - Defines the secondary function key for an action to be taken when pressed.
- `key.function.b.down` - Executes the defined action when the secondary function key + volume down are pressed.
- `key.function.b.up` - Executes the defined action when the secondary function key + volume up are pressed.
- `key.hotkey.a` - Defines a primary hotkey used for dpad and global kill events.
- `key.hotkey.b` - Defines the secondary hotkey for global kill.
- `key.hotkey.c` - Defines the tertiary hotkey for global kill.
- `key.volume.down` - Defines the volume down match event.
- `key.volume.up` - Defines the volume up match event.

Additionally corrects logging to follow system standards (system.loglevel = verbose).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Tested on Max 3 and 2s.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
