### PR TITLE
GameForce Ace - Fix DolphinSA hotkeys (x11 backend)

### DIFF
--- a/packages/emulators/standalone/dolphin-sa/config/RK3588-ACE/GCPadNew.ini.south
+++ b/packages/emulators/standalone/dolphin-sa/config/RK3588-ACE/GCPadNew.ini.south
@@ -2,7 +2,7 @@
 Device = evdev/0/GameForce ACE Gamepad
 Buttons/A = Button 0
 Buttons/B = Button 4
-Buttons/Start = Button 7
+Buttons/Start = Button 9
 Buttons/X = Button 1
 Buttons/Y = Button 3
 Buttons/Z = Button 6

--- a/packages/emulators/standalone/dolphin-sa/config/RK3588-ACE/GCPadNew.ini.west
+++ b/packages/emulators/standalone/dolphin-sa/config/RK3588-ACE/GCPadNew.ini.west
@@ -2,7 +2,7 @@
 Device = evdev/0/GameForce ACE Gamepad
 Buttons/A = Button 1
 Buttons/B = Button 0
-Buttons/Start = Button 7
+Buttons/Start = Button 9
 Buttons/X = Button 3
 Buttons/Y = Button 4
 Buttons/Z = Button 6

--- a/packages/emulators/standalone/dolphin-sa/patches/wayland/000-add-wayland.patch
+++ b/packages/emulators/standalone/dolphin-sa/patches/wayland/000-add-wayland.patch
@@ -1,6 +1,6 @@
 diff -rupN dolphin.orig/CMake/FindWaylandProtocols.cmake dolphin/CMake/FindWaylandProtocols.cmake
 --- dolphin.orig/CMake/FindWaylandProtocols.cmake	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/CMake/FindWaylandProtocols.cmake	2023-10-27 13:46:38.317333047 +0000
++++ dolphin/CMake/FindWaylandProtocols.cmake	2024-03-05 04:06:08.240295843 +0000
 @@ -0,0 +1,28 @@
 +# from https://github.com/glfw/glfw/blob/master/CMake/modules/FindWaylandProtocols.cmake
 +
@@ -32,7 +32,7 @@ diff -rupN dolphin.orig/CMake/FindWaylandProtocols.cmake dolphin/CMake/FindWayla
 +set(WAYLAND_PROTOCOLS_VERSION ${WaylandProtocols_VERSION})
 diff -rupN dolphin.orig/CMake/FindXKBCommon.cmake dolphin/CMake/FindXKBCommon.cmake
 --- dolphin.orig/CMake/FindXKBCommon.cmake	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/CMake/FindXKBCommon.cmake	2023-10-27 13:46:38.317333047 +0000
++++ dolphin/CMake/FindXKBCommon.cmake	2024-03-05 04:06:08.240295843 +0000
 @@ -0,0 +1,33 @@
 +# - Try to find XKBCommon
 +# Once done, this will define
@@ -68,8 +68,8 @@ diff -rupN dolphin.orig/CMake/FindXKBCommon.cmake dolphin/CMake/FindXKBCommon.cm
 +
 +mark_as_advanced(XKBCOMMON_LIBRARY XKBCOMMON_INCLUDE_DIR)
 diff -rupN dolphin.orig/CMakeLists.txt dolphin/CMakeLists.txt
---- dolphin.orig/CMakeLists.txt	2023-09-26 17:58:02.593990718 +0000
-+++ dolphin/CMakeLists.txt	2023-10-27 13:46:40.473383166 +0000
+--- dolphin.orig/CMakeLists.txt	2024-03-05 04:05:25.878960469 +0000
++++ dolphin/CMakeLists.txt	2024-03-05 04:06:08.240295843 +0000
 @@ -47,6 +47,7 @@ set(DOLPHIN_DEFAULT_UPDATE_TRACK "" CACH
  
  if(UNIX AND NOT APPLE AND NOT ANDROID)
@@ -97,8 +97,8 @@ diff -rupN dolphin.orig/CMakeLists.txt dolphin/CMakeLists.txt
    find_package(EGL)
    if(EGL_FOUND)
 diff -rupN dolphin.orig/Source/Core/Common/CMakeLists.txt dolphin/Source/Core/Common/CMakeLists.txt
---- dolphin.orig/Source/Core/Common/CMakeLists.txt	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin/Source/Core/Common/CMakeLists.txt	2023-10-27 13:46:39.913370149 +0000
+--- dolphin.orig/Source/Core/Common/CMakeLists.txt	2024-03-05 04:05:26.574982411 +0000
++++ dolphin/Source/Core/Common/CMakeLists.txt	2024-03-05 04:06:08.240295843 +0000
 @@ -253,11 +253,20 @@ if(ENABLE_EGL AND EGL_FOUND)
        GL/GLInterface/EGLAndroid.cpp
        GL/GLInterface/EGLAndroid.h
@@ -126,8 +126,8 @@ diff -rupN dolphin.orig/Source/Core/Common/CMakeLists.txt dolphin/Source/Core/Co
    target_include_directories(common PRIVATE ${EGL_INCLUDE_DIRS})
    target_link_libraries(common PUBLIC ${EGL_LIBRARIES})
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.cpp dolphin/Source/Core/Common/GL/GLContext.cpp
---- dolphin.orig/Source/Core/Common/GL/GLContext.cpp	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin/Source/Core/Common/GL/GLContext.cpp	2023-10-27 13:46:39.913370149 +0000
+--- dolphin.orig/Source/Core/Common/GL/GLContext.cpp	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Common/GL/GLContext.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -25,6 +25,9 @@
  #if defined(ANDROID)
  #include "Common/GL/GLInterface/EGLAndroid.h"
@@ -164,8 +164,8 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.cpp dolphin/Source/Core/
    if (wsi.type == WindowSystemType::Headless || wsi.type == WindowSystemType::FBDev)
      context = std::make_unique<GLContextEGL>();
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.h dolphin/Source/Core/Common/GL/GLContext.h
---- dolphin.orig/Source/Core/Common/GL/GLContext.h	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin/Source/Core/Common/GL/GLContext.h	2023-10-27 13:46:39.913370149 +0000
+--- dolphin.orig/Source/Core/Common/GL/GLContext.h	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Common/GL/GLContext.h	2024-03-05 04:06:08.240295843 +0000
 @@ -36,8 +36,8 @@ public:
    virtual bool MakeCurrent();
    virtual bool ClearCurrent();
@@ -178,8 +178,8 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLContext.h dolphin/Source/Core/Co
    virtual void Swap();
    virtual void SwapInterval(int interval);
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.h dolphin/Source/Core/Common/GL/GLInterface/AGL.h
---- dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.h	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/AGL.h	2023-10-27 13:46:39.913370149 +0000
+--- dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.h	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/AGL.h	2024-03-05 04:06:08.240295843 +0000
 @@ -27,6 +27,8 @@ public:
  
    bool MakeCurrent() override;
@@ -190,8 +190,8 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.h dolphin/Source/C
    void Update() override;
  
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.mm dolphin/Source/Core/Common/GL/GLInterface/AGL.mm
---- dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.mm	2023-09-26 17:58:02.801995519 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/AGL.mm	2023-10-27 13:46:39.913370149 +0000
+--- dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.mm	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/AGL.mm	2024-03-05 04:06:08.240295843 +0000
 @@ -144,7 +144,7 @@ bool GLContextAGL::ClearCurrent()
    return true;
  }
