### PR TITLE
Update mpv_sense

### DIFF
--- a/packages/multimedia/mpv/scripts/mpv_sense
+++ b/packages/multimedia/mpv/scripts/mpv_sense
@@ -27,13 +27,13 @@ PAUSE_EVENT='*(BTN_SOUTH), value 1'
 CHANGE_AUDIO_EVENT='*(BTN_EAST), value 1'
 CHANGE_SUB_EVENT='*(BTN_WEST), value 1'
 SHOW_OSD_EVENT='*(BTN_NORTH), value 1'
-BACK_5S_DPAD_EVENT='*(DPAD_LEFT), value 1'
+BACK_5S_DPAD_EVENT='*DPAD_LEFT), value 1'
 BACK_5S_HAT_EVENT='*(ABS_HAT0X), value -1*'
-SKIP_5S_DPAD_EVENT='*(DPAD_RIGHT), value 1'
+SKIP_5S_DPAD_EVENT='*DPAD_RIGHT), value 1'
 SKIP_5S_HAT_EVENT='*(ABS_HAT0X), value 1*'
-BACK_60S_DPAD_EVENT='*(DPAD_DOWN), value 1'
+BACK_60S_DPAD_EVENT='*DPAD_DOWN), value 1'
 BACK_60S_HAT_EVENT='*(ABS_HAT0Y), value 1*'
-SKIP_60S_DPAD_EVENT='*(DPAD_UP), value 1'
+SKIP_60S_DPAD_EVENT='*DPAD_UP), value 1'
 SKIP_60S_HAT_EVENT='*(ABS_HAT0Y), value -1*'
 QUIT_HOTKEY_EVENT='*(BTN_SELECT), value 1'
 QUIT_SELECT_EVENT='*(BTN_START), value 1'
@@ -57,11 +57,11 @@ get_devices() {
         INPUT_DEVICES+=("${DEVICE}")
         if [[ "${SUPPORTS}" =~ ID_INPUT_KEY ]]
         then
-          ${DEBUG} log $0 "Found Keyboard: ${DEVICE}"
+          ${DEBUG} && log $0 "Found Keyboard: ${DEVICE}"
           FOUNDKEYS=true
         elif [[ "${SUPPORTS}" =~ ID_INPUT_JOYSTICK ]]
         then
-          ${DEBUG} log $0 "Found Joystick: ${DEVICE}"
+          ${DEBUG} && log $0 "Found Joystick: ${DEVICE}"
           FOUNDJOY=true
         fi
       fi
@@ -69,13 +69,13 @@ get_devices() {
     if [ "${FOUNDKEYS}" = "true" ] &&
        [ "${FOUNDJOY}" = "true" ]
     then
-      ${DEBUG} log $0 "Found all of the needed devices."
+      ${DEBUG} && log $0 "Found all of the needed devices."
       KJDEVS=true
       break
     fi
     if [ "${RETRY}" -ge 5 ]
     then
-      ${DEBUG} log $0 "Did not find all of the needed devices, but that may be OK.  Breaking."
+      ${DEBUG} && log $0 "Did not find all of the needed devices, but that may be OK.  Breaking."
       break
     else
       RETRY=$(( ${RETRY} + 1 ))
@@ -100,11 +100,11 @@ get_devices
 ) | while read line; do
     case ${line} in
         (${CONTROLLER_DISCONNECTED})
-        ${DEBUG} log $0 "Reloading due to ${CONTROLLER_DEVICE} reattach..."
+        ${DEBUG} && log $0 "Reloading due to ${CONTROLLER_DEVICE} reattach..."
         get_devices
         ;;
         (${DEVICE_DISCONNECTED})
-        ${DEBUG} log $0 "Reloading due to ${DEVICE} reattach..."
+        ${DEBUG} && log $0 "Reloading due to ${DEVICE} reattach..."
         get_devices
         ;;
         (${PAUSE_EVENT})


### PR DESCRIPTION
Add && after ${DEBUG}

# Pull Request Template

## Description

mpv controls are broken, ${DEBUG} made all log statements execute 'false' instead of testing for 'true'.
Button patterns are now (at least on my device) preceded by BTN_. Made the pattern only match the end of the event name.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

On a copy of the script. Not on an entire rebuild.

**Test Configuration**:
* Build OS name and version: JELOS 20240314 (0bf0492)
* Docker (Y/N): N
* JELOS Branch: stable 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
