### PR TITLE
sway: export SDL_VIDEODRIVER env var to fix ppsspp (wayland+sdl)

### DIFF
--- a/packages/wayland/compositor/sway/profile.d/050-sway.conf
+++ b/packages/wayland/compositor/sway/profile.d/050-sway.conf
@@ -4,3 +4,6 @@
 export WAYLAND_DISPLAY=wayland-1
 export XDG_RUNTIME_DIR=/var/run/0-runtime-dir
 export SWAYSOCK="${XDG_RUNTIME_DIR}/sway-ipc.0.sock"
+
+# this lets ppsspp to work with wayland and not segfault
+export SDL_VIDEODRIVER=wayland


### PR DESCRIPTION
# fix ppsspp segfault with sway by exporting `SDL_VIDEODRIVER=wayland` env variable
## Description
ppsspp got a segmentation fault when initializing video output while sway was running.
turned out SDL needs an environment variable to work with wayland.

weston already had this, this PR sets the variable in `profile.d/050-sway` too

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested Locally?

- [x] fresh install (dd), first boot RG503, Tools -> Start PPSSPP

**Test Configuration**:
* Build OS name and version: Ubuntu 22.04.4 LTS
* Docker (Y/N): Y
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