@@ -202,8 +202,8 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/AGL.mm dolphin/Source/
    if (!m_view)
      return;
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.cpp dolphin/Source/Core/Common/GL/GLInterface/EGL.cpp
---- dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.cpp	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/EGL.cpp	2023-10-27 13:46:39.913370149 +0000
+--- dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.cpp	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/EGL.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -292,8 +292,8 @@ bool GLContextEGL::CreateWindowSurface()
  {
    if (!IsHeadless())
@@ -267,8 +267,8 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.cpp dolphin/Source
 +  m_backbuffer_height = static_cast<u32>(surface_height);
 +}
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.h dolphin/Source/Core/Common/GL/GLInterface/EGL.h
---- dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/EGL.h	2023-10-27 13:46:39.913370149 +0000
+--- dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.h	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/EGL.h	2024-03-05 04:06:08.240295843 +0000
 @@ -22,7 +22,8 @@ public:
    bool MakeCurrent() override;
    bool ClearCurrent() override;
@@ -294,7 +294,7 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGL.h dolphin/Source/C
    std::vector<int> m_attribs;
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.cpp dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.cpp
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.cpp	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -0,0 +1,36 @@
 +// Copyright 2019 Dolphin Emulator Project
 +// Licensed under GPLv2+
@@ -334,7 +334,7 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.cpp dolphin
 +}
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.h dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.h
 --- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.h	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.h	2023-10-27 13:46:39.913370149 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/EGLWayland.h	2024-03-05 04:06:08.240295843 +0000
 @@ -0,0 +1,19 @@
 +// Copyright 2019 Dolphin Emulator Project
 +// Licensed under GPLv2+
@@ -356,8 +356,8 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLWayland.h dolphin/S
 +  EGLNativeWindowType GetEGLNativeWindow(EGLConfig config) override;
 +};
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.cpp dolphin/Source/Core/Common/GL/GLInterface/EGLX11.cpp
---- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.cpp	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/EGLX11.cpp	2023-10-27 13:46:39.913370149 +0000
+--- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.cpp	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/EGLX11.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -11,7 +11,7 @@ GLContextEGLX11::~GLContextEGLX11()
    m_render_window.reset();
  }
@@ -368,8 +368,8 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.cpp dolphin/Sou
    m_render_window->UpdateDimensions();
    m_backbuffer_width = m_render_window->GetWidth();
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.h dolphin/Source/Core/Common/GL/GLInterface/EGLX11.h
---- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/EGLX11.h	2023-10-27 13:46:39.913370149 +0000
+--- dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.h	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/EGLX11.h	2024-03-05 04:06:08.240295843 +0000
 @@ -13,7 +13,7 @@ class GLContextEGLX11 final : public GLC
  public:
    ~GLContextEGLX11() override;
@@ -380,8 +380,8 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/EGLX11.h dolphin/Sourc
  protected:
    EGLDisplay OpenEGLDisplay() override;
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.cpp dolphin/Source/Core/Common/GL/GLInterface/GLX.cpp
---- dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.cpp	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/GLX.cpp	2023-10-27 13:46:39.913370149 +0000
+--- dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.cpp	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/GLX.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -310,7 +310,7 @@ bool GLContextGLX::ClearCurrent()
    return glXMakeCurrent(m_display, None, nullptr);
  }
@@ -392,8 +392,8 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.cpp dolphin/Source
    m_render_window->UpdateDimensions();
    m_backbuffer_width = m_render_window->GetWidth();
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.h dolphin/Source/Core/Common/GL/GLInterface/GLX.h
---- dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/GLX.h	2023-10-27 13:46:39.913370149 +0000
+--- dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.h	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/GLX.h	2024-03-05 04:06:08.240295843 +0000
 @@ -24,7 +24,7 @@ public:
    bool MakeCurrent() override;
    bool ClearCurrent() override;
@@ -404,8 +404,8 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/GLX.h dolphin/Source/C
    void SwapInterval(int Interval) override;
    void Swap() override;
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.cpp dolphin/Source/Core/Common/GL/GLInterface/WGL.cpp
---- dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.cpp	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/WGL.cpp	2023-10-27 13:46:39.913370149 +0000
+--- dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.cpp	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/WGL.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -480,7 +480,7 @@ bool GLContextWGL::ClearCurrent()
  }
  
@@ -416,8 +416,8 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.cpp dolphin/Source
    RECT rcWindow;
    GetClientRect(m_window_handle, &rcWindow);
 diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.h dolphin/Source/Core/Common/GL/GLInterface/WGL.h
---- dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/GL/GLInterface/WGL.h	2023-10-27 13:46:39.913370149 +0000
+--- dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.h	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Common/GL/GLInterface/WGL.h	2024-03-05 04:06:08.240295843 +0000
 @@ -19,7 +19,7 @@ public:
    bool MakeCurrent() override;
    bool ClearCurrent() override;
@@ -428,8 +428,8 @@ diff -rupN dolphin.orig/Source/Core/Common/GL/GLInterface/WGL.h dolphin/Source/C
    void Swap() override;
    void SwapInterval(int interval) override;
 diff -rupN dolphin.orig/Source/Core/Common/WindowSystemInfo.h dolphin/Source/Core/Common/WindowSystemInfo.h
