### PR TITLE
RK3566 + rg503: fix swapped A/Y buttons

### DIFF
--- a/projects/Rockchip/patches/linux/RK3566/018-fix-rg503-a-y-buttons.patch
+++ b/projects/Rockchip/patches/linux/RK3566/018-fix-rg503-a-y-buttons.patch
@@ -1,0 +1,20 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rg503.dts	2024-03-15 18:26:31.236348216 +0300
++++ b/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rg503.dts	2024-03-15 18:26:48.664293252 +0300
+@@ -139,7 +139,7 @@
+ 
+ &gpio_keys_control {
+ 	button-a {
+-		gpios = <&gpio3 RK_PC1 GPIO_ACTIVE_LOW>;
++		gpios = <&gpio3 RK_PC2 GPIO_ACTIVE_LOW>;
+ 		label = "EAST";
+ 		linux,code = <BTN_EAST>;
+ 	};
+@@ -175,7 +175,7 @@
+ 	};
+ 
+ 	button-y {
+-		gpios = <&gpio3 RK_PC2 GPIO_ACTIVE_LOW>;
++		gpios = <&gpio3 RK_PC1 GPIO_ACTIVE_LOW>;
+ 		label = "WEST";
+ 		linux,code = <BTN_WEST>;
+ 	};


### PR DESCRIPTION
# fix swapped A nd Y buttons on Anbernic RG503

## Description

With mainline RK3566 kernel by default A and Y buttons on Anbernic RG503 are swapped.
To make them work as intended i needed to remap them everywhere -- emulationstation, retroarch, ppsspp, etc.

This PR fixes the DTS.
Mapping `RK_PC1 -> WEST` and `RK_PC2 -> EAST` is now consistent with `rk3566-anbernic-rg353x.dtsi` and `rk3566-powkiddy-rk2023.dtsi`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

- [x] fresh install (dd) on Anbernic rg503, button A is "OK" on first boot

**Test Configuration**:
* Build OS name and version: Ubuntu 22.04.4 LTS
* Docker (Y/N): Y
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
