### PR TITLE
Force Maven repository to be within the apache-ant cache

### DIFF
--- a/packages/devel/apache-ant/package.mk
+++ b/packages/devel/apache-ant/package.mk
@@ -15,26 +15,33 @@ make_host() {
   (
   export JAVA_HOME=$(get_build_dir jdk-zulu)
 
-   ### Work around for down/missing ftp server.
-   TMPCACHE="${ROOT}/.ant/tempcache"
-   if [ ! -d "${TMPCACHE}" ]
-   then
-     mkdir -p ${TMPCACHE}
-   fi
+  ### Work around for down/missing ftp server.
+  TMPCACHE="${ROOT}/.ant/tempcache"
+  if [ ! -d "${TMPCACHE}" ]
+  then
+    mkdir -p ${TMPCACHE}
+  fi
 
-   if [ ! -e "${TMPCACHE}/NetRexx.zip" ]
-   then
-     curl -Lo ${TMPCACHE}/NetRexx.zip https://public.dhe.ibm.com/software/awdtools/netrexx/NetRexx.zip
-   fi
+  ### Force Maven repository to be in ${ROOT}
+  M2_REPOSITORY="${ROOT}/.ant/.m2"
+  if [ ! -d "${M2_REPOSITORY}" ]
+  then
+    mkdir -p ${M2_REPOSITORY}/repository
+  fi
+
+  if [ ! -e "${TMPCACHE}/NetRexx.zip" ]
+  then
+    curl -Lo ${TMPCACHE}/NetRexx.zip https://public.dhe.ibm.com/software/awdtools/netrexx/NetRexx.zip
+  fi
 
   ./bootstrap.sh
-  ./bootstrap/bin/ant -f fetch.xml -Ddest=optional -Dtemp.dir=${TMPCACHE}
+  ./bootstrap/bin/ant -f fetch.xml -Ddest=optional -Dtemp.dir=${TMPCACHE} -Dmaven.repo.local=${M2_REPOSITORY}
   ./build.sh -Ddist.dir=${PKG_BUILD}/binary dist
   )
 }
 
 makeinstall_host() {
   mkdir -p ${TOOLCHAIN}/bin
-    cp binary/bin/ant ${TOOLCHAIN}/bin
-    cp -r binary/lib ${TOOLCHAIN}
+  cp binary/bin/ant ${TOOLCHAIN}/bin
+  cp -r binary/lib ${TOOLCHAIN}
 }


### PR DESCRIPTION
## Description

Maven repository cache was sometimes located in ~ instead of $ROOT, this change forces the maven repository to exist inside the apache-ant cache.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
(May require a clean of apache-ant:host)

## How Has This Been Tested Locally?

I'm not sure what packages use apache-ant, but this change allows my build to complete