---- dolphin.orig/Source/Core/Common/WindowSystemInfo.h	2023-09-26 17:58:02.805995611 +0000
-+++ dolphin/Source/Core/Common/WindowSystemInfo.h	2023-10-27 13:46:39.937370706 +0000
+--- dolphin.orig/Source/Core/Common/WindowSystemInfo.h	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Common/WindowSystemInfo.h	2024-03-05 04:06:08.240295843 +0000
 @@ -40,7 +40,11 @@ struct WindowSystemInfo
    // This is kept seperate as input may require a different handle to rendering, and
    // during video backend startup the surface pointer may change (MoltenVK).
@@ -444,8 +444,8 @@ diff -rupN dolphin.orig/Source/Core/Common/WindowSystemInfo.h dolphin/Source/Cor
    float render_surface_scale = 1.0f;
  };
 diff -rupN dolphin.orig/Source/Core/Core/BootManager.cpp dolphin/Source/Core/Core/BootManager.cpp
---- dolphin.orig/Source/Core/Core/BootManager.cpp	2023-09-26 17:58:02.809995703 +0000
-+++ dolphin/Source/Core/Core/BootManager.cpp	2023-10-27 13:48:21.555727990 +0000
+--- dolphin.orig/Source/Core/Core/BootManager.cpp	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Core/BootManager.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -64,6 +64,11 @@ bool BootCore(std::unique_ptr<BootParame
    if (!StartUp.SetPathsAndGameMetadata(*boot))
      return false;
@@ -459,8 +459,8 @@ diff -rupN dolphin.orig/Source/Core/Core/BootManager.cpp dolphin/Source/Core/Cor
    if (Movie::IsPlayingInput() && Movie::IsConfigSaved())
    {
 diff -rupN dolphin.orig/Source/Core/Core/ConfigManager.cpp dolphin/Source/Core/Core/ConfigManager.cpp
---- dolphin.orig/Source/Core/Core/ConfigManager.cpp	2023-09-26 17:58:02.809995703 +0000
-+++ dolphin/Source/Core/Core/ConfigManager.cpp	2023-10-27 13:48:21.555727990 +0000
+--- dolphin.orig/Source/Core/Core/ConfigManager.cpp	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Core/ConfigManager.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -139,6 +139,10 @@ void SConfig::SetRunningGameMetadata(con
    SetRunningGameMetadata(game_id, "", 0, 0, DiscIO::Region::Unknown);
  }
@@ -473,8 +473,8 @@ diff -rupN dolphin.orig/Source/Core/Core/ConfigManager.cpp dolphin/Source/Core/C
                                       u64 title_id, u16 revision, DiscIO::Region region)
  {
 diff -rupN dolphin.orig/Source/Core/Core/ConfigManager.h dolphin/Source/Core/Core/ConfigManager.h
---- dolphin.orig/Source/Core/Core/ConfigManager.h	2023-09-26 17:58:02.809995703 +0000
-+++ dolphin/Source/Core/Core/ConfigManager.h	2023-10-27 13:48:21.555727990 +0000
+--- dolphin.orig/Source/Core/Core/ConfigManager.h	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Core/ConfigManager.h	2024-03-05 04:06:08.240295843 +0000
 @@ -56,6 +56,8 @@ struct SConfig
    // TODO: remove this as soon as the ticket view hack in IOS/ES/Views is dropped.
    bool m_disc_booted_from_game_list = false;
@@ -493,8 +493,8 @@ diff -rupN dolphin.orig/Source/Core/Core/ConfigManager.h dolphin/Source/Core/Cor
    std::string m_gametdb_id;
    std::string m_title_name;
 diff -rupN dolphin.orig/Source/Core/Core/Core.cpp dolphin/Source/Core/Core/Core.cpp
---- dolphin.orig/Source/Core/Core/Core.cpp	2023-09-26 17:58:02.809995703 +0000
-+++ dolphin/Source/Core/Core/Core.cpp	2023-10-27 19:08:44.565345159 +0000
+--- dolphin.orig/Source/Core/Core/Core.cpp	2024-03-05 04:05:26.578982537 +0000
++++ dolphin/Source/Core/Core/Core.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -474,6 +474,8 @@ static void EmuThread(std::unique_ptr<Bo
    // is relative to the render window, instead of the main window.
    ASSERT(g_controller_interface.IsInit());
@@ -505,8 +505,8 @@ diff -rupN dolphin.orig/Source/Core/Core/Core.cpp dolphin/Source/Core/Core/Core.
    Pad::LoadConfig();
    Pad::LoadGBAConfig();
 diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.cpp dolphin/Source/Core/Core/HW/GCPadEmu.cpp
---- dolphin.orig/Source/Core/Core/HW/GCPadEmu.cpp	2023-09-26 17:58:02.817995888 +0000
-+++ dolphin/Source/Core/Core/HW/GCPadEmu.cpp	2023-10-27 13:46:40.045373218 +0000
+--- dolphin.orig/Source/Core/Core/HW/GCPadEmu.cpp	2024-03-05 04:05:26.582982663 +0000
++++ dolphin/Source/Core/Core/HW/GCPadEmu.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -24,6 +24,7 @@ static const u16 button_bitmasks[] = {
      PAD_BUTTON_X,
      PAD_BUTTON_Y,
@@ -526,8 +526,8 @@ diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.cpp dolphin/Source/Core/Cor
    groups.emplace_back(m_main_stick = new ControllerEmu::OctagonAnalogStick(
                            MAIN_STICK_GROUP, _trans("Control Stick"), MAIN_STICK_GATE_RADIUS));
 diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.h dolphin/Source/Core/Core/HW/GCPadEmu.h
---- dolphin.orig/Source/Core/Core/HW/GCPadEmu.h	2023-09-26 17:58:02.817995888 +0000
-+++ dolphin/Source/Core/Core/HW/GCPadEmu.h	2023-10-27 13:46:40.045373218 +0000
+--- dolphin.orig/Source/Core/Core/HW/GCPadEmu.h	2024-03-05 04:05:26.582982663 +0000
++++ dolphin/Source/Core/Core/HW/GCPadEmu.h	2024-03-05 04:06:08.240295843 +0000
 @@ -65,6 +65,7 @@ public:
    static constexpr const char* X_BUTTON = "X";
    static constexpr const char* Y_BUTTON = "Y";
@@ -537,8 +537,8 @@ diff -rupN dolphin.orig/Source/Core/Core/HW/GCPadEmu.h dolphin/Source/Core/Core/
  
    // i18n: The left trigger button (labeled L on real controllers)
 diff -rupN dolphin.orig/Source/Core/Core/State.cpp dolphin/Source/Core/Core/State.cpp
---- dolphin.orig/Source/Core/Core/State.cpp	2023-09-26 17:58:02.829996165 +0000
-+++ dolphin/Source/Core/Core/State.cpp	2023-10-27 19:10:09.907147486 +0000
+--- dolphin.orig/Source/Core/Core/State.cpp	2024-03-05 04:05:26.586982789 +0000
++++ dolphin/Source/Core/Core/State.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -327,7 +327,10 @@ static std::string SystemTimeAsDoubleToS
  #endif
  }
@@ -633,8 +633,8 @@ diff -rupN dolphin.orig/Source/Core/Core/State.cpp dolphin/Source/Core/Core/Stat
  
  void LoadLastSaved(int i)
 diff -rupN dolphin.orig/Source/Core/DolphinLib.props dolphin/Source/Core/DolphinLib.props
---- dolphin.orig/Source/Core/DolphinLib.props	2023-09-26 17:58:02.829996165 +0000
-+++ dolphin/Source/Core/DolphinLib.props	2023-10-27 13:46:40.185376472 +0000
+--- dolphin.orig/Source/Core/DolphinLib.props	2024-03-05 04:05:26.590982915 +0000
++++ dolphin/Source/Core/DolphinLib.props	2024-03-05 04:06:08.240295843 +0000
 @@ -1207,6 +1207,7 @@
      <ClCompile Include="VideoBackends\Vulkan\VKPerfQuery.cpp" />
      <ClCompile Include="VideoBackends\Vulkan\VKPipeline.cpp" />
@@ -644,8 +644,8 @@ diff -rupN dolphin.orig/Source/Core/DolphinLib.props dolphin/Source/Core/Dolphin
      <ClCompile Include="VideoBackends\Vulkan\VKStreamBuffer.cpp" />
      <ClCompile Include="VideoBackends\Vulkan\VKSwapChain.cpp" />
 diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/CMakeLists.txt dolphin/Source/Core/DolphinNoGUI/CMakeLists.txt
---- dolphin.orig/Source/Core/DolphinNoGUI/CMakeLists.txt	2023-09-26 17:58:02.833996257 +0000
-+++ dolphin/Source/Core/DolphinNoGUI/CMakeLists.txt	2023-10-27 13:46:40.157375820 +0000
+--- dolphin.orig/Source/Core/DolphinNoGUI/CMakeLists.txt	2024-03-05 04:05:26.590982915 +0000
++++ dolphin/Source/Core/DolphinNoGUI/CMakeLists.txt	2024-03-05 04:06:08.240295843 +0000
 @@ -17,6 +17,22 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux"
    target_sources(dolphin-nogui PRIVATE PlatformFBDev.cpp)
  endif()
@@ -670,8 +670,8 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/CMakeLists.txt dolphin/Source/C
  
  target_link_libraries(dolphin-nogui
 diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/MainNoGUI.cpp dolphin/Source/Core/DolphinNoGUI/MainNoGUI.cpp
---- dolphin.orig/Source/Core/DolphinNoGUI/MainNoGUI.cpp	2023-09-26 17:58:02.833996257 +0000
-+++ dolphin/Source/Core/DolphinNoGUI/MainNoGUI.cpp	2023-10-27 13:46:40.173376194 +0000
+--- dolphin.orig/Source/Core/DolphinNoGUI/MainNoGUI.cpp	2024-03-05 04:05:26.590982915 +0000
++++ dolphin/Source/Core/DolphinNoGUI/MainNoGUI.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -155,6 +155,11 @@ static std::unique_ptr<Platform> GetPlat
  {
    std::string platform_name = static_cast<const char*>(options.get("platform"));
@@ -696,8 +696,8 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/MainNoGUI.cpp dolphin/Source/Co
  
    optparse::Values& options = CommandLineParse::ParseArguments(parser.get(), argc, argv);
 diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/Platform.h dolphin/Source/Core/DolphinNoGUI/Platform.h
---- dolphin.orig/Source/Core/DolphinNoGUI/Platform.h	2023-09-26 17:58:02.833996257 +0000
-+++ dolphin/Source/Core/DolphinNoGUI/Platform.h	2023-10-27 13:46:40.185376472 +0000
+--- dolphin.orig/Source/Core/DolphinNoGUI/Platform.h	2024-03-05 04:05:26.590982915 +0000
++++ dolphin/Source/Core/DolphinNoGUI/Platform.h	2024-03-05 04:06:08.240295843 +0000
 @@ -35,6 +35,10 @@ public:
    static std::unique_ptr<Platform> CreateX11Platform();
  #endif
@@ -711,7 +711,7 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/Platform.h dolphin/Source/Core/
  #endif
 diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformWayland.cpp dolphin/Source/Core/DolphinNoGUI/PlatformWayland.cpp
 --- dolphin.orig/Source/Core/DolphinNoGUI/PlatformWayland.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/Source/Core/DolphinNoGUI/PlatformWayland.cpp	2023-10-27 13:46:40.185376472 +0000
++++ dolphin/Source/Core/DolphinNoGUI/PlatformWayland.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -0,0 +1,364 @@
 +// Copyright 2018 Dolphin Emulator Project
 +// Licensed under GPLv2+
@@ -1078,9 +1078,23 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformWayland.cpp dolphin/Sou
 +  return std::make_unique<PlatformWayland>();
 +}
 diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp dolphin/Source/Core/DolphinNoGUI/PlatformX11.cpp
---- dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp	2023-09-26 17:58:02.833996257 +0000
-+++ dolphin/Source/Core/DolphinNoGUI/PlatformX11.cpp	2023-10-27 13:46:40.185376472 +0000
-@@ -57,8 +57,8 @@ private:
+--- dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp	2024-03-05 04:05:26.590982915 +0000
++++ dolphin/Source/Core/DolphinNoGUI/PlatformX11.cpp	2024-03-05 04:21:20.855117890 +0000
+@@ -16,6 +16,13 @@ static constexpr auto X_None = None;
+ #include "Core/Core.h"
+ #include "Core/State.h"
+ 
++#include "Core/HW/GCPad.h"
++#include "InputCommon/GCPadStatus.h"
++#include <fmt/format.h>
++#include "Core/Config/GraphicsSettings.h"
++#include "VideoCommon/VideoConfig.h"
++#include "VideoCommon/OnScreenDisplay.h"
++
+ #include <climits>
+ #include <cstdio>
+ #include <cstring>
+@@ -57,8 +64,8 @@ private:
  #endif
    int m_window_x = Config::Get(Config::MAIN_RENDER_WINDOW_XPOS);
    int m_window_y = Config::Get(Config::MAIN_RENDER_WINDOW_YPOS);
@@ -1091,7 +1105,126 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp dolphin/Source/
  };
  
  PlatformX11::~PlatformX11()
-@@ -166,6 +166,8 @@ WindowSystemInfo PlatformX11::GetWindowS
+@@ -149,11 +156,118 @@ void PlatformX11::MainLoop()
+ {
+   while (IsRunning())
+   {
++    static int hotkey = 0;
++    static int slot = 0;
++    static int fps = 0;
++    static int aspect = 0;
++    static int fforward = 0;
++    static int ires = 0;
++
+     UpdateRunningFlag();
+     Core::HostDispatchJobs();
+     ProcessEvents();
+     UpdateWindowPosition();
+ 
++    if(Pad::IsInitialized()) {
++      GCPadStatus x = Pad::GetStatus(0);
++
++      if( (x.button & PAD_BUTTON_HOTKEY) == PAD_BUTTON_HOTKEY) { // hotkey pressed
++       if(hotkey == 1) {
++         hotkey = 2;
++       }
++      } else {
++       hotkey = 1; // assure hotkey is released between actions
++      }
++
++      if(hotkey == 2) { // hotkey pressed
++       if( (x.button & PAD_BUTTON_START) == PAD_BUTTON_START) {
++         RequestShutdown();
++         hotkey = 0;
++       }
++
++       if( (x.button & PAD_TRIGGER_L) == PAD_TRIGGER_L) {
++         State::Load(slot);
++         hotkey = 0;
++       }
++       if( (x.button & PAD_TRIGGER_R) == PAD_TRIGGER_R) {
++         State::Save(slot);
++         hotkey = 0;
++       }
++       if( (x.button & PAD_BUTTON_DOWN) == PAD_BUTTON_DOWN) {
++         if(slot > 0) slot--;
++         Core::DisplayMessage(fmt::format("Slot {} selected", slot), 4000);
++         hotkey = 0;
++       }
++       if( (x.button & PAD_BUTTON_UP) == PAD_BUTTON_UP) {
++         if(slot < 10) slot++;
++         Core::DisplayMessage(fmt::format("Slot {} selected", slot), 4000);
++         hotkey = 0;
++       }
++       if( (x.button & PAD_BUTTON_A) == PAD_BUTTON_A) {
++         Core::SaveScreenShot();
++         hotkey = 0;
++       }
++       if( (x.button & PAD_BUTTON_Y) == PAD_BUTTON_Y) {
++         if(fps == 0) {
++           Config::SetCurrent(Config::GFX_SHOW_FPS, True);
++           fps = 1;
++         } else {
++           Config::SetCurrent(Config::GFX_SHOW_FPS, False);
++           fps = 0;
++         }
++         hotkey = 0;
++       }
++       if( (x.button & PAD_BUTTON_X) == PAD_BUTTON_X) {
++         if(aspect == 0) {
++           Config::SetCurrent(Config::GFX_ASPECT_RATIO, AspectMode::Stretch);
++           aspect = 1;
++         } else {
++           Config::SetCurrent(Config::GFX_ASPECT_RATIO, AspectMode::Auto);
++           aspect = 0;
++         }
++         hotkey = 0;
++       }
++       if( (x.button & PAD_BUTTON_B) == PAD_BUTTON_B) {
++         if(ires == 0) {
++           Config::SetCurrent(Config::GFX_EFB_SCALE, 2);
++           OSD::AddMessage("Internal Resolution: 480P");
++           ires = 2;
++         }
++         else if(ires == 2) {
++           Config::SetCurrent(Config::GFX_EFB_SCALE, 4);
++           OSD::AddMessage("Internal Resolution: 720P");
++           ires = 4;
++         }
++         else if(ires == 4) {
++           Config::SetCurrent(Config::GFX_EFB_SCALE, 6);
++           OSD::AddMessage("Internal Resolution: 1080P");
++           ires = 6;
++         } else {
++           Config::SetCurrent(Config::GFX_EFB_SCALE, 1);
++           OSD::AddMessage("Internal Resolution: 240P");
++           ires = 0;
++         }
++         hotkey = 0;
++       }
++       if( (x.button & PAD_TRIGGER_Z) == PAD_TRIGGER_Z) {
++        if(fforward == 0) {
++          auto speed = Config::Get(Config::MAIN_EMULATION_SPEED) + 1.0;
++          speed = (speed >= 0.95 && speed <= 1.05) ? 1.0 : speed;
++          Config::SetCurrent(Config::MAIN_EMULATION_SPEED, speed);
++          OSD::AddMessage("Fast Forward: ON");
++          fforward = 1;
++        } else {
++          auto speed = Config::Get(Config::MAIN_EMULATION_SPEED) - 1.0;
++          speed = (speed <= 0 || (speed >= 0.95 && speed <= 1.05)) ? 1.0 : speed;
++          Config::SetCurrent(Config::MAIN_EMULATION_SPEED, speed);
++          OSD::AddMessage("Fast Forward: OFF");
++          fforward = 0;
++        }
++        hotkey = 0;
++       }
++    }
++    }
++
+     // TODO: Is this sleep appropriate?
+     std::this_thread::sleep_for(std::chrono::milliseconds(1));
+   }
+@@ -166,6 +280,8 @@ WindowSystemInfo PlatformX11::GetWindowS
    wsi.display_connection = static_cast<void*>(m_display);
    wsi.render_window = reinterpret_cast<void*>(m_window);
    wsi.render_surface = reinterpret_cast<void*>(m_window);
@@ -1100,7 +1233,7 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp dolphin/Source/
    return wsi;
  }
  
-@@ -176,8 +178,9 @@ void PlatformX11::UpdateWindowPosition()
+@@ -176,8 +292,9 @@ void PlatformX11::UpdateWindowPosition()
  
    Window winDummy;
    unsigned int borderDummy, depthDummy;
@@ -1112,7 +1245,7 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp dolphin/Source/
  }
  
  void PlatformX11::ProcessEvents()
-@@ -264,7 +267,10 @@ void PlatformX11::ProcessEvents()
+@@ -264,7 +381,10 @@ void PlatformX11::ProcessEvents()
      case ConfigureNotify:
      {
        if (g_renderer)
@@ -1125,8 +1258,8 @@ diff -rupN dolphin.orig/Source/Core/DolphinNoGUI/PlatformX11.cpp dolphin/Source/
      break;
      }
 diff -rupN dolphin.orig/Source/Core/InputCommon/GCPadStatus.h dolphin/Source/Core/InputCommon/GCPadStatus.h
---- dolphin.orig/Source/Core/InputCommon/GCPadStatus.h	2023-09-26 17:58:02.845996536 +0000
-+++ dolphin/Source/Core/InputCommon/GCPadStatus.h	2023-10-27 13:46:40.297379075 +0000
+--- dolphin.orig/Source/Core/InputCommon/GCPadStatus.h	2024-03-05 04:05:26.598983167 +0000
++++ dolphin/Source/Core/InputCommon/GCPadStatus.h	2024-03-05 04:06:08.240295843 +0000
 @@ -26,6 +26,7 @@ enum PadButton
    PAD_BUTTON_X = 0x0400,
    PAD_BUTTON_Y = 0x0800,
@@ -1136,8 +1269,8 @@ diff -rupN dolphin.orig/Source/Core/InputCommon/GCPadStatus.h dolphin/Source/Cor
  
  struct GCPadStatus
 diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.cpp dolphin/Source/Core/VideoBackends/OGL/OGLRender.cpp
---- dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/OGL/OGLRender.cpp	2023-10-27 13:46:40.349380285 +0000
+--- dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.cpp	2024-03-05 04:05:26.598983167 +0000
++++ dolphin/Source/Core/VideoBackends/OGL/OGLRender.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -471,11 +471,7 @@ Renderer::Renderer(std::unique_ptr<GLCon
    g_ogl_config.bSupportsDebug =
        GLExtensions::Supports("GL_KHR_debug") || GLExtensions::Supports("GL_ARB_debug_output");
@@ -1249,8 +1382,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.cpp dolphin/Sour
    m_backbuffer_height = m_main_gl_context->GetBackBufferHeight();
    m_system_framebuffer->UpdateDimensions(m_backbuffer_width, m_backbuffer_height);
 diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.h dolphin/Source/Core/VideoBackends/OGL/OGLRender.h
---- dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/OGL/OGLRender.h	2023-10-27 13:46:40.345380190 +0000
+--- dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.h	2024-03-05 04:05:26.598983167 +0000
++++ dolphin/Source/Core/VideoBackends/OGL/OGLRender.h	2024-03-05 04:06:08.240295843 +0000
 @@ -31,6 +31,14 @@ enum GlslVersion
    GlslEs310,  // GLES 3.1
    GlslEs320,  // GLES 3.2
@@ -1295,8 +1428,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLRender.h dolphin/Source
    bool bSupportsImageLoadStore;
    bool bSupportsAniso;
 diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLTexture.cpp dolphin/Source/Core/VideoBackends/OGL/OGLTexture.cpp
---- dolphin.orig/Source/Core/VideoBackends/OGL/OGLTexture.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/OGL/OGLTexture.cpp	2023-10-27 13:46:40.345380190 +0000
+--- dolphin.orig/Source/Core/VideoBackends/OGL/OGLTexture.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/OGL/OGLTexture.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -128,12 +128,18 @@ OGLTexture::OGLTexture(const TextureConf
    GLenum gl_internal_format = GetGLInternalFormatForTextureFormat(m_config.format, true);
    if (tex_config.IsMultisampled())
@@ -1318,8 +1451,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/OGLTexture.cpp dolphin/Sou
    else if (g_ogl_config.bSupportsTextureStorage)
    {
 diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp dolphin/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
---- dolphin.orig/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp	2023-10-27 13:46:40.341380098 +0000
+--- dolphin.orig/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -661,12 +661,13 @@ void ProgramShaderCache::CreateHeader()
    std::string SupportedESTextureBuffer;
    switch (g_ogl_config.SupportedESPointSize)
@@ -1379,8 +1512,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp dol
  }
  
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.cpp dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.cpp
---- dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.cpp	2023-10-27 13:46:40.357380469 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -32,6 +32,16 @@ bool SWOGLWindow::IsHeadless() const
    return m_gl_context->IsHeadless();
  }
@@ -1418,8 +1551,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.cpp dolph
    GLsizei glWidth = (GLsizei)m_gl_context->GetBackBufferWidth();
    GLsizei glHeight = (GLsizei)m_gl_context->GetBackBufferHeight();
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.h dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.h
---- dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.h	2023-10-27 13:46:40.357380469 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.h	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Software/SWOGLWindow.h	2024-03-05 04:06:08.240295843 +0000
 @@ -20,6 +20,10 @@ public:
    GLContext* GetContext() const { return m_gl_context.get(); }
    bool IsHeadless() const;
@@ -1432,8 +1565,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWOGLWindow.h dolphin
    void ShowImage(const AbstractTexture* image, const MathUtil::Rectangle<int>& xfb_region);
  
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.cpp dolphin/Source/Core/VideoBackends/Software/SWRenderer.cpp
---- dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Software/SWRenderer.cpp	2023-10-27 13:46:40.357380469 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Software/SWRenderer.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -60,17 +60,17 @@ SWRenderer::CreateFramebuffer(AbstractTe
                                 static_cast<SWTexture*>(depth_attachment));
  }
@@ -1488,8 +1621,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.cpp dolphi
  {
    u32 value = 0;
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.h dolphin/Source/Core/VideoBackends/Software/SWRenderer.h
---- dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Software/SWRenderer.h	2023-10-27 13:46:40.357380469 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.h	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Software/SWRenderer.h	2024-03-05 04:06:08.240295843 +0000
 @@ -29,7 +29,7 @@ public:
    std::unique_ptr<AbstractFramebuffer>
    CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment) override;
@@ -1509,8 +1642,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Software/SWRenderer.h dolphin/
  };
  }  // namespace SW
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CMakeLists.txt dolphin/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/CMakeLists.txt	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/CMakeLists.txt	2023-10-27 13:46:40.357380469 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/CMakeLists.txt	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/CMakeLists.txt	2024-03-05 04:06:08.240295843 +0000
 @@ -35,6 +35,8 @@ add_library(videovulkan
    VulkanContext.h
    VulkanLoader.cpp
@@ -1521,8 +1654,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CMakeLists.txt dolphin/
  
  target_link_libraries(videovulkan
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp	2023-10-27 13:46:40.357380469 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -10,24 +10,24 @@
  #include "Common/MsgHandler.h"
  #include "Common/Thread.h"
@@ -1922,8 +2055,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cp
 -std::unique_ptr<CommandBufferManager> g_command_buffer_mgr;
  }  // namespace Vulkan
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h	2023-10-27 13:46:40.357380469 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h	2024-03-05 04:06:08.240295843 +0000
 @@ -22,10 +22,12 @@
  
  namespace Vulkan
@@ -2063,8 +2196,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h 
  
  }  // namespace Vulkan
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/Constants.h dolphin/Source/Core/VideoBackends/Vulkan/Constants.h
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/Constants.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/Constants.h	2023-10-27 13:46:40.357380469 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/Constants.h	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/Constants.h	2024-03-05 04:06:08.240295843 +0000
 @@ -12,7 +12,7 @@
  namespace Vulkan
  {
@@ -2075,8 +2208,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/Constants.h dolphin/Sou
  // Number of frames in flight, will be used to decide how many descriptor pools are used
  constexpr size_t NUM_FRAMES_IN_FLIGHT = 2;
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp	2023-10-27 13:46:40.357380469 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -389,6 +389,8 @@ VkSampler ObjectCache::GetSampler(const
  VkRenderPass ObjectCache::GetRenderPass(VkFormat color_format, VkFormat depth_format,
                                          u32 multisamples, VkAttachmentLoadOp load_op)
@@ -2096,8 +2229,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp dolphin
      vkDestroyRenderPass(g_vulkan_context->GetDevice(), it.second, nullptr);
    m_render_pass_cache.clear();
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.h dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.h
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.h	2023-10-27 13:46:40.357380469 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.h	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/ObjectCache.h	2024-03-05 04:06:08.240295843 +0000
 @@ -7,6 +7,7 @@
  #include <cstddef>
  #include <map>
@@ -2115,8 +2248,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/ObjectCache.h dolphin/S
    std::map<RenderPassCacheKey, VkRenderPass> m_render_pass_cache;
  
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp dolphin/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp	2023-10-27 13:46:40.357380469 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -8,6 +8,7 @@
  
  #include "Common/Assert.h"
@@ -2138,8 +2271,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp dolph
  
  void StagingBuffer::BufferMemoryBarrier(VkCommandBuffer command_buffer, VkBuffer buffer,
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.cpp dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.cpp	2023-10-27 13:46:40.369380750 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -16,59 +16,93 @@
  
  namespace Vulkan
@@ -2539,8 +2672,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.cpp dolphi
                              g_object_cache->GetPipelineLayout(PIPELINE_LAYOUT_COMPUTE), 0, 1,
                              &m_compute_descriptor_set, 1, &m_bindings.utility_ubo_offset);
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.h dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.h
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.h	2023-10-27 13:46:40.369380750 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.h	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/StateTracker.h	2024-03-05 04:06:08.240295843 +0000
 @@ -13,28 +13,24 @@
  
  namespace Vulkan
@@ -2616,8 +2749,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/StateTracker.h dolphin/
  };
  }  // namespace Vulkan
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp	2023-10-27 13:46:40.369380750 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -12,6 +12,7 @@
  #include "VideoBackends/Vulkan/StagingBuffer.h"
  #include "VideoBackends/Vulkan/StateTracker.h"
