### PR TITLE
Resolve the link error when compiling u-boot

### DIFF
--- a/projects/Rockchip/packages/u-boot/package.mk
+++ b/projects/Rockchip/packages/u-boot/package.mk
@@ -83,7 +83,7 @@ make_target() {
       echo "toolchain (${TOOLCHAIN})"
       export BL31="${PKG_BL31}"
       export ROCKCHIP_TPL="${PKG_DATAFILE}"
-
+      export LD_LIBRARY_PATH=${TOOLCHAIN}/lib:$LD_LIBRARY_PATH
       case ${DEVICE} in
         RK3566-BSP*)
           DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm64 make mrproper


### PR DESCRIPTION
# Pull Request Template

## Description

Fix the link error when compiling u-boot for RK3566

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested Locally?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

1. [x] make RK3566

**Test Configuration**:
* Build OS name and version: JELOS 20240314 [1238415](https://github.com/JustEnoughLinuxOS/distribution/commit/12384158ee09f24b84054cd538546bd9746b047f)
* Docker (Y/N): N
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
![微信截图_20240326115838](https://github.com/JustEnoughLinuxOS/distribution/assets/23023879/cf609d86-7d88-45d0-81ed-ab90805fe6f7)

