### PR TITLE
RK3566: system of udev rules to make js0 the primary (virtual) gamepad

### DIFF
--- a/packages/apps/jelos-gamepad/system.d/jelos_gamepad.service
+++ b/packages/apps/jelos-gamepad/system.d/jelos_gamepad.service
@@ -3,6 +3,7 @@ Description=Ragnarok Input Daemon
 
 [Service]
 Type=simple
+ExecStartPre=/usr/bin/udevadm settle
 ExecStart=/usr/bin/jelos_gamepad
 
 [Install]

--- a/packages/hardware/quirks/platforms/RK3566/061-rebind-joysticks
+++ b/packages/hardware/quirks/platforms/RK3566/061-rebind-joysticks
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 Danil Zagoskin (https://github.com/stolen)
+
+# avoid activity if the quirk has done its job already
+[ -d /sys/class/input/js0 ] || exit 0
+grep -q JELOS /sys/class/input/js0/device/name && exit 0
+
+# save udev rules to make virtual gamepad appear as js0
+cat <<EOF >/storage/.config/udev.rules.d/90-disable-joysticks.rules
+# Unbind platform joysticks before jelos_gamepad starts
+ACTION=="?*", SUBSYSTEMS=="platform", DRIVER=="?*", KERNEL=="adc-joystick", RUN+="/bin/sh -c '/bin/pgrep jelos_gamepad || echo adc-joystick > /sys/bus/platform/drivers/adc-joystick/unbind'"
+ACTION=="?*", SUBSYSTEMS=="platform", DRIVER=="?*", KERNEL=="gpio-keys-control", RUN+="/bin/sh -c '/bin/pgrep jelos_gamepad || echo gpio-keys-control > /sys/bus/platform/drivers/gpio-keys/unbind'"
+
+# When virtual device is created, pull the trigger to re-bind platform joysticks
+ACTION=="add", SUBSYSTEM=="input", ATTRS{name}=="JELOS Gamepad", RUN+="/bin/udevadm trigger"
+
+# On trigger try to re-bind (only if not bound, i.e. empty driver)
+ACTION=="change", SUBSYSTEMS=="platform", DRIVER=="", KERNEL=="adc-joystick", RUN+="/bin/sh -c 'echo adc-joystick > /sys/bus/platform/drivers/adc-joystick/bind'"
+ACTION=="change", SUBSYSTEMS=="platform", DRIVER=="", KERNEL=="gpio-keys-control", RUN+="/bin/sh -c 'echo gpio-keys-control > /sys/bus/platform/drivers/gpio-keys/bind'"
+EOF
+
+# refresh udev and jelos_gamepad to make things work on first boot
+/bin/systemctl stop jelos_gamepad
+/bin/udevadm control --reload-rules
+/bin/udevadm trigger
+/bin/systemctl start jelos_gamepad


### PR DESCRIPTION
# RK3566: make virtual gamepad appear as `/dev/input/js0`, fix retroarch inputs

## Description

JELOS on Anbernic RG503 uses virtual gamepad device (`jelos_gamepad` process) to merge inputs from several kernel devices.  
Multiple `/dev/input/js*` devices confuse some software (especially emulationstation+retroarch combo) and launching a game leads to loss of controls.

This PR adds some `udev` magic:
  * just after boot platform joysticks are unbound from their drivers to release all `/dev/input/js*` devices
  * `jelos_gamepad` waits for udev to do its job, then creates `/dev/input/js0` virtual device
  * when virtual gamepad is added, `udevadm trigger` is called to update devices
  * platfom joysticks unbound from their drivers are bound back, appear as `js1` and `js2`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

- [x] boot Anbernic RG503 with a fresh written microsd card, put `Chip 'n Dale - Rescue Rangers (Europe).nes` and start it, ensure buttons work
- [x] add a comment to `90-disable-joysticks.rules` created by quirk, reboot, ensure file is unchanged, so no extra writes and delays

**Test Configuration**:
* Build OS name and version: Ubuntu 22.04.4 LTS
* Docker (Y/N): Y
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