@@ -2755,8 +2888,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp dolph
  
  bool VKBoundingBox::CreateGPUBuffer()
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKMain.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKMain.cpp
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKMain.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKMain.cpp	2023-10-27 13:46:40.369380750 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKMain.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKMain.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -18,6 +18,7 @@
  #include "VideoBackends/Vulkan/VKVertexManager.h"
  #include "VideoBackends/Vulkan/VulkanContext.h"
@@ -2841,8 +2974,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKMain.cpp dolphin/Sour
    ShutdownShared();
    UnloadVulkanLibrary();
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp	2023-10-27 13:46:40.369380750 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -11,6 +11,7 @@
  #include "Common/Logging/Log.h"
  #include "Common/MsgHandler.h"
@@ -2962,8 +3095,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKPerfQuery.cpp dolphin
      Renderer::GetInstance()->ExecuteCommandBuffer(true, blocking);
    }
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp	2023-10-27 13:46:40.369380750 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -31,6 +31,7 @@
  #include "VideoBackends/Vulkan/VKVertexFormat.h"
  #include "VideoBackends/Vulkan/VulkanContext.h"
@@ -3685,7 +3818,7 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp dolphin/
  }  // namespace Vulkan
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp	2023-10-27 13:46:40.377380934 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -0,0 +1,155 @@
 +// Copyright 2022 Dolphin Emulator Project
 +// SPDX-License-Identifier: GPL-2.0-or-later
