### PR TITLE
Fix a race in ES that consumes unnecessary CPU time.

### DIFF
--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="870947e4f46cefed3aa73c94a14e4c1412c8fa5c"
+PKG_VERSION="802410db9948e34fc1f66dc432190c3f22a9f168"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
## Description

Fixes a bug in EmulationStation that causes the brightness to constantly be checked causing unnecessary cpu consumption and lower idle battery life.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Tested on Ayn Loki Max.

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