@@ -3844,7 +3977,7 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.cpp dolphin
 +}  // namespace Vulkan
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.h dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.h
 --- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.h	1970-01-01 00:00:00.000000000 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.h	2023-10-27 13:46:40.377380934 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKScheduler.h	2024-03-05 04:06:08.240295843 +0000
 @@ -0,0 +1,160 @@
 +// Copyright 2022 Dolphin Emulator Project
 +// SPDX-License-Identifier: GPL-2.0-or-later
@@ -4007,8 +4140,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKScheduler.h dolphin/S
 +extern std::unique_ptr<Scheduler> g_scheduler;
 +}  // namespace Vulkan
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp	2023-10-27 13:46:40.377380934 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -12,6 +12,7 @@
  #include "Common/MsgHandler.h"
  
@@ -4082,8 +4215,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKStreamBuffer.cpp dolp
                           m_current_offset == iter->second ? m_tracked_fences.end() : ++iter);
    m_current_offset = new_offset;
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp	2023-10-27 13:46:40.377380934 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -13,9 +13,9 @@
  
  #include "VideoBackends/Vulkan/CommandBufferManager.h"
@@ -4248,8 +4381,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp dolphin
    if (m_surface == VK_NULL_HANDLE)
      return false;
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.h dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.h
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.h	2023-10-27 13:46:40.377380934 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.h	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKSwapChain.h	2024-03-05 04:06:08.240295843 +0000
 @@ -3,6 +3,7 @@
  
  #pragma once
@@ -4303,8 +4436,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKSwapChain.h dolphin/S
    u32 m_height = 0;
    u32 m_layers = 0;
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.cpp	2023-10-27 13:46:40.377380934 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -21,6 +21,7 @@
  #include "VideoBackends/Vulkan/VKStreamBuffer.h"
  #include "VideoBackends/Vulkan/VulkanContext.h"
@@ -4812,8 +4945,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.cpp dolphin/S
  }
  }  // namespace Vulkan
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.h dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.h
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.h	2023-10-27 13:46:40.377380934 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.h	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKTexture.h	2024-03-05 04:06:08.240295843 +0000
 @@ -67,8 +67,8 @@ public:
    // irrelevant and will not be loaded.
    void OverrideImageLayout(VkImageLayout new_layout);
@@ -4826,8 +4959,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKTexture.h dolphin/Sou
  private:
    bool CreateView(VkImageViewType type);
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp dolphin/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp	2023-10-27 13:46:40.377380934 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -15,6 +15,7 @@
  #include "VideoBackends/Vulkan/CommandBufferManager.h"
  #include "VideoBackends/Vulkan/StateTracker.h"
@@ -5022,8 +5155,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp dol
  }
  }  // namespace Vulkan
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp dolphin/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp	2023-10-27 13:46:40.377380934 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -274,6 +274,13 @@ bool VulkanContext::SelectInstanceExtens
      return false;
    }
@@ -5039,8 +5172,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp dolph
    if (wstype == WindowSystemType::Android &&
        !AddExtension(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, true))
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl dolphin/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl	2023-10-27 13:46:40.377380934 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl	2024-03-05 04:06:08.240295843 +0000
 @@ -49,6 +49,11 @@ VULKAN_INSTANCE_ENTRY_POINT(vkCreateXlib
  VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceXlibPresentationSupportKHR, false)
  #endif
@@ -5054,8 +5187,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl d
  VULKAN_INSTANCE_ENTRY_POINT(vkCreateAndroidSurfaceKHR, false)
  #endif
 diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanLoader.h dolphin/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
---- dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanLoader.h	2023-09-26 17:58:02.853996721 +0000
-+++ dolphin/Source/Core/VideoBackends/Vulkan/VulkanLoader.h	2023-10-27 13:46:40.377380934 +0000
+--- dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanLoader.h	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoBackends/Vulkan/VulkanLoader.h	2024-03-05 04:06:08.240295843 +0000
 @@ -13,6 +13,10 @@
  #define VK_USE_PLATFORM_XLIB_KHR
  #endif
@@ -5068,8 +5201,8 @@ diff -rupN dolphin.orig/Source/Core/VideoBackends/Vulkan/VulkanLoader.h dolphin/
  #define VK_USE_PLATFORM_ANDROID_KHR
  #endif
 diff -rupN dolphin.orig/Source/Core/VideoCommon/FramebufferManager.cpp dolphin/Source/Core/VideoCommon/FramebufferManager.cpp
---- dolphin.orig/Source/Core/VideoCommon/FramebufferManager.cpp	2023-09-26 17:58:02.857996813 +0000
-+++ dolphin/Source/Core/VideoCommon/FramebufferManager.cpp	2023-10-27 13:46:40.429382144 +0000
+--- dolphin.orig/Source/Core/VideoCommon/FramebufferManager.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoCommon/FramebufferManager.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -630,7 +630,7 @@ void FramebufferManager::DestroyReadback
  
  bool FramebufferManager::CreateReadbackFramebuffer()
@@ -5107,8 +5240,8 @@ diff -rupN dolphin.orig/Source/Core/VideoCommon/FramebufferManager.cpp dolphin/S
      return;
    }
 diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.cpp dolphin/Source/Core/VideoCommon/RenderBase.cpp
---- dolphin.orig/Source/Core/VideoCommon/RenderBase.cpp	2023-09-26 17:58:02.857996813 +0000
-+++ dolphin/Source/Core/VideoCommon/RenderBase.cpp	2023-10-27 13:46:40.429382144 +0000
+--- dolphin.orig/Source/Core/VideoCommon/RenderBase.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoCommon/RenderBase.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -364,19 +364,24 @@ void Renderer::RenderToXFB(u32 xfbAddr,
      return;
  }
@@ -5171,8 +5304,8 @@ diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.cpp dolphin/Source/Co
  }
  
 diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.h dolphin/Source/Core/VideoCommon/RenderBase.h
---- dolphin.orig/Source/Core/VideoCommon/RenderBase.h	2023-09-26 17:58:02.857996813 +0000
-+++ dolphin/Source/Core/VideoCommon/RenderBase.h	2023-10-27 13:46:40.429382144 +0000
+--- dolphin.orig/Source/Core/VideoCommon/RenderBase.h	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoCommon/RenderBase.h	2024-03-05 04:06:08.240295843 +0000
 @@ -193,7 +193,8 @@ public:
    std::tuple<MathUtil::Rectangle<int>, MathUtil::Rectangle<int>>
    ConvertStereoRectangle(const MathUtil::Rectangle<int>& rc) const;
@@ -5214,8 +5347,8 @@ diff -rupN dolphin.orig/Source/Core/VideoCommon/RenderBase.h dolphin/Source/Core
    // These will be set on the first call to SetWindowSize.
    int m_last_window_request_width = 0;
 diff -rupN dolphin.orig/Source/Core/VideoCommon/TextureCacheBase.cpp dolphin/Source/Core/VideoCommon/TextureCacheBase.cpp
---- dolphin.orig/Source/Core/VideoCommon/TextureCacheBase.cpp	2023-09-26 17:58:02.857996813 +0000
-+++ dolphin/Source/Core/VideoCommon/TextureCacheBase.cpp	2023-10-27 13:46:40.429382144 +0000
+--- dolphin.orig/Source/Core/VideoCommon/TextureCacheBase.cpp	2024-03-05 04:05:26.602983293 +0000
++++ dolphin/Source/Core/VideoCommon/TextureCacheBase.cpp	2024-03-05 04:06:08.240295843 +0000
 @@ -1046,7 +1046,7 @@ static void SetSamplerState(u32 index, f
      // that have arbitrary contents, eg. are used for fog effects where the
      // distance they kick in at is important to preserve at any resolution.


### PR DESCRIPTION
Adds dolphin hotkey support for the x11 renderer.  This render is used on the Ace. 

There is a bug where hotkey is mapped to start and start is mapped to hotkey. Probably an ordering issue. This is for the wayland backend as well. 